### PR TITLE
Translate French comments and docs to English

### DIFF
--- a/docs/roller_standup_policy_summary.md
+++ b/docs/roller_standup_policy_summary.md
@@ -1,86 +1,86 @@
-# Policy `roller_standup` — se relever sur rollers
+# Policy `roller_standup` — standing up on rollers
 
-**But** : le microduck (sur rollers) part du sol — à plat ventre ou à plat dos — et se remet **debout sur ses roues**, puis **tient** la station.
+**Goal**: the microduck (on rollers) starts on the ground — face down or face up — and gets back **up on its wheels**, then **holds** the stance.
 
-- **Tâche** : `Mjlab-RollerStandUp-Flat-MicroDuck`
-- **Fichier** : `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`
-- **Base** : dérivée de l'env roller (`velocity_rollers`) → même robot, même physique/DR, **même observation 61D** (interchangeable au runtime, chargeable via `--new-cmd-obs`).
-- **Spec** : `docs/superpowers/specs/2026-08-04-roller-standup-design.md`
-- **Politique aveugle** : pas de scan de terrain ; proprioception + `projected_gravity`.
+- **Task**: `Mjlab-RollerStandUp-Flat-MicroDuck`
+- **File**: `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`
+- **Base**: derived from the roller env (`velocity_rollers`) → same robot, same physics/DR, **same 61D observation** (hot-swappable at runtime, loadable via `--new-cmd-obs`).
+- **Spec**: `docs/superpowers/specs/2026-08-04-roller-standup-design.md`
+- **Blind policy**: no terrain scan; proprioception + `projected_gravity`.
 
-## Hauteurs (mesurées, pas devinées)
+## Heights (measured, not guessed)
 
-| pose | modèle pieds | modèle rollers |
+| pose | feet model | roller model |
 |---|---|---|
-| debout | 0.1172 → `STAND_Z=0.115` sous charge | 0.1407 → **`ROLLER_STAND_Z=0.138`** |
-| à plat ventre (repos) | 0.075 | 0.075 |
-| à plat dos (repos) | 0.048 | 0.048 |
+| standing | 0.1172 → `STAND_Z=0.115` under load | 0.1407 → **`ROLLER_STAND_Z=0.138`** |
+| face down (rest) | 0.075 | 0.075 |
+| face up (rest) | 0.048 | 0.048 |
 
-Les hauteurs de repos au sol sont identiques aux deux modèles : c'est la coque du tronc qui touche, pas les pieds.
+The ground rest heights are identical on both models: it is the trunk shell that touches, not the feet.
 
-## ⚠️ Indices de joints — les roues sont INTERCALÉES
+## ⚠️ Joint indices — the wheels are INTERLEAVED
 
 ```
-0-4   jambe gauche      5-6   roues gauches
-7-10  cou / tête       11-15  jambe droite      16-17  roues droites
+0-4   left leg          5-6   left wheels
+7-10  neck / head      11-15  right leg          16-17  right wheels
 ```
-`_LEG_JOINTS = [0-4, 11-15]`. Les indices du `standup` (`[0-4, 9-13]`) valent pour le modèle **sans** roues et pointeraient sur des roues ici. Verrouillé par `tests/test_roller_standup_cfg.py::test_joint_indices_match_actual_roller_model`.
+`_LEG_JOINTS = [0-4, 11-15]`. The `standup` indices (`[0-4, 9-13]`) hold for the model **without** wheels and would point at wheels here. Locked in by `tests/test_roller_standup_cfg.py::test_joint_indices_match_actual_roller_model`.
 
-## Reset — départ au sol
+## Reset — starting on the ground
 
-`set_random_ground_state` : ventre (`prone_z` 0.076–0.09, plancher relevé car le ventre ne décolle du sol qu'à 0.0752) / dos / **déjà debout** (`standing_z` 0.134–0.144), ± 10° de bruit en pitch/roll. Pas de bucket « assis ». Le bucket « debout » est nécessaire : sans lui la policy monte mais ne tient pas.
+`set_random_ground_state`: face down (`prone_z` 0.076–0.09, floor raised because face down only clears the ground at 0.0752) / face up / **already standing** (`standing_z` 0.134–0.144), ± 10° of pitch/roll noise. No "sitting" bucket. The "standing" bucket is necessary: without it the policy rises but does not hold.
 
-**Curriculum `ground_state_mix`** (easy → hard, le dos en dernier) :
+**Curriculum `ground_state_mix`** (easy → hard, face up last):
 
-| iter | debout | ventre | dos |
+| iter | standing | face down | face up |
 |---|---|---|---|
 | 0 | 0.50 | 0.50 | 0.00 |
 | 600 | 0.35 | 0.45 | 0.20 |
 | 1500 | 0.25 | 0.40 | 0.35 |
 | 2500 | 0.20 | 0.40 | 0.40 |
 
-## Récompenses
+## Rewards
 
-Dix termes repris du `standup` avec leurs poids déjà réglés : `pose_stand_legs` (+8), `pose_stand_l1` (+5), `height_stand` (+4, std 0.04), `height_stand_sharp` (+4, std 0.015), `height_stand_l1` (+30), `com_upward_velocity` (+3), `gentle_rise` (−0.02), `upright_linear` (+6), `upright_sharp` (+6), `standing_composite` (+15). Plus `joint_torque_rate_l2` (−2e-3), l'anti-jitter qui n'empêche pas le retournement.
+Ten terms taken from `standup` with their already-tuned weights: `pose_stand_legs` (+8), `pose_stand_l1` (+5), `height_stand` (+4, std 0.04), `height_stand_sharp` (+4, std 0.015), `height_stand_l1` (+30), `com_upward_velocity` (+3), `gentle_rise` (−0.02), `upright_linear` (+6), `upright_sharp` (+6), `standing_composite` (+15). Plus `joint_torque_rate_l2` (−2e-3), the anti-jitter term that does not block the roll-over.
 
-Régularisateurs hérités : `body_ang_vel` **−0.05** (bloqueur de mouvement, à garder LÉGER), `angular_momentum` −0.02, `action_rate_l2` (rampe −0.4 → −1.0, **pas** le −2.0 du roller), `neck_action_rate_l2` −0.5, `neck_joint_pos_l2` −0.5 (tête droite), `joint_torques_l2` −1e-3, `action_over_limit` −0.5, `self_collisions` −1.0.
+Inherited regularizers: `body_ang_vel` **−0.05** (motion blocker, keep it LIGHT), `angular_momentum` −0.02, `action_rate_l2` (ramp −0.4 → −1.0, **not** the roller's −2.0), `neck_action_rate_l2` −0.5, `neck_joint_pos_l2` −0.5 (head upright), `joint_torques_l2` −1e-3, `action_over_limit` −0.5, `self_collisions` −1.0.
 
-Retirées : toutes les récompenses de patinage, plus `feet_flat` (les lames ne sont pas à plat pendant la montée) et `hip_roll_neutral` (se relever demande d'écarter les jambes).
+Removed: all the skating rewards, plus `feet_flat` (the blades are not flat during the rise) and `hip_roll_neutral` (standing up requires spreading the legs).
 
-## ⚠️ Le point dur : les roues roulent
+## ⚠️ The hard part: the wheels roll
 
-Aucune adhérence longitudinale pour pousser sur le sol. Le **curriculum de friction de roulement est INVERSÉ** (l'env roller la fait monter, ici elle descend) :
+There is no longitudinal traction to push against the ground. The **rolling-friction curriculum is REVERSED** (the roller env ramps it up, here it goes down):
 
 | iter | frictionloss | |
 |---|---|---|
-| 0 | 0.05 | roues quasi bloquées → se relève comme avec des pieds |
+| 0 | 0.05 | near-locked wheels → rises as if on feet |
 | 1000 | 0.02 | |
 | 2000 | 0.008 | |
 | 3000 | 0.003 | |
-| 4000 | 0.0015 | la vraie valeur du roulement |
+| 4000 | 0.0015 | the real rolling value |
 
-**Surveiller `Episode_Reward/standing_composite` aux paliers.** S'il s'écroule, le geste « pieds adhérents » ne transfère pas aux roues libres → il faudra guider une technique de patineur (appui genou intermédiaire, un patin à la fois). C'est un résultat, pas un échec.
+**Watch `Episode_Reward/standing_composite` at each stage.** If it collapses, the "sticky feet" gesture does not transfer to free wheels → we will have to guide a skater technique (intermediate knee support, one skate at a time). That is a result, not a failure.
 
-**Surveiller AUSSI la dérive horizontale du robot en play**, à chaque palier de friction. `standing_composite` ne voit ni `root_link_pos_w[:2]` ni la vitesse horizontale : une policy qui se relève en glissant loin de son point de départ collecte exactement le même score qu'une qui se relève et s'arrête. Tant que cette dérive n'a pas été mesurée visuellement, le résultat du curriculum de friction (la question même que cet env existe pour trancher) n'est pas fiable.
+**ALSO watch the robot's horizontal drift at play time**, at every friction stage. `standing_composite` sees neither `root_link_pos_w[:2]` nor horizontal velocity: a policy that stands up while sliding far from its starting point collects exactly the same score as one that stands up and stops. Until that drift has been measured visually, the outcome of the friction curriculum (the very question this env exists to settle) is not trustworthy.
 
-**Sim2real** : seuls les checkpoints d'après iter 4000 sont candidats au déploiement. Avant, la policy s'appuie sur une friction qui n'existe pas sur le vrai robot.
+**Sim2real**: only checkpoints from after iter 4000 are deployment candidates. Before that, the policy relies on a friction that does not exist on the real robot.
 
-## Commande
+## Command
 
-Slot `twist` neutralisé : `lin_vel_x`/`lin_vel_y` ± 0.01, `ang_vel_z` **± 0.05** (5× plus large — même
-choix que le `standup`). Slots `head_pose` / `body_pose` **zero-paddés** (convention roller). Déploiement visé : en `--standing` face à la policy roller en `--walking`, avec la bascule automatique sur la magnitude de la commande (`infer_policy.py:262`, seuil 0.05) ; le slot twist y est laissé à zéro (`infer_policy.py:239`).
+The `twist` slot is neutralized: `lin_vel_x`/`lin_vel_y` ± 0.01, `ang_vel_z` **± 0.05** (5× wider — the same
+choice as `standup`). The `head_pose` / `body_pose` slots are **zero-padded** (roller convention). Intended deployment: in `--standing` alongside the roller policy in `--walking`, with the automatic switch on command magnitude (`infer_policy.py:262`, threshold 0.05); the twist slot is left at zero there (`infer_policy.py:239`).
 
-**Réserve** : `infer_policy.py` est le script de sim/clavier local. Le runtime robot est le binaire Rust `microduck_runtime`, absent du repo — il n'est pas vérifié qu'il expose un équivalent `--standing`. Le doc de passation du crouch ne liste que `--model`, `--ground-pick`, `--fold-policy`. À confirmer.
+**Caveat**: `infer_policy.py` is the local sim/keyboard script. The robot runtime is the Rust binary `microduck_runtime`, absent from this repo — it has not been verified that it exposes a `--standing` equivalent. The crouch handover doc only lists `--model`, `--ground-pick`, `--fold-policy`. To be confirmed.
 
-## Terminaisons
+## Terminations
 
-`fell_over` **supprimée** (le robot démarre tombé). `nan_state` héritée. `nan_policy="sanitize"` sur les obs actor/critic.
+`fell_over` **removed** (the robot starts fallen). `nan_state` inherited. `nan_policy="sanitize"` on the actor/critic obs.
 
-## Réseau / PPO
+## Network / PPO
 
-Actor et critic `(512, 256, 128)` elu, `obs_normalization=True`. PPO `lr=1e-3` adaptive, `desired_kl=0.01`, `gamma=0.99`, `lam=0.95`, `num_steps_per_env=24`, épisode 6 s, `max_iterations=15000`. **Symétrie OFF** (`SYMMETRY_CFG` est câblé pour le layout 51D).
+Actor and critic `(512, 256, 128)` elu, `obs_normalization=True`. PPO `lr=1e-3` adaptive, `desired_kl=0.01`, `gamma=0.99`, `lam=0.95`, `num_steps_per_env=24`, 6 s episode, `max_iterations=15000`. **Symmetry OFF** (`SYMMETRY_CFG` is wired for the 51D layout).
 
-## Commandes
+## Commands
 
 ```bash
 uv run train Mjlab-RollerStandUp-Flat-MicroDuck --env.scene.num-envs 4096 --agent.max_iterations 15000
@@ -89,107 +89,107 @@ uv run scripts/export_latest.py      # alias md-export
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
 
-### ⚠️ Voir les départs sur le dos au play
+### ⚠️ Seeing face-up starts at play time
 
-Un play ne montre **jamais** de départ sur le dos par défaut : l'env de play est
-reconstruit à neuf, donc `common_step_counter` repart à 0 et le curriculum applique son
-palier 0, où `face_up_prob = 0`. On ne voit que 50 % ventre / 50 % debout, quelle que soit
-la maturité du checkpoint chargé. Or le dos est le cas le plus dur, celui qu'on veut
-justement inspecter.
+A play run **never** shows a face-up start by default: the play env is
+rebuilt from scratch, so `common_step_counter` restarts at 0 and the curriculum applies its
+stage 0, where `face_up_prob = 0`. You only see 50% face down / 50% standing, whatever
+the maturity of the loaded checkpoint. Yet face up is the hardest case, the very one we
+want to inspect.
 
-`STANDUP_PLAY_FACE_UP` force le mélange (même motif que `SLOPE_PLAY_DIFFICULTY` dans
-`roller_slope`), **uniquement sur le chemin `play=True`** — l'entraînement et son
-curriculum easy → hard sont intouchés :
+`STANDUP_PLAY_FACE_UP` forces the mix (same pattern as `SLOPE_PLAY_DIFFICULTY` in
+`roller_slope`), **on the `play=True` path only** — training and its easy → hard
+curriculum are untouched:
 
 ```bash
-STANDUP_PLAY_FACE_UP=1.0 md-play    # 100 % de départs sur le dos
-STANDUP_PLAY_FACE_UP=0.4 md-play    # le mélange du dernier palier du curriculum
-STANDUP_PLAY_FACE_UP=none md-play   # défaut (palier 0, pas de dos)
+STANDUP_PLAY_FACE_UP=1.0 md-play    # 100% face-up starts
+STANDUP_PLAY_FACE_UP=0.4 md-play    # the mix of the curriculum's last stage
+STANDUP_PLAY_FACE_UP=none md-play   # default (stage 0, no face up)
 ```
 
-Le reste (`1 - face_up`) est réparti ventre:debout dans le rapport 2:1 du dernier palier,
-si bien que `0.4` reproduit exactement le mélange de fin d'entraînement (0.40 / 0.20 / 0.40).
+The remainder (`1 - face_up`) is split face-down:standing in that last stage's 2:1 ratio,
+so `0.4` reproduces the end-of-training mix exactly (0.40 / 0.20 / 0.40).
 
-## 🔧 Correction anti-violence (après premier test robot)
+## 🔧 Anti-violence fix (after the first robot test)
 
-**Symptômes** sur un checkpoint 4000+ : mouvements très brusques, la tête tape le sol,
-échec du relevé depuis le dos sur le robot. **Présents en simu aussi** → ce n'était donc
-ni du sim2real, ni un checkpoint trop jeune, mais la conception des récompenses.
+**Symptoms** on a 4000+ checkpoint: very abrupt motions, the head banging the ground,
+failure to rise from the back on the robot. **Present in sim too** → so this was
+neither a sim2real issue nor a too-young checkpoint, but the reward design.
 
-**Root cause : `gentle_rise` récompensait la violence.** `trunk_vertical_accel_penalty`
-renvoie déjà `-|a_z|` (`mdp.py:2171`) ; multiplié par le poids **−0.02** hérité du
-`standup`, ça faisait un double négatif, donc `+0.02·|a_z|` — **plus le tronc accélérait
-brutalement, plus la policy était payée**. Confirmé par le log : `Episode_Reward/gentle_rise
-= +0.0118` sur le run `vweolw91`, seul terme de pénalité loggé positif.
+**Root cause: `gentle_rise` was rewarding violence.** `trunk_vertical_accel_penalty`
+already returns `-|a_z|` (`mdp.py:2171`); multiplied by the **−0.02** weight inherited from
+`standup`, that made a double negative, hence `+0.02·|a_z|` — **the more brutally the trunk
+accelerated, the more the policy was paid**. Confirmed by the log: `Episode_Reward/gentle_rise
+= +0.0118` on run `vweolw91`, the only penalty term logged positive.
 
-`mdp.py` mélange deux conventions de signe, et c'est le piège :
+`mdp.py` mixes two sign conventions, and that is the trap:
 
-| terme | la fonction renvoie | poids correct |
+| term | the function returns | correct weight |
 |---|---|---|
-| `height_stand_l1`, `pose_stand_l1`, `gentle_rise` | `-abs(...)`, déjà négatif | **positif** |
-| `joint_torques_l2`, `joint_torque_rate_l2`, `action_rate_l2`, `body_impact_cost` | magnitude positive | **négatif** |
+| `height_stand_l1`, `pose_stand_l1`, `gentle_rise` | `-abs(...)`, already negative | **positive** |
+| `joint_torques_l2`, `joint_torque_rate_l2`, `action_rate_l2`, `body_impact_cost` | positive magnitude | **negative** |
 
-Verrouillé par `test_already_negative_penalties_use_positive_weights`.
+Locked in by `test_already_negative_penalties_use_positive_weights`.
 
-⚠️ **Le `standup` du marcheur a exactement le même bug** (même fonction, même poids −0.02).
-Ça explique la série de tentatives d'amortissement infructueuses documentées dans ses
-commentaires (« *violent / shaky / overshoot-tip-repeat on the real robot* ») : elles
-combattaient un terme qui poussait activement dans l'autre sens. **Non corrigé ici** — c'est
-un autre env, à trancher séparément.
+⚠️ **The walker's `standup` has exactly the same bug** (same function, same −0.02 weight).
+That explains the series of unsuccessful damping attempts documented in its
+comments ("*violent / shaky / overshoot-tip-repeat on the real robot*"): they were
+fighting a term that actively pushed the other way. **Not fixed here** — that is
+a different env, to be settled separately.
 
-**Problème structurel associé.** À convergence les récompenses de tâche totalisaient **≈ +41.6**
-saturées à 95–99 %, contre **≈ −1.2** pour tous les amortisseurs réunis — dont
-`joint_torque_rate_l2` à **−0.0002/pas** et `joint_torques_l2` à **−0.0001/pas**, soit rien.
-Rapport ~35:1 : aucune raison d'être doux.
+**Associated structural problem.** At convergence the task rewards totalled **≈ +41.6**
+saturated at 95–99%, against **≈ −1.2** for all the dampers combined — of which
+`joint_torque_rate_l2` at **−0.0002/step** and `joint_torques_l2` at **−0.0001/step**, i.e. nothing.
+A ~35:1 ratio: no reason to be gentle.
 
-**État actuel des corrections :**
+**Current state of the fixes:**
 
-| | avant | maintenant | pourquoi |
+| | before | now | why |
 |---|---|---|---|
-| `gentle_rise` | −0.02 (récompense) | **+0.02** (pénalité) | signe corrigé ; magnitude gardée PETITE exprès — `\|a_z\|` est forcément élevé pendant un retournement, un gros poids serait un bloqueur de mouvement |
-| `joint_torque_rate_l2` | −2e-3 | **−0.2** | le levier SÛR : pénalise la variation de couple, pas le mouvement |
-| `head_impact_penalty` | absent | **toujours absent** | essayé à −1.0, a gelé la policy — voir ci-dessous |
+| `gentle_rise` | −0.02 (reward) | **+0.02** (penalty) | sign fixed; magnitude deliberately kept SMALL — `\|a_z\|` is necessarily high during a roll-over, and a large weight would be a motion blocker |
+| `joint_torque_rate_l2` | −2e-3 | **−0.2** | the SAFE lever: it penalizes torque rate, not motion |
+| `head_impact_penalty` | absent | **still absent** | tried at −1.0, froze the policy — see below |
 
-### ⚠️ La pénalité d'impact tête a gelé la policy — ne pas la remettre telle quelle
+### ⚠️ The head-impact penalty froze the policy — do not put it back as-is
 
-Tentative avec les valeurs de `velstand` (`body_impact_cost`, sous-arbre `neck`, −1.0,
-seuil 2.0) : **la policy a convergé vers rester couchée, inerte.** Mesuré (run `d8rnko6p`) :
+Attempt with `velstand`'s values (`body_impact_cost`, `neck` subtree, −1.0,
+threshold 2.0): **the policy converged to lying down, inert.** Measured (run `d8rnko6p`):
 
-| terme | avant (violent) | avec head_impact (gelé) |
+| term | before (violent) | with head_impact (frozen) |
 |---|---|---|
 | `standing_composite` | +14.32 | **+3.26** |
 | `upright_sharp` | +5.76 | +1.06 |
-| `head_impact_penalty` | — | **−1.01** ← plus gros terme négatif |
-| `joint_torque_rate_l2` | −0.0002 | −0.255 (donc **pas** le coupable) |
+| `head_impact_penalty` | — | **−1.01** ← largest negative term |
+| `joint_torque_rate_l2` | −0.0002 | −0.255 (so **not** the culprit) |
 
-L'erreur de raisonnement : croire qu'une pénalité « ciblée » ne bride pas le mouvement.
-**Faux ici — pour se relever du dos, ce robot pivote sur sa tête et ses épaules.** La tête
-est le point d'appui du retournement, pas un dégât collatéral ; la pénaliser bloque le seul
-mécanisme disponible, et le dos était déjà le cas qui échouait.
+The reasoning error: believing that a "targeted" penalty does not restrict motion.
+**False here — to get up from its back, this robot pivots on its head and shoulders.** The head
+is the fulcrum of the roll-over, not collateral damage; penalizing it blocks the only
+available mechanism, and face up was already the failing case.
 
-**L'optimum paresseux qui rend ce gel possible** : `pose_stand_legs` restait à **+7.72 sur 8**
-alors que le robot était allongé — les jambes sont à HOME en position couchée, donc cette
-récompense est encaissée quasi gratuitement. C'est `height_stand_l1` (poids +30) qui doit
-rendre « rester au sol » net négatif ; il ne faut pas l'affaiblir.
+**The lazy optimum that makes this freeze possible**: `pose_stand_legs` stayed at **+7.72 out of 8**
+while the robot was lying flat — the legs are at HOME in a prone position, so that
+reward is collected almost for free. It is `height_stand_l1` (weight +30) that must
+make "stay on the ground" net negative; it must not be weakened.
 
-**Hypothèse en cours de test** : taper la tête était un *symptôme* de la violence (le bug de
-signe payait la brutalité, et une montée brutale finit sur la tête), pas un défaut séparé.
-Si le slam revient maintenant que le signe est corrigé, la reprise doit être une pénalité
-**gatée en hauteur** (comme `upright_sharp` l'est), qui épargne la phase de retournement au sol.
+**Hypothesis under test**: head banging was a *symptom* of the violence (the sign bug
+paid for brutality, and a brutal rise ends on the head), not a separate defect.
+If the slam comes back now that the sign is fixed, the reintroduction must be a
+**height-gated** penalty (as `upright_sharp` is), which spares the ground roll-over phase.
 
-**Leçon de méthode** : les trois corrections ont été appliquées d'un coup, donc le gel n'a pas
-pu être attribué avec certitude — seul le suspect le plus probable a pu être désigné. Une
-correction à la fois, à l'avenir.
+**Methodological lesson**: the three fixes were applied all at once, so the freeze could not
+be attributed with certainty — only the most likely suspect could be named. One
+fix at a time in future.
 
-**Recalibrage si c'est encore violent** : `|Δτ|²` vaut ~0.1 à convergence, donc la
-contribution de `joint_torque_rate_l2` ≈ `0.1 × |poids|`. Monter **ce** terme, **pas**
-`body_ang_vel` (−0.05) ni `action_rate_l2` (rampe → −1.0) : ceux-là sont des bloqueurs de
-mouvement et le `standup` documente qu'à −0.15 et −1.2 respectivement, ils **gelaient** le
-relevé depuis le dos. Si au contraire le dos cesse de fonctionner, **baisser**
-`joint_torque_rate_l2` en premier.
+**Recalibration if it is still violent**: `|Δτ|²` is ~0.1 at convergence, so
+`joint_torque_rate_l2`'s contribution ≈ `0.1 × |weight|`. Raise **that** term, **not**
+`body_ang_vel` (−0.05) nor `action_rate_l2` (ramp → −1.0): those are motion
+blockers, and `standup` documents that at −0.15 and −1.2 respectively they **froze** the
+rise from the back. If instead face up stops working, **lower**
+`joint_torque_rate_l2` first.
 
-## Hors périmètre
+## Out of scope
 
-Intégrer le relevé dans la policy de roulage (recette `velstand`) ; buckets de départ sur le côté ; variante rough ; pénalités d'impact tronc/tête.
+Integrating the standup into the rolling policy (the `velstand` recipe); side-lying start buckets; a rough variant; trunk/head impact penalties.
 
-Aucune récompense ne pénalise la vitesse horizontale du tronc (`root_link_lin_vel_w[:, :2]`) : « se relever en roulant loin » est un résultat non pénalisé et qui score à plein. Décision volontaire (pas un oubli) : une récompense d'immobilité qui ne serait pas gatée en hauteur pénaliserait aussi la translation que le relevé depuis le sol exige physiquement — le mode d'échec « bloqueur de mouvement » que le `standup` documente. Candidat si le problème se confirme : une immobilité gatée en hauteur (proche de `ROLLER_STAND_Z` seulement).
+No reward penalizes the trunk's horizontal velocity (`root_link_lin_vel_w[:, :2]`): "standing up while rolling far away" is an unpenalized outcome that scores full marks. This is a deliberate decision (not an oversight): a stillness reward that was not height-gated would also penalize the translation that rising from the ground physically requires — the "motion blocker" failure mode that `standup` documents. Candidate if the problem is confirmed: a height-gated stillness term (close to `ROLLER_STAND_Z` only).

--- a/docs/superpowers/plans/2026-07-17-roller-crouch-glide.md
+++ b/docs/superpowers/plans/2026-07-17-roller-crouch-glide.md
@@ -2,49 +2,49 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ajouter un geste « s'accroupir en glissant puis se relever » déclenché au bouton A, sans modifier le runtime Rust, en entraînant une policy mjlab chargée dans le slot `--ground-pick`.
+**Goal:** Add a "crouch while gliding, then stand back up" gesture triggered by button A, without modifying the Rust runtime, by training an mjlab policy loaded into the `--ground-pick` slot.
 
-**Architecture:** Nouvelle tâche mjlab entraînée sur le robot rollers, pilotée par la commande de phase `GroundPickPhaseCommand` (celle qu'envoie le slot ground-pick du runtime). Une nouvelle reward suit une cible de hauteur du tronc « en trapèze » (haut → bas → palier 1 s → haut) le long de la phase. Le même layout d'obs 61D que la policy roller → interchangeable au runtime. Export ONNX, chargé via `--ground-pick`.
+**Architecture:** A new mjlab task trained on the roller robot, driven by the `GroundPickPhaseCommand` phase command (the one the runtime's ground-pick slot sends). A new reward tracks a trapezoidal trunk-height target (high → low → 1 s plateau → high) along the phase. The same 61D obs layout as the roller policy → hot-swappable at runtime. ONNX export, loaded via `--ground-pick`.
 
-**Tech Stack:** Python, PyTorch, mjlab 1.3.0, MuJoCo, uv, ONNX. Runtime cible : `apirrone/microduck_runtime` (Rust, binaire — NON modifié).
+**Tech Stack:** Python, PyTorch, mjlab 1.3.0, MuJoCo, uv, ONNX. Target runtime: `apirrone/microduck_runtime` (Rust, a binary — NOT modified).
 
 ## Global Constraints
 
-- **Aucune modification du runtime Rust.** Le geste réutilise le slot `--ground-pick` existant (bouton A, one-shot).
-- **Layout d'obs unifié 61D** obligatoire (`--new-cmd-obs`) : `[twist(3), head(4), body(6)]`, head/body zero-paddés. Toute nouvelle policy DOIT conserver ce layout.
-- **14 joints actifs** (roues passives exclues via `SceneEntityCfg("robot", joint_names=(r"^(?!passive_).*",))`), `action.scale = 1.0`, `kp_fw = 200`.
-- **Parité entraînement/déploiement (sim2real) :** au déploiement, forcer `--ground-pick-kp-ratio 1.0` (défaut 0.6), `--ground-pick-action-scale` = action_scale runtime, `--ground-pick-period 5.0`.
-- **Phase encoding (imposé par le runtime) :** `command = [cos(2π·φ), sin(2π·φ), 0]`, période 4 s. Palier de glisse = 1 s → `hold_lo=0.375`, `hold_hi=0.625`.
-- **Commits simples** (pas de `Co-Authored-By`).
-- Lancer les tests via `uv run --with pytest pytest` (pas de dépendance pytest ajoutée au projet).
-- Spec de référence : `docs/superpowers/specs/2026-07-17-roller-crouch-glide-design.md`.
+- **No modification of the Rust runtime.** The gesture reuses the existing `--ground-pick` slot (button A, one-shot).
+- **The unified 61D obs layout** is mandatory (`--new-cmd-obs`): `[twist(3), head(4), body(6)]`, head/body zero-padded. Every new policy MUST preserve this layout.
+- **14 active joints** (passive wheels excluded via `SceneEntityCfg("robot", joint_names=(r"^(?!passive_).*",))`), `action.scale = 1.0`, `kp_fw = 200`.
+- **Training/deployment parity (sim2real):** at deployment, force `--ground-pick-kp-ratio 1.0` (default 0.6), `--ground-pick-action-scale` = the runtime action_scale, `--ground-pick-period 5.0`.
+- **Phase encoding (imposed by the runtime):** `command = [cos(2π·φ), sin(2π·φ), 0]`, 4 s period. Glide plateau = 1 s → `hold_lo=0.375`, `hold_hi=0.625`.
+- **Simple commits** (no `Co-Authored-By`).
+- Run the tests via `uv run --with pytest pytest` (no pytest dependency added to the project).
+- Reference spec: `docs/superpowers/specs/2026-07-17-roller-crouch-glide-design.md`.
 
 ---
 
 ## File Structure
 
-| Fichier | Responsabilité |
+| File | Responsibility |
 |---|---|
-| `src/mjlab_microduck/tasks/mdp.py` | **Modifier.** Ajouter 3 fonctions : `crouch_height_target` (pure), `crouch_glide_reward_from_values` (pure), `crouch_glide_height_by_phase` (wrapper env) et `forward_speed_reward`. |
-| `tests/test_crouch_glide.py` | **Créer.** Tests unitaires des fonctions pures. |
-| `src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py` | **Créer.** L'env (hybride roller + phase) + `MicroduckRollerCrouchRlCfg`. |
-| `src/mjlab_microduck/tasks/__init__.py` | **Modifier.** Importer + enregistrer `Mjlab-RollerCrouch-Flat-MicroDuck`. |
-| `tests/test_roller_crouch_cfg.py` | **Créer.** Smoke test : l'env se construit avec la bonne commande/rewards. |
+| `src/mjlab_microduck/tasks/mdp.py` | **Modify.** Add 3 functions: `crouch_height_target` (pure), `crouch_glide_reward_from_values` (pure), `crouch_glide_height_by_phase` (env wrapper), plus `forward_speed_reward`. |
+| `tests/test_crouch_glide.py` | **Create.** Unit tests of the pure functions. |
+| `src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py` | **Create.** The env (roller + phase hybrid) + `MicroduckRollerCrouchRlCfg`. |
+| `src/mjlab_microduck/tasks/__init__.py` | **Modify.** Import + register `Mjlab-RollerCrouch-Flat-MicroDuck`. |
+| `tests/test_roller_crouch_cfg.py` | **Create.** Smoke test: the env builds with the right command/rewards. |
 
 ---
 
-## Task 1: Cible de hauteur « en trapèze » (fonction pure)
+## Task 1: Trapezoidal height target (pure function)
 
 **Files:**
-- Modify: `src/mjlab_microduck/tasks/mdp.py` (ajouter la fonction, après `com_height_target` vers la ligne 737)
+- Modify: `src/mjlab_microduck/tasks/mdp.py` (add the function, after `com_height_target` around line 737)
 - Test: `tests/test_crouch_glide.py`
 
 **Interfaces:**
-- Produces: `crouch_height_target(phase: torch.Tensor, height_low: float, height_high: float, hold_lo: float = 0.375, hold_hi: float = 0.625) -> torch.Tensor` — prend la phase (B,) ∈ [0,1) et retourne la hauteur-cible (B,).
+- Produces: `crouch_height_target(phase: torch.Tensor, height_low: float, height_high: float, hold_lo: float = 0.375, hold_hi: float = 0.625) -> torch.Tensor` — takes the phase (B,) ∈ [0,1) and returns the target height (B,).
 
-- [ ] **Step 1: Écrire le test qui échoue**
+- [ ] **Step 1: Write the failing test**
 
-Créer `tests/test_crouch_glide.py` :
+Create `tests/test_crouch_glide.py`:
 
 ```python
 import math
@@ -53,41 +53,41 @@ from mjlab_microduck.tasks import mdp
 
 
 def test_crouch_height_target_endpoints_are_high():
-    # phase 0 (début) et phase ~1 (fin) → hauteur haute (debout)
+    # phase 0 (start) and phase ~1 (end) → high stance (standing)
     phase = torch.tensor([0.0, 0.999])
     t = mdp.crouch_height_target(phase, height_low=0.075, height_high=0.11)
     assert torch.allclose(t, torch.tensor([0.11, 0.11]), atol=2e-3)
 
 
 def test_crouch_height_target_plateau_is_low():
-    # tout le palier [0.375, 0.625] → hauteur basse constante
+    # the whole plateau [0.375, 0.625] → constant low height
     phase = torch.tensor([0.375, 0.5, 0.624])
     t = mdp.crouch_height_target(phase, height_low=0.075, height_high=0.11)
     assert torch.allclose(t, torch.full((3,), 0.075), atol=1e-6)
 
 
 def test_crouch_height_target_descent_midpoint():
-    # milieu de la descente (phase = hold_lo/2 = 0.1875) → milieu des deux hauteurs
+    # midway through the descent (phase = hold_lo/2 = 0.1875) → midpoint of the two heights
     phase = torch.tensor([0.1875])
     t = mdp.crouch_height_target(phase, height_low=0.075, height_high=0.11)
     assert torch.allclose(t, torch.tensor([(0.11 + 0.075) / 2]), atol=1e-6)
 
 
 def test_crouch_height_target_rise_midpoint():
-    # milieu de la remontée (phase = 0.8125) → milieu des deux hauteurs
+    # midway through the rise (phase = 0.8125) → midpoint of the two heights
     phase = torch.tensor([0.8125])
     t = mdp.crouch_height_target(phase, height_low=0.075, height_high=0.11)
     assert torch.allclose(t, torch.tensor([(0.11 + 0.075) / 2]), atol=1e-6)
 ```
 
-- [ ] **Step 2: Lancer le test pour vérifier qu'il échoue**
+- [ ] **Step 2: Run the test to verify it fails**
 
 Run: `uv run --with pytest pytest tests/test_crouch_glide.py -v`
 Expected: FAIL — `AttributeError: module ... has no attribute 'crouch_height_target'`
 
-- [ ] **Step 3: Implémenter la fonction**
+- [ ] **Step 3: Implement the function**
 
-Dans `src/mjlab_microduck/tasks/mdp.py`, juste après `com_height_target` (après la ligne 737) :
+In `src/mjlab_microduck/tasks/mdp.py`, just after `com_height_target` (after line 737):
 
 ```python
 def crouch_height_target(
@@ -97,19 +97,19 @@ def crouch_height_target(
     hold_lo: float = 0.375,
     hold_hi: float = 0.625,
 ) -> torch.Tensor:
-    """Cible de hauteur du tronc « en trapèze » le long de la phase [0,1).
+    """Trapezoidal trunk-height target along the phase [0,1).
 
-    phase ∈ [0, hold_lo)      : descente   height_high -> height_low
-    phase ∈ [hold_lo, hold_hi): palier      height_low   (la glisse accroupie)
-    phase ∈ [hold_hi, 1.0)    : remontée    height_low  -> height_high
+    phase ∈ [0, hold_lo)      : descent   height_high -> height_low
+    phase ∈ [hold_lo, hold_hi): plateau    height_low   (the crouched glide)
+    phase ∈ [hold_hi, 1.0)    : rise       height_low  -> height_high
 
     Args:
-        phase: (B,) phase par env, dans [0, 1).
-        height_low: hauteur du tronc accroupi (m).
-        height_high: hauteur du tronc debout (m).
-        hold_lo, hold_hi: bornes du palier bas en fraction de phase.
+        phase: (B,) per-env phase, in [0, 1).
+        height_low: crouched trunk height (m).
+        height_high: standing trunk height (m).
+        hold_lo, hold_hi: bounds of the low plateau, as a fraction of phase.
     Returns:
-        (B,) hauteur-cible en mètres.
+        (B,) target height in meters.
     """
     descend = phase < hold_lo
     hold = (phase >= hold_lo) & (phase < hold_hi)
@@ -125,7 +125,7 @@ def crouch_height_target(
     return torch.where(descend, t_descend, torch.where(hold, t_hold, t_rise))
 ```
 
-- [ ] **Step 4: Lancer le test pour vérifier qu'il passe**
+- [ ] **Step 4: Run the test to verify it passes**
 
 Run: `uv run --with pytest pytest tests/test_crouch_glide.py -v`
 Expected: PASS (4 tests)
@@ -134,31 +134,31 @@ Expected: PASS (4 tests)
 
 ```bash
 git add src/mjlab_microduck/tasks/mdp.py tests/test_crouch_glide.py
-git commit -m "roller-crouch: cible de hauteur en trapezoide (fonction pure + tests)"
+git commit -m "roller-crouch: trapezoidal height target (pure function + tests)"
 ```
 
 ---
 
-## Task 2: Rewards crouch-glide et forward-speed
+## Task 2: The crouch-glide and forward-speed rewards
 
 **Files:**
 - Modify: `src/mjlab_microduck/tasks/mdp.py`
-- Test: `tests/test_crouch_glide.py` (ajouts)
+- Test: `tests/test_crouch_glide.py` (additions)
 
 **Interfaces:**
 - Consumes: `crouch_height_target` (Task 1).
 - Produces:
   - `crouch_glide_reward_from_values(com_height, cmd_cos, cmd_sin, height_low, height_high, hold_lo=0.375, hold_hi=0.625, std=0.02) -> torch.Tensor` (pure).
-  - `crouch_glide_height_by_phase(env, command_name="twist", height_low=0.075, height_high=0.11, hold_lo=0.375, hold_hi=0.625, std=0.02, asset_cfg=_DEFAULT_ASSET_CFG) -> torch.Tensor` (wrapper env).
-  - `forward_speed_reward(env, vel_ref=0.2, asset_cfg=_DEFAULT_ASSET_CFG) -> torch.Tensor` — récompense la vitesse avant (élan), indépendante de la commande.
+  - `crouch_glide_height_by_phase(env, command_name="twist", height_low=0.075, height_high=0.11, hold_lo=0.375, hold_hi=0.625, std=0.02, asset_cfg=_DEFAULT_ASSET_CFG) -> torch.Tensor` (env wrapper).
+  - `forward_speed_reward(env, vel_ref=0.2, asset_cfg=_DEFAULT_ASSET_CFG) -> torch.Tensor` — rewards forward speed (momentum), independent of the command.
 
-- [ ] **Step 1: Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Ajouter à `tests/test_crouch_glide.py` :
+Add to `tests/test_crouch_glide.py`:
 
 ```python
 def test_reward_is_one_when_height_matches_target():
-    # phase 0.5 (plein palier) → cible = height_low ; si com_height == height_low → reward 1
+    # phase 0.5 (full plateau) → target = height_low; if com_height == height_low → reward 1
     cmd_cos = torch.tensor([math.cos(2 * math.pi * 0.5)])  # -1
     cmd_sin = torch.tensor([math.sin(2 * math.pi * 0.5)])  # ~0
     com_height = torch.tensor([0.075])
@@ -169,7 +169,7 @@ def test_reward_is_one_when_height_matches_target():
 
 
 def test_reward_decays_when_off_by_one_std():
-    # à height_low + std de la cible → exp(-1) ≈ 0.368
+    # at height_low + std from the target → exp(-1) ≈ 0.368
     cmd_cos = torch.tensor([math.cos(2 * math.pi * 0.5)])
     cmd_sin = torch.tensor([math.sin(2 * math.pi * 0.5)])
     com_height = torch.tensor([0.075 + 0.02])
@@ -180,25 +180,25 @@ def test_reward_decays_when_off_by_one_std():
 
 
 def test_reward_at_phase_zero_expects_high_stance():
-    # phase 0 → cible = height_high ; rester debout est récompensé, être accroupi non
+    # phase 0 → target = height_high; staying upright is rewarded, crouching is not
     cmd_cos = torch.tensor([1.0, 1.0])   # cos(0)
     cmd_sin = torch.tensor([0.0, 0.0])   # sin(0)
-    com_height = torch.tensor([0.11, 0.075])  # debout vs accroupi
+    com_height = torch.tensor([0.11, 0.075])  # standing vs crouched
     r = mdp.crouch_glide_reward_from_values(
         com_height, cmd_cos, cmd_sin, height_low=0.075, height_high=0.11, std=0.02
     )
-    assert r[0] > 0.99          # debout à phase 0 → ~1
-    assert r[1] < 0.2           # accroupi à phase 0 → faible
+    assert r[0] > 0.99          # standing at phase 0 → ~1
+    assert r[1] < 0.2           # crouched at phase 0 → low
 ```
 
-- [ ] **Step 2: Vérifier l'échec**
+- [ ] **Step 2: Verify it fails**
 
 Run: `uv run --with pytest pytest tests/test_crouch_glide.py -v`
-Expected: FAIL — `crouch_glide_reward_from_values` n'existe pas.
+Expected: FAIL — `crouch_glide_reward_from_values` does not exist.
 
-- [ ] **Step 3: Implémenter les trois fonctions**
+- [ ] **Step 3: Implement the three functions**
 
-Dans `src/mjlab_microduck/tasks/mdp.py`, à la suite de `crouch_height_target` :
+In `src/mjlab_microduck/tasks/mdp.py`, following `crouch_height_target`:
 
 ```python
 def crouch_glide_reward_from_values(
@@ -211,10 +211,10 @@ def crouch_glide_reward_from_values(
     hold_hi: float = 0.625,
     std: float = 0.02,
 ) -> torch.Tensor:
-    """Récompense gaussienne du suivi de la cible de hauteur (fonction pure).
+    """Gaussian reward for tracking the height target (pure function).
 
-    Décode la phase depuis [cos, sin] puis compare la hauteur mesurée à la
-    cible-trapèze. Retourne exp(-((h - cible)/std)^2) ∈ (0, 1].
+    Decodes the phase from [cos, sin], then compares the measured height to the
+    trapezoidal target. Returns exp(-((h - target)/std)^2) ∈ (0, 1].
     """
     phase = (torch.atan2(cmd_sin, cmd_cos) / (2 * torch.pi)) % 1.0
     target = crouch_height_target(phase, height_low, height_high, hold_lo, hold_hi)
@@ -231,10 +231,10 @@ def crouch_glide_height_by_phase(
     std: float = 0.02,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Reward principale : suit la cible de hauteur du tronc le long de la phase.
+    """Main reward: tracks the trunk-height target along the phase.
 
-    La hauteur du CoM est calculée comme dans `com_height_target` (world z moins
-    l'origine du terrain, nan->0). La phase provient de la commande GroundPick.
+    The CoM height is computed as in `com_height_target` (world z minus the
+    terrain origin, nan->0). The phase comes from the GroundPick command.
     """
     asset: Entity = env.scene[asset_cfg.name]
     com_height = torch.nan_to_num(
@@ -252,31 +252,31 @@ def forward_speed_reward(
     vel_ref: float = 0.2,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Récompense la vitesse avant du tronc (conserver l'élan / ne pas freiner).
+    """Reward the trunk's forward speed (keep the momentum / do not brake).
 
-    Indépendante de la commande (la commande porte la phase, pas la vitesse).
-    tanh(clamp(vx, 0)/vel_ref) → sature à ~1, ne récompense jamais reculer.
+    Independent of the command (the command carries the phase, not the speed).
+    tanh(clamp(vx, 0)/vel_ref) → saturates at ~1, never rewards going backward.
     """
     asset: Entity = env.scene[asset_cfg.name]
     vx = asset.data.root_link_lin_vel_b[:, 0]
     return torch.tanh(torch.clamp(vx, min=0.0) / vel_ref)
 ```
 
-- [ ] **Step 4: Vérifier le passage**
+- [ ] **Step 4: Verify it passes**
 
 Run: `uv run --with pytest pytest tests/test_crouch_glide.py -v`
-Expected: PASS (7 tests au total)
+Expected: PASS (7 tests in total)
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/mdp.py tests/test_crouch_glide.py
-git commit -m "roller-crouch: rewards crouch-glide-height et forward-speed"
+git commit -m "roller-crouch: crouch-glide-height and forward-speed rewards"
 ```
 
 ---
 
-## Task 3: L'environnement + enregistrement de la tâche
+## Task 3: The environment + task registration
 
 **Files:**
 - Create: `src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py`
@@ -284,12 +284,12 @@ git commit -m "roller-crouch: rewards crouch-glide-height et forward-speed"
 - Test: `tests/test_roller_crouch_cfg.py`
 
 **Interfaces:**
-- Consumes: `crouch_glide_height_by_phase`, `forward_speed_reward`, `ground_pick_return_pose` (Task 2 + existant), `GroundPickPhaseCommandCfg`, `GroundPickPhaseCommand`, `MICRODUCK_WALK_ROLLERS_ROBOT_CFG`.
-- Produces: `make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg`, `MicroduckRollerCrouchRlCfg`, tâche `Mjlab-RollerCrouch-Flat-MicroDuck`.
+- Consumes: `crouch_glide_height_by_phase`, `forward_speed_reward`, `ground_pick_return_pose` (Task 2 + existing), `GroundPickPhaseCommandCfg`, `GroundPickPhaseCommand`, `MICRODUCK_WALK_ROLLERS_ROBOT_CFG`.
+- Produces: `make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg`, `MicroduckRollerCrouchRlCfg`, and the `Mjlab-RollerCrouch-Flat-MicroDuck` task.
 
-- [ ] **Step 1: Écrire le smoke test qui échoue**
+- [ ] **Step 1: Write the failing smoke test**
 
-Créer `tests/test_roller_crouch_cfg.py` :
+Create `tests/test_roller_crouch_cfg.py`:
 
 ```python
 from mjlab_microduck.tasks.microduck_roller_crouch_env_cfg import (
@@ -310,7 +310,7 @@ def test_cfg_has_crouch_and_forward_rewards():
     cfg = make_microduck_roller_crouch_env_cfg()
     assert "crouch_glide_height" in cfg.rewards
     assert "forward_speed" in cfg.rewards
-    # rewards de patinage actif retirées (pas de stride pendant le trick)
+    # active skating rewards removed (no stride during the trick)
     for gone in ("braking", "skating_air_time", "single_support", "glide", "wheel_speed"):
         assert gone not in cfg.rewards
 
@@ -320,29 +320,29 @@ def test_cfg_has_entry_velocity_event():
     assert "entry_velocity" in cfg.events
 ```
 
-- [ ] **Step 2: Vérifier l'échec**
+- [ ] **Step 2: Verify it fails**
 
 Run: `uv run --with pytest pytest tests/test_roller_crouch_cfg.py -v`
 Expected: FAIL — `ModuleNotFoundError: ...microduck_roller_crouch_env_cfg`
 
-- [ ] **Step 3: Créer le fichier d'environnement**
+- [ ] **Step 3: Create the environment file**
 
-Créer `src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py` :
+Create `src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py`:
 
 ```python
 """Microduck roller crouch-glide task.
 
-Geste one-shot déclenché au bouton A via le slot --ground-pick du runtime :
-le robot s'accroupit et glisse sur son élan (palier ~1 s), puis se relève et
-rend la main à la policy roller.
+One-shot gesture triggered by button A through the runtime's --ground-pick
+slot: the robot crouches and glides on its momentum (~1 s plateau), then stands
+back up and hands control back to the roller policy.
 
-Hybride :
-  - physique / robot roller  ← microduck_velocity_rollers_env_cfg.py
-  - machinerie phase one-shot ← microduck_ground_pick_env_cfg.py
-    (commande GroundPickPhaseCommand : [cos(2πφ), sin(2πφ), 0], période 4 s)
+Hybrid:
+  - roller physics / robot     ← microduck_velocity_rollers_env_cfg.py
+  - one-shot phase machinery   ← microduck_ground_pick_env_cfg.py
+    (GroundPickPhaseCommand: [cos(2πφ), sin(2πφ), 0], period 4 s)
 
-Cible de hauteur « en trapèze » (haut→bas→palier 1 s→haut) via
-crouch_glide_height_by_phase. Obs 61D unifié → interchangeable au runtime.
+Trapezoidal height target (high→low→1 s plateau→high) via
+crouch_glide_height_by_phase. Unified 61D obs → hot-swappable at runtime.
 """
 
 import math
@@ -350,7 +350,7 @@ from copy import deepcopy
 
 ENABLE_SYMMETRY = False
 
-# DR — repris du roller env
+# DR — taken from the roller env
 ENABLE_COM_RANDOMIZATION             = True
 ENABLE_HEAD_COM_RANDOMIZATION        = True
 ENABLE_MASS_INERTIA_RANDOMIZATION    = True
@@ -371,11 +371,11 @@ VELOCITY_PUSH_RANGE              = (-0.2, 0.2)
 IMU_ORIENTATION_RANDOMIZATION_ANGLE = 6.0
 ENCODER_BIAS_RANGE               = (-0.015, 0.015)
 
-# Geste : hauteurs cibles (m) et vitesse d'entrée (élan)
-CROUCH_HEIGHT_HIGH = 0.11    # tronc debout
-CROUCH_HEIGHT_LOW  = 0.075   # tronc accroupi (à affiner en play)
+# Gesture: target heights (m) and entry velocity (momentum)
+CROUCH_HEIGHT_HIGH = 0.11    # standing trunk
+CROUCH_HEIGHT_LOW  = 0.075   # crouched trunk (to be refined at play time)
 CROUCH_STD         = 0.02
-ENTRY_VELOCITY_X   = (0.2, 0.5)  # m/s : le robot arrive en roulant
+ENTRY_VELOCITY_X   = (0.2, 0.5)  # m/s: the robot arrives already rolling
 
 from mjlab.envs import ManagerBasedRlEnvCfg
 from mjlab.envs.mdp import dr
@@ -402,7 +402,7 @@ from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg, SYMMETRY_CFG
 
 
 def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
-    """Env crouch-glide sur rollers, piloté par la phase du slot ground-pick."""
+    """Crouch-glide-on-rollers env, driven by the ground-pick slot's phase."""
 
     feet_ground_cfg = ContactSensorCfg(
         name="feet_ground_contact",
@@ -448,7 +448,7 @@ def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEn
     cfg.rewards["angular_momentum"].weight = -0.02
     cfg.rewards["action_rate_l2"].weight = -1.0
 
-    # Reward principale : cible de hauteur trapèze le long de la phase
+    # Main reward: trapezoidal height target along the phase
     cfg.rewards["crouch_glide_height"] = RewardTermCfg(
         func=microduck_mdp.crouch_glide_height_by_phase,
         weight=4.0,
@@ -461,13 +461,13 @@ def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEn
             "std": CROUCH_STD,
         },
     )
-    # Conserver l'élan (ne pas freiner) — indépendant de la commande
+    # Preserve the momentum (do not brake) — independent of the command
     cfg.rewards["forward_speed"] = RewardTermCfg(
         func=microduck_mdp.forward_speed_reward,
         weight=2.0,
         params={"vel_ref": 0.2},
     )
-    # Fin de phase : converger vers la pose roller debout pour rendre la main proprement
+    # End of phase: converge to the standing roller pose for a clean handover
     _LEG_JOINTS = [0, 1, 2, 3, 4, 9, 10, 11, 12, 13]
     _NECK_JOINTS = [5, 6, 7, 8]
     cfg.rewards["return_pose_legs"] = RewardTermCfg(
@@ -480,7 +480,7 @@ def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEn
         weight=3.0,
         params={"std": 0.15, "command_name": "twist", "joint_indices": _NECK_JOINTS},
     )
-    # Stabilité de glisse
+    # Glide stability
     cfg.rewards["feet_flat"] = RewardTermCfg(
         func=microduck_mdp.feet_flat_penalty,
         weight=-2.0,
@@ -512,7 +512,7 @@ def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEn
     )
     del cfg.events["foot_friction"]
 
-    # Vitesse d'entrée : le robot démarre en roulant vers l'avant (élan à conserver)
+    # Entry velocity: the robot starts rolling forward (momentum to preserve)
     cfg.events["entry_velocity"] = EventTermCfg(
         func=mdp.push_by_setting_velocity,
         mode="reset",
@@ -658,7 +658,7 @@ def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEn
             func=microduck_mdp.zero_command_padding, params={"dim": 6},
         )
 
-    # === COMMAND: phase (comme ground_pick) ===
+    # === COMMAND: phase (like ground_pick) ===
     command: UniformVelocityCommandCfg = cfg.commands["twist"]
     command.rel_standing_envs = 0.0
     command.rel_heading_envs = 0.0
@@ -751,9 +751,9 @@ MicroduckRollerCrouchRlCfg = RslRlOnPolicyRunnerCfg(
 )
 ```
 
-- [ ] **Step 4: Enregistrer la tâche**
+- [ ] **Step 4: Register the task**
 
-Dans `src/mjlab_microduck/tasks/__init__.py`, ajouter l'import après le bloc rollers (après la ligne 54) :
+In `src/mjlab_microduck/tasks/__init__.py`, add the import after the rollers block (after line 54):
 
 ```python
 from .microduck_roller_crouch_env_cfg import (
@@ -762,7 +762,7 @@ from .microduck_roller_crouch_env_cfg import (
 )
 ```
 
-et l'enregistrement après le bloc rollers (après la ligne 175) :
+and the registration after the rollers block (after line 175):
 
 ```python
 register_mjlab_task(
@@ -775,60 +775,60 @@ register_mjlab_task(
 print("✓ RollerCrouch task registered: Mjlab-RollerCrouch-Flat-MicroDuck")
 ```
 
-- [ ] **Step 5: Vérifier le passage du smoke test**
+- [ ] **Step 5: Verify the smoke test passes**
 
 Run: `uv run --with pytest pytest tests/test_roller_crouch_cfg.py -v`
-Expected: PASS (3 tests). (Ce test construit l'env — il compile le spec MuJoCo, donc il est plus lent ; c'est normal.)
+Expected: PASS (3 tests). (This test builds the env — it compiles the MuJoCo spec, so it is slower; that is normal.)
 
-- [ ] **Step 6: Vérifier que la tâche est bien enregistrée**
+- [ ] **Step 6: Verify the task is properly registered**
 
 Run: `uv run python -c "import mjlab_microduck.tasks"`
-Expected: la ligne `✓ RollerCrouch task registered: Mjlab-RollerCrouch-Flat-MicroDuck` s'affiche sans erreur.
+Expected: the line `✓ RollerCrouch task registered: Mjlab-RollerCrouch-Flat-MicroDuck` is printed without error.
 
 - [ ] **Step 7: Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py \
         src/mjlab_microduck/tasks/__init__.py tests/test_roller_crouch_cfg.py
-git commit -m "roller-crouch: env crouch-glide + enregistrement de la tache"
+git commit -m "roller-crouch: crouch-glide env + task registration"
 ```
 
 ---
 
-## Task 4: Smoke run d'entraînement (vérification runtime)
+## Task 4: Training smoke run (runtime verification)
 
-**Files:** aucun (vérification observationnelle).
+**Files:** none (observational check).
 
 **Interfaces:**
-- Consumes: la tâche `Mjlab-RollerCrouch-Flat-MicroDuck` (Task 3).
+- Consumes: the `Mjlab-RollerCrouch-Flat-MicroDuck` task (Task 3).
 
-- [ ] **Step 1: Lancer un entraînement très court**
+- [ ] **Step 1: Run a very short training**
 
 Run:
 ```bash
 uv run train Mjlab-RollerCrouch-Flat-MicroDuck \
   --env.scene.num-envs 64 --agent.max_iterations 5
 ```
-Expected: l'entraînement démarre, log les rewards (dont `crouch_glide_height`, `forward_speed`), 5 itérations sans crash, un checkpoint est écrit.
+Expected: training starts, logs the rewards (including `crouch_glide_height`, `forward_speed`), runs 5 iterations without crashing, and writes a checkpoint.
 
-- [ ] **Step 2: Vérifier l'absence d'erreur de forme d'obs**
+- [ ] **Step 2: Check for obs-shape errors**
 
-Inspecter le log de démarrage : l'obs actor doit être **61D** (comme les autres policies de la famille). Si la dim diffère, le padding head/body ou l'exclusion des roues est mal câblé — corriger avant de continuer.
+Inspect the startup log: the actor obs must be **61D** (like the other policies in the family). If the dimension differs, the head/body padding or the wheel exclusion is miswired — fix it before continuing.
 
-- [ ] **Step 3: Commit (si un fichier de conf a dû être ajusté)**
+- [ ] **Step 3: Commit (if a config file had to be adjusted)**
 
 ```bash
-git add -A && git commit -m "roller-crouch: ajustement post smoke-run"
+git add -A && git commit -m "roller-crouch: post smoke-run adjustment"
 ```
-(S'il n'y a rien à committer, sauter cette étape.)
+(If there is nothing to commit, skip this step.)
 
 ---
 
-## Task 5: Entraînement complet + vérification en play
+## Task 5: Full training + play verification
 
-**Files:** itérations possibles sur `microduck_roller_crouch_env_cfg.py` (poids de reward, `CROUCH_HEIGHT_LOW`).
+**Files:** possible iterations on `microduck_roller_crouch_env_cfg.py` (reward weights, `CROUCH_HEIGHT_LOW`).
 
-- [ ] **Step 1: Lancer l'entraînement complet**
+- [ ] **Step 1: Run the full training**
 
 Run:
 ```bash
@@ -836,39 +836,39 @@ uv run train Mjlab-RollerCrouch-Flat-MicroDuck \
   --env.scene.num-envs 4096 --agent.max_iterations 8000
 ```
 
-- [ ] **Step 2: Visualiser en play**
+- [ ] **Step 2: Visualize in play**
 
-Run: `uv run scripts/play_latest.py` (ou l'entrée play du projet pour cette tâche).
-Observer le cycle : le robot **descend**, **glisse ~1 s** avec les roues qui continuent de tourner (il ne freine pas), puis **se relève** et la pose finale rejoint la pose roller debout. Il ne doit pas tomber.
+Run: `uv run scripts/play_latest.py` (or the project's play entry point for this task).
+Watch the cycle: the robot **goes down**, **glides ~1 s** with the wheels still turning (it does not brake), then **stands back up** and the final pose rejoins the standing roller pose. It must not fall.
 
-- [ ] **Step 3: Itérer si nécessaire**
+- [ ] **Step 3: Iterate if needed**
 
-Réglages typiques (dans `microduck_roller_crouch_env_cfg.py`) :
-- Il ne descend pas assez → baisser `CROUCH_HEIGHT_LOW` (ex. 0.07) et/ou monter le poids de `crouch_glide_height`.
-- Il freine pendant l'accroupi → monter le poids de `forward_speed`.
-- Il tombe en position basse → monter `upright`, baisser la vitesse d'entrée `ENTRY_VELOCITY_X`, ou raccourcir le palier (rapprocher `hold_lo`/`hold_hi`).
-- La remontée est brutale → monter `return_pose_*` et/ou `action_rate_l2`.
+Typical adjustments (in `microduck_roller_crouch_env_cfg.py`):
+- It does not go down far enough → lower `CROUCH_HEIGHT_LOW` (e.g. 0.07) and/or raise the `crouch_glide_height` weight.
+- It brakes during the crouch → raise the `forward_speed` weight.
+- It falls in the low position → raise `upright`, lower the entry velocity `ENTRY_VELOCITY_X`, or shorten the plateau (bring `hold_lo`/`hold_hi` closer together).
+- The rise is brutal → raise `return_pose_*` and/or `action_rate_l2`.
 
-Après chaque changement, relancer un entraînement et re-visualiser. Committer chaque réglage retenu :
+After each change, retrain and re-visualize. Commit each adjustment you keep:
 ```bash
 git add src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py
-git commit -m "roller-crouch: reglage <ce qui a change>"
+git commit -m "roller-crouch: tune <what changed>"
 ```
 
 ---
 
-## Task 6: Export ONNX + déploiement sur le robot
+## Task 6: ONNX export + deployment on the robot
 
-**Files:** aucun (manuel / matériel).
+**Files:** none (manual / hardware).
 
-- [ ] **Step 1: Exporter la policy en ONNX**
+- [ ] **Step 1: Export the policy to ONNX**
 
-Run: `uv run scripts/export_latest.py` (le normaliseur d'obs est baké dans le graphe par `scripts/export.py`).
-Récupérer le fichier `.onnx`, le renommer `roller_crouch.onnx`, le copier sur le robot (ex. `~/microduck/policies/roller_crouch.onnx`).
+Run: `uv run scripts/export_latest.py` (the obs normalizer is baked into the graph by `scripts/export.py`).
+Collect the `.onnx` file, rename it `roller_crouch.onnx`, and copy it onto the robot (e.g. `~/microduck/policies/roller_crouch.onnx`).
 
-- [ ] **Step 2: Lancer le runtime avec le slot ground-pick**
+- [ ] **Step 2: Launch the runtime with the ground-pick slot**
 
-Sur le robot :
+On the robot:
 ```bash
 microduck_runtime --variant pre-alpha --new-cmd-obs --roller \
   --model output.onnx \
@@ -880,20 +880,20 @@ microduck_runtime --variant pre-alpha --new-cmd-obs --roller \
   --ground-pick-action-scale 0.8
 ```
 
-**Paramètres critiques (parité sim2real) :**
-- `--ground-pick-kp-ratio 1.0` — le défaut 0.6 baisserait kp à 120 alors qu'on entraîne à 200.
-- `--ground-pick-action-scale 0.8` — doit matcher l'`action_scale` d'entraînement.
-- `--ground-pick-period 5.0` — doit matcher la période entraînée.
+**Critical parameters (sim2real parity):**
+- `--ground-pick-kp-ratio 1.0` — the 0.6 default would lower kp to 120 while we train at 200.
+- `--ground-pick-action-scale 0.8` — must match the training `action_scale`.
+- `--ground-pick-period 5.0` — must match the trained period.
 
-- [ ] **Step 3: Tester le geste**
+- [ ] **Step 3: Test the gesture**
 
-Lancer le robot à petite vitesse en avant, appuyer sur **A**. Vérifier : il s'accroupit, glisse ~1 s, se relève, et la policy roller reprend la main proprement. Si instable, revenir à la Task 5 (itérer sur les poids / la hauteur / la vitesse d'entrée).
+Run the robot forward at low speed and press **A**. Check: it crouches, glides ~1 s, stands back up, and the roller policy cleanly takes back control. If unstable, go back to Task 5 (iterate on the weights / the height / the entry velocity).
 
 ---
 
-## Notes de vérification (self-review)
+## Verification notes (self-review)
 
-- **Couverture spec :** cible trapèze 1 s (Task 1) ; rewards crouch + anti-freinage + return-pose (Task 2/3) ; robot rollers + phase + obs 61D + DR (Task 3) ; vitesse d'entrée (Task 3, event `entry_velocity`) ; flags de déploiement dont le piège `kp-ratio` (Task 6). ✅
-- **Piège phase vs vitesse :** `wheel_speed_reward`/`braking`/`coasting_reward` du roller env utilisent `command[:,0]` comme *vitesse* — invalide ici où `command[:,0]=cos(2πφ)`. Elles sont donc **retirées** et remplacées par `forward_speed_reward` (indépendante de la commande). Testé par `test_cfg_has_crouch_and_forward_rewards`.
-- **Cohérence des noms :** `crouch_glide_height` (clé reward) vs `crouch_glide_height_by_phase` (fonction) — voulu : la clé est le nom du terme, la fonction est `func=`.
+- **Spec coverage:** 1 s trapezoidal target (Task 1); crouch + anti-braking + return-pose rewards (Task 2/3); roller robot + phase + 61D obs + DR (Task 3); entry velocity (Task 3, the `entry_velocity` event); deployment flags including the `kp-ratio` pitfall (Task 6). ✅
+- **Phase vs velocity pitfall:** the roller env's `wheel_speed_reward`/`braking`/`coasting_reward` use `command[:,0]` as a *velocity* — invalid here, where `command[:,0]=cos(2πφ)`. They are therefore **removed** and replaced with `forward_speed_reward` (command-independent). Tested by `test_cfg_has_crouch_and_forward_rewards`.
+- **Naming consistency:** `crouch_glide_height` (the reward key) vs `crouch_glide_height_by_phase` (the function) — intentional: the key is the term's name, the function goes in `func=`.
 ```

--- a/docs/superpowers/plans/2026-07-22-roller-slope.md
+++ b/docs/superpowers/plans/2026-07-22-roller-slope.md
@@ -129,7 +129,7 @@ git commit -m "roller-slope: ramp angle by difficulty (pure function + tests)"
 - [ ] **Step 1: Write the failing test**
 
 ```python
-# tests/test_slope_terrain.py  (ajouter)
+# tests/test_slope_terrain.py  (add)
 import mujoco
 import numpy as np
 from mjlab_microduck.tasks.slope_terrain import FlatRampTerrainCfg

--- a/docs/superpowers/plans/2026-07-22-roller-slope.md
+++ b/docs/superpowers/plans/2026-07-22-roller-slope.md
@@ -1,45 +1,45 @@
-# Mode pente `roller_slope` — Implementation Plan
+# Slope mode `roller_slope` — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Entraîner une politique dédiée où microduck (rollers) démarre sur du plat avec une impulsion, roule sur une rampe descendante, et se laisse glisser jusqu'en bas en restant debout — sans aucun pilotage.
+**Goal:** Train a dedicated policy where the microduck (on rollers) starts on the flat with an impulse, rolls onto a downhill ramp, and lets itself glide to the bottom while staying upright — with no steering at all.
 
-**Architecture:** Nouvelle tâche isolée clonée de `velocity_rollers` (même robot, même obs 61D → interchangeable au runtime). Terrain custom « plat + rampe » à angle interpolé par difficulté, curriculum de raideur maison, commande neutralisée, récompenses d'équilibre + posture debout nominale. Bouton `Y` de bascule dans `infer_policy.py`.
+**Architecture:** A new isolated task cloned from `velocity_rollers` (same robot, same 61D obs → hot-swappable at runtime). A custom "flat + ramp" terrain whose angle is interpolated by difficulty, a home-grown steepness curriculum, a neutralized command, and balance + nominal standing posture rewards. A `Y` toggle key in `infer_policy.py`.
 
-**Tech Stack:** Python, mjlab 1.3.x, MuJoCo (MjSpec terrains), rsl_rl (PPO), PyTorch, onnxruntime (déploiement), pytest.
+**Tech Stack:** Python, mjlab 1.3.x, MuJoCo (MjSpec terrains), rsl_rl (PPO), PyTorch, onnxruntime (deployment), pytest.
 
 ## Global Constraints
 
-- **Observation unifiée 61D** : twist (3D) + head_command (4D) + body_command (6D) en zéro-padding. Ne jamais changer ce layout — la politique doit charger via `--new-cmd-obs`.
-- **Résolution des joints par NOM**, jamais par index (roues passives intercalées).
-- **Vitesse d'entrée via `reset_root_state_uniform` (velocity_range)**, JAMAIS via `push_by_setting_velocity` en mode reset (accumule sur l'état racine → free-joint diverge → NaN). Leçon `roller_crouch`.
-- **Angles en radians** dans le code physique ; les constantes de raideur sont exprimées en degrés (`RAMP_DEG_MIN=2.0`, `RAMP_DEG_MAX=20.0`) et converties.
-- **Commits simples**, style du dépôt (pas de `Co-authored-by`).
-- Tests dans `tests/`, lancés avec `uv run pytest`.
+- **Unified 61D observation**: twist (3D) + head_command (4D) + body_command (6D) zero-padded. Never change this layout — the policy must load via `--new-cmd-obs`.
+- **Joints resolved BY NAME**, never by index (the passive wheels are interleaved).
+- **Entry velocity through `reset_root_state_uniform` (velocity_range)**, NEVER through `push_by_setting_velocity` in reset mode (it accumulates on the root state → the free joint diverges → NaN). A `roller_crouch` lesson.
+- **Angles in radians** in the physics code; the steepness constants are expressed in degrees (`RAMP_DEG_MIN=2.0`, `RAMP_DEG_MAX=20.0`) and converted.
+- **Simple commits**, in the repo's style (no `Co-authored-by`).
+- Tests in `tests/`, run with `uv run pytest`.
 
 ---
 
 ## File Structure
 
-- **Create** `src/mjlab_microduck/tasks/slope_terrain.py` — `ramp_angle_by_difficulty()` + `FlatRampTerrainCfg` (géométrie du terrain plat+rampe). Responsabilité unique : le terrain.
-- **Modify** `src/mjlab_microduck/tasks/mdp.py` — ajouter `slope_move_masks()` (pur) + `terrain_levels_slope()` (curriculum de raideur).
+- **Create** `src/mjlab_microduck/tasks/slope_terrain.py` — `ramp_angle_by_difficulty()` + `FlatRampTerrainCfg` (the flat+ramp terrain geometry). Single responsibility: the terrain.
+- **Modify** `src/mjlab_microduck/tasks/mdp.py` — add `slope_move_masks()` (pure) + `terrain_levels_slope()` (the steepness curriculum).
 - **Create** `src/mjlab_microduck/tasks/microduck_roller_slope_env_cfg.py` — `make_microduck_roller_slope_env_cfg()` + `MicroduckRollerSlopeRlCfg`.
-- **Modify** `src/mjlab_microduck/tasks/__init__.py` — enregistrer la tâche.
-- **Modify** `scripts/infer_policy.py` — flag `--slope` + touche `Y`.
+- **Modify** `src/mjlab_microduck/tasks/__init__.py` — register the task.
+- **Modify** `scripts/infer_policy.py` — the `--slope` flag + the `Y` key.
 - **Create** `tests/test_slope_terrain.py`, `tests/test_slope_curriculum.py`, `tests/test_roller_slope_cfg.py`.
 
 ---
 
-## Task 1 : angle de rampe par difficulté (fonction pure)
+## Task 1: ramp angle by difficulty (pure function)
 
 **Files:**
 - Create: `src/mjlab_microduck/tasks/slope_terrain.py`
 - Test: `tests/test_slope_terrain.py`
 
 **Interfaces:**
-- Produces: `ramp_angle_by_difficulty(difficulty: float, deg_min: float = 2.0, deg_max: float = 20.0) -> float` (retourne des **radians**). Constantes module `RAMP_DEG_MIN = 2.0`, `RAMP_DEG_MAX = 20.0`.
+- Produces: `ramp_angle_by_difficulty(difficulty: float, deg_min: float = 2.0, deg_max: float = 20.0) -> float` (returns **radians**). Module constants `RAMP_DEG_MIN = 2.0`, `RAMP_DEG_MAX = 20.0`.
 
-- [ ] **Step 1: Écrire le test qui échoue**
+- [ ] **Step 1: Write the failing test**
 
 ```python
 # tests/test_slope_terrain.py
@@ -66,20 +66,20 @@ def test_ramp_angle_clamps_out_of_range():
     assert math.isclose(ramp_angle_by_difficulty(2.0), math.radians(RAMP_DEG_MAX), abs_tol=1e-9)
 ```
 
-- [ ] **Step 2: Lancer le test — il doit échouer**
+- [ ] **Step 2: Run the test — it must fail**
 
 Run: `uv run pytest tests/test_slope_terrain.py -v`
 Expected: FAIL — `ModuleNotFoundError: No module named 'mjlab_microduck.tasks.slope_terrain'`
 
-- [ ] **Step 3: Implémentation minimale**
+- [ ] **Step 3: Minimal implementation**
 
 ```python
 # src/mjlab_microduck/tasks/slope_terrain.py
-"""Terrain custom « plat + rampe descendante » pour la tâche roller_slope.
+"""Custom "flat + downhill ramp" terrain for the roller_slope task.
 
-Le robot spawne sur une zone plate, reçoit une impulsion vers +x, roule
-jusqu'à la rampe et se laisse glisser. L'angle de la rampe est interpolé par
-la difficulté (curriculum) sur [RAMP_DEG_MIN, RAMP_DEG_MAX] degrés.
+The robot spawns on a flat area, gets an impulse toward +x, rolls to the ramp
+and lets itself glide. The ramp angle is interpolated by the difficulty
+(curriculum) over [RAMP_DEG_MIN, RAMP_DEG_MAX] degrees.
 """
 
 from __future__ import annotations
@@ -95,12 +95,12 @@ RAMP_DEG_MAX = 20.0
 def ramp_angle_by_difficulty(
     difficulty: float, deg_min: float = RAMP_DEG_MIN, deg_max: float = RAMP_DEG_MAX
 ) -> float:
-    """Angle de rampe (radians) interpolé linéairement par la difficulté [0,1]."""
+    """Ramp angle (radians), linearly interpolated by the difficulty [0,1]."""
     d = float(np.clip(difficulty, 0.0, 1.0))
     return math.radians(deg_min + d * (deg_max - deg_min))
 ```
 
-- [ ] **Step 4: Lancer le test — il doit passer**
+- [ ] **Step 4: Run the test — it must pass**
 
 Run: `uv run pytest tests/test_slope_terrain.py -v`
 Expected: PASS (3 tests)
@@ -109,24 +109,24 @@ Expected: PASS (3 tests)
 
 ```bash
 git add src/mjlab_microduck/tasks/slope_terrain.py tests/test_slope_terrain.py
-git commit -m "roller-slope: angle de rampe par difficulte (fonction pure + tests)"
+git commit -m "roller-slope: ramp angle by difficulty (pure function + tests)"
 ```
 
 ---
 
-## Task 2 : terrain custom `FlatRampTerrainCfg`
+## Task 2: custom terrain `FlatRampTerrainCfg`
 
 **Files:**
 - Modify: `src/mjlab_microduck/tasks/slope_terrain.py`
 - Test: `tests/test_slope_terrain.py`
 
 **Interfaces:**
-- Consumes: `ramp_angle_by_difficulty` (Task 1), `SubTerrainCfg`, `TerrainGeometry`, `TerrainOutput` de `mjlab.terrains.terrain_generator`.
-- Produces: `FlatRampTerrainCfg(SubTerrainCfg)` avec champs `flat_length: float = 2.0`, `ramp_length: float = 5.0`, `deg_min: float = 2.0`, `deg_max: float = 20.0`, `thickness: float = 0.5` ; méthode `function(difficulty, spec, rng) -> TerrainOutput`. L'origine de spawn est sur le plat.
+- Consumes: `ramp_angle_by_difficulty` (Task 1), and `SubTerrainCfg`, `TerrainGeometry`, `TerrainOutput` from `mjlab.terrains.terrain_generator`.
+- Produces: `FlatRampTerrainCfg(SubTerrainCfg)` with fields `flat_length: float = 2.0`, `ramp_length: float = 5.0`, `deg_min: float = 2.0`, `deg_max: float = 20.0`, `thickness: float = 0.5`; and a `function(difficulty, spec, rng) -> TerrainOutput` method. The spawn origin is on the flat.
 
-**Notes géométrie (à retenir) :** la surface du plat est à `z=0` local. La rampe est un box tourné autour de `+y` par un quaternion `[cos(a/2), 0, sin(a/2), 0]` — une rotation `+a` autour de `+y` abaisse le bord `+x` (la rampe descend quand `x` augmente). L'assemblage exact plat/rampe (pas de marche, pas de trou) **doit être vérifié dans le viewer** (Step 6) car le `z` du centre de la rampe est sensible.
+**Geometry notes (worth remembering):** the flat's surface is at local `z=0`. The ramp is a box rotated about `+y` by a quaternion `[cos(a/2), 0, sin(a/2), 0]` — a `+a` rotation about `+y` lowers the `+x` edge (the ramp descends as `x` increases). The exact flat/ramp joint (no step, no gap) **must be verified in the viewer** (Step 6) because the ramp center's `z` is sensitive.
 
-- [ ] **Step 1: Écrire le test qui échoue**
+- [ ] **Step 1: Write the failing test**
 
 ```python
 # tests/test_slope_terrain.py  (ajouter)
@@ -143,35 +143,35 @@ def _empty_terrain_spec():
 
 def test_flat_ramp_builds_geoms_and_origin_on_flat():
     cfg = FlatRampTerrainCfg(flat_length=2.0, ramp_length=5.0)
-    cfg.size = (8.0, 4.0)  # posé normalement par le générateur
+    cfg.size = (8.0, 4.0)  # normally set by the generator
     spec = _empty_terrain_spec()
     out = cfg.function(difficulty=0.5, spec=spec, rng=np.random.default_rng(0))
-    # deux géométries : plat + rampe
+    # two geoms: flat + ramp
     assert len(out.geometries) == 2
-    # origine sur le plat (x dans [0, flat_length], z ~ 0)
+    # origin on the flat (x in [0, flat_length], z ~ 0)
     assert 0.0 <= out.origin[0] <= 2.0
     assert abs(out.origin[2]) < 1e-6
 
 
 def test_flat_ramp_steeper_at_higher_difficulty():
-    # à difficulté plus haute, le bout de rampe descend plus bas
+    # at higher difficulty the end of the ramp goes lower
     cfg = FlatRampTerrainCfg()
     cfg.size = (8.0, 4.0)
     easy = cfg.function(0.0, _empty_terrain_spec(), np.random.default_rng(0))
     hard = cfg.function(1.0, _empty_terrain_spec(), np.random.default_rng(0))
-    # la rampe (2e géométrie) est plus basse (centre z plus négatif) en difficile
+    # the ramp (2nd geom) sits lower (more negative center z) at high difficulty
     assert hard.geometries[1].geom.pos[2] < easy.geometries[1].geom.pos[2]
 ```
 
-- [ ] **Step 2: Lancer le test — il doit échouer**
+- [ ] **Step 2: Run the test — it must fail**
 
 Run: `uv run pytest tests/test_slope_terrain.py -k flat_ramp -v`
 Expected: FAIL — `ImportError: cannot import name 'FlatRampTerrainCfg'`
 
-- [ ] **Step 3: Implémentation minimale**
+- [ ] **Step 3: Minimal implementation**
 
 ```python
-# src/mjlab_microduck/tasks/slope_terrain.py  (ajouter en tête)
+# src/mjlab_microduck/tasks/slope_terrain.py  (add at the top)
 from dataclasses import dataclass
 
 import mujoco
@@ -185,35 +185,35 @@ from mjlab.terrains.terrain_generator import (
 
 @dataclass(kw_only=True)
 class FlatRampTerrainCfg(SubTerrainCfg):
-    """Zone plate de départ suivie d'une rampe descendante (angle par difficulté)."""
+    """A flat starting area followed by a downhill ramp (angle by difficulty)."""
 
-    flat_length: float = 2.0   # longueur du plat de départ le long de +x (m)
-    ramp_length: float = 5.0   # longueur horizontale de la rampe le long de +x (m)
+    flat_length: float = 2.0   # length of the starting flat along +x (m)
+    ramp_length: float = 5.0   # horizontal length of the ramp along +x (m)
     deg_min: float = RAMP_DEG_MIN
     deg_max: float = RAMP_DEG_MAX
-    thickness: float = 0.5     # épaisseur des box (m)
+    thickness: float = 0.5     # box thickness (m)
 
     def function(
         self, difficulty: float, spec: mujoco.MjSpec, rng
     ) -> TerrainOutput:
-        del rng  # non utilisé
+        del rng  # unused
         body = spec.body("terrain")
         angle = ramp_angle_by_difficulty(difficulty, self.deg_min, self.deg_max)
         width = self.size[1]
         t = self.thickness
 
-        # Plat : box dont la surface supérieure est à z=0, x dans [0, flat_length].
+        # Flat: a box whose top surface is at z=0, x in [0, flat_length].
         flat = body.add_geom(
             type=mujoco.mjtGeom.mjGEOM_BOX,
             size=(self.flat_length / 2.0, width / 2.0, t / 2.0),
             pos=(self.flat_length / 2.0, 0.0, -t / 2.0),
         )
 
-        # Rampe : box tourné de +angle autour de +y (le bord +x descend).
-        # Longueur de surface = ramp_length / cos(angle).
+        # Ramp: a box rotated by +angle about +y (the +x edge goes down).
+        # Surface length = ramp_length / cos(angle).
         surf_len = self.ramp_length / math.cos(angle)
         ramp_cx = self.flat_length + self.ramp_length / 2.0
-        # Centre z : mi-descente de la surface, moins la demi-épaisseur projetée.
+        # Center z: halfway down the surface, minus the projected half-thickness.
         ramp_cz = -(self.ramp_length * math.tan(angle) / 2.0) - (t / 2.0) * math.cos(angle)
         half = angle / 2.0
         ramp = body.add_geom(
@@ -233,7 +233,7 @@ class FlatRampTerrainCfg(SubTerrainCfg):
         )
 ```
 
-- [ ] **Step 4: Lancer les tests — ils doivent passer**
+- [ ] **Step 4: Run the tests — they must pass**
 
 Run: `uv run pytest tests/test_slope_terrain.py -v`
 Expected: PASS (5 tests)
@@ -242,20 +242,20 @@ Expected: PASS (5 tests)
 
 ```bash
 git add src/mjlab_microduck/tasks/slope_terrain.py tests/test_slope_terrain.py
-git commit -m "roller-slope: terrain custom plat+rampe (FlatRampTerrainCfg + tests)"
+git commit -m "roller-slope: custom flat+ramp terrain (FlatRampTerrainCfg + tests)"
 ```
 
-- [ ] **Step 6: Vérification visuelle (checkpoint humain)**
+- [ ] **Step 6: Visual verification (human checkpoint)**
 
-La géométrie (surtout `ramp_cz` et le signe du quaternion) doit être confirmée à l'œil.
-Après la Task 4 (env assemblé), lancer le viewer play (voir Task 4 Step 6) et vérifier :
-la zone plate rejoint la rampe **sans marche ni trou**, et la rampe **descend** dans
-la direction `+x` (devant le robot). Si un décalage vertical apparaît, ajuster `ramp_cz` ;
-si la rampe monte au lieu de descendre, inverser le signe (`-half`) du quaternion.
+The geometry (especially `ramp_cz` and the quaternion's sign) must be confirmed by eye.
+After Task 4 (env assembled), launch the play viewer (see Task 4 Step 6) and check:
+the flat area meets the ramp **with no step and no gap**, and the ramp **descends** in
+the `+x` direction (in front of the robot). If a vertical offset appears, adjust `ramp_cz`;
+if the ramp goes up instead of down, flip the sign (`-half`) of the quaternion.
 
 ---
 
-## Task 3 : curriculum de raideur `terrain_levels_slope`
+## Task 3: steepness curriculum `terrain_levels_slope`
 
 **Files:**
 - Modify: `src/mjlab_microduck/tasks/mdp.py`
@@ -263,10 +263,10 @@ si la rampe monte au lieu de descendre, inverser le signe (`-half`) du quaternio
 
 **Interfaces:**
 - Produces:
-  - `slope_move_masks(distance: torch.Tensor, size_x: float) -> tuple[torch.Tensor, torch.Tensor]` — helper pur. `move_up = distance > size_x * 0.5` (a atteint le bas → rampe plus raide) ; `move_down = (distance < size_x * 0.2) & ~move_up` (chute/blocage tôt → rampe plus douce). Retourne `(move_up, move_down)` en `bool`.
-  - `terrain_levels_slope(env, env_ids) -> torch.Tensor` — signature curriculum mjlab ; calcule la distance parcourue en `x` depuis l'origine, applique `slope_move_masks`, appelle `terrain.update_env_origins`, retourne le niveau moyen.
+  - `slope_move_masks(distance: torch.Tensor, size_x: float) -> tuple[torch.Tensor, torch.Tensor]` — a pure helper. `move_up = distance > size_x * 0.5` (reached the bottom → steeper ramp); `move_down = (distance < size_x * 0.2) & ~move_up` (early fall/stall → gentler ramp). Returns `(move_up, move_down)` as `bool`.
+  - `terrain_levels_slope(env, env_ids) -> torch.Tensor` — the mjlab curriculum signature; computes the distance travelled in `x` from the origin, applies `slope_move_masks`, calls `terrain.update_env_origins`, and returns the mean level.
 
-- [ ] **Step 1: Écrire le test qui échoue**
+- [ ] **Step 1: Write the failing test**
 
 ```python
 # tests/test_slope_curriculum.py
@@ -275,7 +275,7 @@ from mjlab_microduck.tasks.mdp import slope_move_masks
 
 
 def test_move_up_when_reached_bottom():
-    # distance > size_x/2 → monte en difficulté
+    # distance > size_x/2 → promote to a harder slope
     dist = torch.tensor([5.0, 4.1])
     up, down = slope_move_masks(dist, size_x=8.0)
     assert bool(up[0]) and bool(up[1])
@@ -283,7 +283,7 @@ def test_move_up_when_reached_bottom():
 
 
 def test_move_down_when_stuck_early():
-    # distance < size_x*0.2 (=1.6) → descend en difficulté
+    # distance < size_x*0.2 (=1.6) → demote to an easier slope
     dist = torch.tensor([0.5, 1.0])
     up, down = slope_move_masks(dist, size_x=8.0)
     assert not bool(up[0]) and not bool(up[1])
@@ -291,29 +291,29 @@ def test_move_down_when_stuck_early():
 
 
 def test_stay_in_middle_band():
-    # entre 1.6 et 4.0 → ni haut ni bas
+    # between 1.6 and 4.0 → neither up nor down
     dist = torch.tensor([2.5])
     up, down = slope_move_masks(dist, size_x=8.0)
     assert not bool(up[0]) and not bool(down[0])
 ```
 
-- [ ] **Step 2: Lancer le test — il doit échouer**
+- [ ] **Step 2: Run the test — it must fail**
 
 Run: `uv run pytest tests/test_slope_curriculum.py -v`
 Expected: FAIL — `ImportError: cannot import name 'slope_move_masks'`
 
-- [ ] **Step 3: Implémentation minimale**
+- [ ] **Step 3: Minimal implementation**
 
-Ajouter dans `src/mjlab_microduck/tasks/mdp.py` (près des autres curriculums, ex. après `com_range_curriculum`). Vérifier en tête de fichier que `torch` est importé (il l'est).
+Add to `src/mjlab_microduck/tasks/mdp.py` (near the other curricula, e.g. after `com_range_curriculum`). Check at the top of the file that `torch` is imported (it is).
 
 ```python
 def slope_move_masks(distance: "torch.Tensor", size_x: float):
-    """Masques de promotion/rétrogradation du curriculum de pente.
+    """Promotion/demotion masks for the slope curriculum.
 
-    move_up   : a parcouru plus de la moitié de la tuile → il a dévalé la rampe,
-                on la rend plus raide.
-    move_down : a à peine avancé (< 20% de la tuile) → chute/blocage précoce,
-                on adoucit la rampe.
+    move_up   : travelled more than half the tile → it rode the ramp down, so we
+                make it steeper.
+    move_down : barely moved (< 20% of the tile) → early fall/stall, so we
+                flatten the ramp.
     """
     move_up = distance > size_x * 0.5
     move_down = (distance < size_x * 0.2) & (~move_up)
@@ -321,9 +321,9 @@ def slope_move_masks(distance: "torch.Tensor", size_x: float):
 
 
 def terrain_levels_slope(env, env_ids):
-    """Curriculum de raideur pour roller_slope (pas de vitesse commandée).
+    """Steepness curriculum for roller_slope (no commanded velocity).
 
-    Progression basée sur la distance en x parcourue depuis l'origine de spawn.
+    Progression based on the x distance travelled from the spawn origin.
     """
     asset = env.scene["robot"]
     terrain = env.scene.terrain
@@ -339,7 +339,7 @@ def terrain_levels_slope(env, env_ids):
     return torch.mean(terrain.terrain_levels.float())
 ```
 
-- [ ] **Step 4: Lancer le test — il doit passer**
+- [ ] **Step 4: Run the test — it must pass**
 
 Run: `uv run pytest tests/test_slope_curriculum.py -v`
 Expected: PASS (3 tests)
@@ -348,12 +348,12 @@ Expected: PASS (3 tests)
 
 ```bash
 git add src/mjlab_microduck/tasks/mdp.py tests/test_slope_curriculum.py
-git commit -m "roller-slope: curriculum de raideur terrain_levels_slope (+ helper pur teste)"
+git commit -m "roller-slope: terrain_levels_slope steepness curriculum (+ tested pure helper)"
 ```
 
 ---
 
-## Task 4 : env cfg `roller_slope` + enregistrement
+## Task 4: `roller_slope` env cfg + registration
 
 **Files:**
 - Create: `src/mjlab_microduck/tasks/microduck_roller_slope_env_cfg.py`
@@ -361,12 +361,12 @@ git commit -m "roller-slope: curriculum de raideur terrain_levels_slope (+ helpe
 - Test: `tests/test_roller_slope_cfg.py`
 
 **Interfaces:**
-- Consumes: `make_microduck_velocity_rollers_env_cfg` (base physique/DR/obs), `FlatRampTerrainCfg` (Task 2), `terrain_levels_slope` (Task 3), fonctions mdp existantes : `body_upright_gaussian`, `is_alive`, `pose_target_match`, `pose_l1_penalty`, `feet_flat_penalty`, `neck_action_rate_l2`, `joint_torques_l2`, `robot_state_is_nan`, `reset_action_history`, `zero_command_padding`.
-- Produces: `make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg` et `MicroduckRollerSlopeRlCfg` (`RslRlOnPolicyRunnerCfg`, `experiment_name="roller_slope"`).
+- Consumes: `make_microduck_velocity_rollers_env_cfg` (the physics/DR/obs base), `FlatRampTerrainCfg` (Task 2), `terrain_levels_slope` (Task 3), and the existing mdp functions: `body_upright_gaussian`, `is_alive`, `pose_target_match`, `pose_l1_penalty`, `feet_flat_penalty`, `neck_action_rate_l2`, `joint_torques_l2`, `robot_state_is_nan`, `reset_action_history`, `zero_command_padding`.
+- Produces: `make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg` and `MicroduckRollerSlopeRlCfg` (`RslRlOnPolicyRunnerCfg`, `experiment_name="roller_slope"`).
 
-> Réutiliser les blocs DR/obs/reset du roller env : on **part** de `make_microduck_velocity_rollers_env_cfg()` et on ne modifie QUE terrain, commande, récompenses, terminaisons, curriculum. Ne pas réécrire la DR.
+> Reuse the roller env's DR/obs/reset blocks: we **start from** `make_microduck_velocity_rollers_env_cfg()` and modify ONLY the terrain, command, rewards, terminations and curriculum. Do not rewrite the DR.
 
-- [ ] **Step 1: Écrire le test qui échoue**
+- [ ] **Step 1: Write the failing test**
 
 ```python
 # tests/test_roller_slope_cfg.py
@@ -394,7 +394,7 @@ def test_command_is_neutralised():
 def test_entry_velocity_set_on_reset_base():
     cfg = make_microduck_roller_slope_env_cfg()
     vr = cfg.events["reset_base"].params["velocity_range"]
-    assert vr["x"][0] > 0.0  # impulsion vers l'avant
+    assert vr["x"][0] > 0.0  # forward impulse
 
 
 def test_has_upright_and_pose_rewards():
@@ -403,22 +403,22 @@ def test_has_upright_and_pose_rewards():
         assert name in cfg.rewards
 ```
 
-- [ ] **Step 2: Lancer le test — il doit échouer**
+- [ ] **Step 2: Run the test — it must fail**
 
 Run: `uv run pytest tests/test_roller_slope_cfg.py -v`
-Expected: FAIL — `ModuleNotFoundError` (module env cfg absent)
+Expected: FAIL — `ModuleNotFoundError` (the env cfg module is missing)
 
-- [ ] **Step 3: Implémentation**
+- [ ] **Step 3: Implementation**
 
 ```python
 # src/mjlab_microduck/tasks/microduck_roller_slope_env_cfg.py
-"""Microduck roller slope — descente passive équilibrée.
+"""Microduck roller slope — balanced passive descent.
 
-Le robot spawne sur du plat (impulsion vers l'avant), roule sur une rampe
-descendante et se laisse glisser en restant debout. Aucun pilotage : la
-commande twist est neutralisée (rel_standing_envs=1.0). Terrain custom
-plat+rampe (FlatRampTerrainCfg), curriculum de raideur (terrain_levels_slope).
-Obs 61D unifié → interchangeable au runtime (--new-cmd-obs).
+The robot spawns on the flat (with a forward impulse), rolls onto a downhill
+ramp and lets itself glide while staying upright. No steering: the twist
+command is neutralized (rel_standing_envs=1.0). Custom flat+ramp terrain
+(FlatRampTerrainCfg), steepness curriculum (terrain_levels_slope).
+Unified 61D obs → hot-swappable at runtime (--new-cmd-obs).
 """
 
 from mjlab.envs import ManagerBasedRlEnvCfg
@@ -437,27 +437,27 @@ from mjlab_microduck.tasks.microduck_velocity_rollers_env_cfg import (
 )
 from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg
 
-ENTRY_VELOCITY_X = (0.2, 0.5)  # impulsion vers l'avant au reset (m/s)
+ENTRY_VELOCITY_X = (0.2, 0.5)  # forward impulse at reset (m/s)
 
 
 def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
     cfg = make_microduck_velocity_rollers_env_cfg(play=play)
 
-    # === TERRAIN : plat + rampe, curriculum de raideur ===
+    # === TERRAIN: flat + ramp, steepness curriculum ===
     cfg.scene.terrain = TerrainEntityCfg(
         terrain_type="generator",
         terrain_generator=TerrainGeneratorCfg(
             size=(8.0, 4.0),
             curriculum=True,
-            num_rows=10,          # 10 niveaux de raideur
+            num_rows=10,          # 10 steepness levels
             num_cols=1,
             difficulty_range=(0.0, 1.0),
             sub_terrains={"flat_ramp": FlatRampTerrainCfg(flat_length=2.0, ramp_length=5.0)},
         ),
-        max_init_terrain_level=0,  # démarrer sur la rampe la plus douce
+        max_init_terrain_level=0,  # start on the gentlest ramp
     )
 
-    # === COMMANDE neutralisée (équilibre pur) ===
+    # === Neutralized COMMAND (pure balance) ===
     command = cfg.commands["twist"]
     command.rel_standing_envs = 1.0
     command.rel_heading_envs = 0.0
@@ -466,10 +466,10 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
     if getattr(command.ranges, "ang_vel_z", None) is not None:
         command.ranges.ang_vel_z = (0.0, 0.0)
 
-    # === RESET : impulsion vers l'avant sur le plat ===
+    # === RESET: forward impulse on the flat ===
     cfg.events["reset_base"].params["velocity_range"] = {"x": ENTRY_VELOCITY_X}
 
-    # === RÉCOMPENSES : équilibre + posture debout nominale ===
+    # === REWARDS: balance + nominal standing posture ===
     keep = {"action_rate_l2"}
     for name in list(cfg.rewards.keys()):
         if name not in keep:
@@ -481,7 +481,7 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
         params={"asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)), "std": 0.2},
     )
     cfg.rewards["alive"] = RewardTermCfg(func=microduck_mdp.is_alive, weight=1.0)
-    # posture debout nominale (cible fixe = default_joint_pos, aucun override)
+    # nominal standing posture (fixed target = default_joint_pos, no override)
     cfg.rewards["standing_pose"] = RewardTermCfg(
         func=microduck_mdp.pose_target_match, weight=3.0, params={"std": 0.4},
     )
@@ -504,7 +504,7 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
     )
     cfg.rewards["action_rate_l2"].weight = -1.0
 
-    # === TERMINATIONS : chute + bas atteint ===
+    # === TERMINATIONS: fall + bottom reached ===
     cfg.terminations["fell_over"] = TerminationTermCfg(
         func=base_mdp.bad_orientation,
         params={"limit_angle": 1.0, "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",))},
@@ -519,7 +519,7 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
         func=microduck_mdp.reset_action_history, mode="reset",
     )
 
-    # === CURRICULUM : raideur de la rampe ===
+    # === CURRICULUM: ramp steepness ===
     for name in list(cfg.curriculum.keys()):
         del cfg.curriculum[name]
     cfg.curriculum["terrain_levels"] = CurriculumTermCfg(func=microduck_mdp.terrain_levels_slope)
@@ -550,55 +550,55 @@ MicroduckRollerSlopeRlCfg = RslRlOnPolicyRunnerCfg(
 )
 ```
 
-Puis enregistrer dans `src/mjlab_microduck/tasks/__init__.py`, en suivant EXACTEMENT le pattern d'enregistrement de `roller_crouch` déjà présent (import de `make_...` + `Microduck...RlCfg`, puis `register_mjlab_task(...)` avec un id du style `"Microduck-Roller-Slope"`). Copier le bloc `roller_crouch` et remplacer `crouch`→`slope`.
+Then register it in `src/mjlab_microduck/tasks/__init__.py`, following EXACTLY the registration pattern of the `roller_crouch` block already present (import `make_...` + `Microduck...RlCfg`, then `register_mjlab_task(...)` with an id in the style of `"Microduck-Roller-Slope"`). Copy the `roller_crouch` block and replace `crouch`→`slope`.
 
-- [ ] **Step 4: Lancer les tests — ils doivent passer**
+- [ ] **Step 4: Run the tests — they must pass**
 
 Run: `uv run pytest tests/test_roller_slope_cfg.py -v`
 Expected: PASS (4 tests)
 
-- [ ] **Step 5: Vérifier l'enregistrement de la tâche + build complet**
+- [ ] **Step 5: Verify the task registration + a full build**
 
 Run:
 ```bash
 uv run python -c "import gymnasium as gym; import mjlab_microduck.tasks; print([e for e in gym.registry if 'Slope' in e])"
 ```
-Expected: la liste contient l'id `Microduck-Roller-Slope` (ou variante enregistrée).
+Expected: the list contains the id `Microduck-Roller-Slope` (or whichever variant was registered).
 
-- [ ] **Step 6: Vérification visuelle du terrain + descente (checkpoint humain — clôt Task 2 Step 6)**
+- [ ] **Step 6: Visual verification of the terrain + descent (human checkpoint — closes Task 2 Step 6)**
 
-Lancer un court entraînement puis le play (ou `scripts/play_latest.py` selon l'usage du dépôt) et observer :
-1. Plat + rampe assemblés sans marche/trou ; la rampe **descend** devant le robot.
-2. Le robot spawne sur le plat, part vers l'avant, atteint la rampe.
-Si la géométrie est fausse, corriger `slope_terrain.py` (voir Task 2 Step 6) et re-commit.
+Run a short training, then play (or `scripts/play_latest.py`, depending on the repo's usage) and observe:
+1. Flat + ramp assembled with no step/gap; the ramp **descends** in front of the robot.
+2. The robot spawns on the flat, moves forward, and reaches the ramp.
+If the geometry is wrong, fix `slope_terrain.py` (see Task 2 Step 6) and re-commit.
 
 - [ ] **Step 7: Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/microduck_roller_slope_env_cfg.py src/mjlab_microduck/tasks/__init__.py tests/test_roller_slope_cfg.py
-git commit -m "roller-slope: env descente passive (terrain plat+rampe, cmd nulle, rewards equilibre) + enregistrement"
+git commit -m "roller-slope: passive descent env (flat+ramp terrain, zero cmd, balance rewards) + registration"
 ```
 
 ---
 
-## Task 5 : déploiement — flag `--slope` + touche `Y`
+## Task 5: deployment — the `--slope` flag + the `Y` key
 
 **Files:**
 - Modify: `scripts/infer_policy.py`
 
 **Interfaces:**
-- Consumes: le `.onnx` exporté de la politique `roller_slope`.
-- Produces: argument CLI `--slope <path>` ; attribut `self.slope_session` + flag `self.slope_mode` ; méthode `toggle_slope_mode()` ; touche `GLFW_KEY_Y = 89` câblée.
+- Consumes: the exported `.onnx` of the `roller_slope` policy.
+- Produces: the `--slope <path>` CLI argument; a `self.slope_session` attribute + a `self.slope_mode` flag; a `toggle_slope_mode()` method; the `GLFW_KEY_Y = 89` key wired up.
 
-> La politique pente tourne avec commande twist nulle (comme le mode standing). En slope mode, la bascule automatique walking/standing doit être neutralisée.
+> The slope policy runs with a zero twist command (like standing mode). In slope mode, the automatic walking/standing switch must be disabled.
 
-- [ ] **Step 1: Ajouter l'argument CLI et charger la session**
+- [ ] **Step 1: Add the CLI argument and load the session**
 
-Dans `main()` (près des autres `add_argument`, ~ligne 471) :
+In `main()` (near the other `add_argument` calls, ~line 471):
 ```python
     parser.add_argument("--slope", type=str, default=None, help="Path to slope policy ONNX file (press Y to toggle)")
 ```
-Passer `slope_onnx_path=args.slope` au constructeur du contrôleur (ajouter le paramètre `slope_onnx_path=None` à `__init__`, ~ligne 51-57, et charger comme les autres) :
+Pass `slope_onnx_path=args.slope` to the controller's constructor (add the `slope_onnx_path=None` parameter to `__init__`, ~lines 51-57, and load it like the others):
 ```python
         self.slope_session = None
         self.slope_mode = False
@@ -607,12 +607,12 @@ Passer `slope_onnx_path=args.slope` au constructeur du contrôleur (ajouter le p
             self.slope_session = ort.InferenceSession(slope_onnx_path)
 ```
 
-- [ ] **Step 2: Ajouter `toggle_slope_mode` et neutraliser la bascule auto**
+- [ ] **Step 2: Add `toggle_slope_mode` and disable the automatic switch**
 
-Après `toggle_body_pose_mode` (~ligne 285) :
+After `toggle_body_pose_mode` (~line 285):
 ```python
     def toggle_slope_mode(self):
-        """Bascule vers/depuis la politique pente (descente passive)."""
+        """Toggle to/from the slope policy (passive descent)."""
         if self.slope_session is None:
             print("Slope unavailable: no --slope policy loaded")
             return
@@ -620,52 +620,52 @@ Après `toggle_body_pose_mode` (~ligne 285) :
         if self.slope_mode:
             self.ort_session = self.slope_session
             self.current_policy = "slope"
-            self.set_vel_cmd(0.0, 0.0, 0.0)  # descente passive : commande nulle
-            print("Slope mode: ON (descente passive)")
+            self.set_vel_cmd(0.0, 0.0, 0.0)  # passive descent: zero command
+            print("Slope mode: ON (passive descent)")
         else:
             self.ort_session = self.walking_session or self.standing_session
             self.current_policy = "walking" if self.walking_session else "standing"
             print("Slope mode: OFF")
 ```
-Dans `_update_policy_session` (~ligne 250), ajouter le garde en tête (après le garde `ground_pick_mode`) :
+In `_update_policy_session` (~line 250), add the guard at the top (after the `ground_pick_mode` guard):
 ```python
         if self.slope_mode:
-            return  # Ne pas basculer pendant le mode pente
+            return  # Do not switch while in slope mode
 ```
 
-- [ ] **Step 3: Câbler la touche `Y`**
+- [ ] **Step 3: Wire up the `Y` key**
 
-Ajouter le code de touche près des autres (~ligne 680) :
+Add the key code near the others (~line 680):
 ```python
     GLFW_KEY_Y = 89
 ```
-Dans `key_callback`, ajouter une branche (ex. après la branche `GLFW_KEY_B`) :
+In `key_callback`, add a branch (e.g. after the `GLFW_KEY_B` branch):
 ```python
             elif key == GLFW_KEY_Y:
                 policy.toggle_slope_mode()
 ```
-Ajouter la ligne d'aide clavier (près des `print` ~ligne 821) :
+Add the keyboard help line (near the `print` calls, ~line 821):
 ```python
-    print("  Y:                toggle slope mode (requires --slope, descente passive)")
+    print("  Y:                toggle slope mode (requires --slope, passive descent)")
 ```
 
-- [ ] **Step 4: Vérifier que le script se charge sans erreur**
+- [ ] **Step 4: Check that the script loads without error**
 
 Run: `uv run python scripts/infer_policy.py --help`
-Expected: l'aide s'affiche et liste `--slope`.
+Expected: the help is displayed and lists `--slope`.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add scripts/infer_policy.py
-git commit -m "roller-slope: deploiement --slope + touche Y (bascule mode pente)"
+git commit -m "roller-slope: --slope deployment + Y key (slope mode toggle)"
 ```
 
 ---
 
-## Self-Review (fait par l'auteur du plan)
+## Self-Review (by the plan's author)
 
-- **Couverture spec** : tâche dédiée (Task 4) ✓ ; terrain plat+rampe custom (Task 2) ✓ ; départ plat + impulsion (Task 4 reset velocity_range) ✓ ; commande nulle (Task 4) ✓ ; récompenses équilibre + pose debout + anti-écrasement (Task 4) ✓ ; terminaisons chute/bas/nan (Task 4) ✓ ; curriculum 0→20° (Task 1 angle + Task 3 promotion) ✓ ; obs 61D interchangeable (hérité du roller env, non modifié) ✓ ; bouton Y (Task 5) ✓.
-- **Placeholders** : aucun « TBD/TODO » ; les deux checkpoints humains (géométrie viewer) sont des vérifications explicites, pas des trous d'implémentation.
-- **Cohérence des types** : `ramp_angle_by_difficulty` (Task 1) réutilisé par `FlatRampTerrainCfg` (Task 2) ; `slope_move_masks` (Task 3) consommé par `terrain_levels_slope` (Task 3) ; noms de récompenses testés en Task 4 (`upright`, `alive`, `standing_pose`, `feet_flat`) alignés sur l'implémentation.
-- **Risques signalés** : géométrie de la rampe (`ramp_cz`, signe du quaternion) à confirmer au viewer ; noms exacts d'API mjlab (`terrain.terrain_levels`, `TerrainEntityCfg`, id d'enregistrement) à valider contre le pattern `roller_crouch` existant lors de l'implémentation.
+- **Spec coverage**: dedicated task (Task 4) ✓; custom flat+ramp terrain (Task 2) ✓; flat start + impulse (Task 4 reset velocity_range) ✓; zero command (Task 4) ✓; balance + standing pose + anti-flattening rewards (Task 4) ✓; fall/bottom/nan terminations (Task 4) ✓; 0→20° curriculum (Task 1 angle + Task 3 promotion) ✓; hot-swappable 61D obs (inherited from the roller env, unmodified) ✓; the Y button (Task 5) ✓.
+- **Placeholders**: no "TBD/TODO"; the two human checkpoints (viewer geometry) are explicit verifications, not implementation gaps.
+- **Type consistency**: `ramp_angle_by_difficulty` (Task 1) reused by `FlatRampTerrainCfg` (Task 2); `slope_move_masks` (Task 3) consumed by `terrain_levels_slope` (Task 3); the reward names tested in Task 4 (`upright`, `alive`, `standing_pose`, `feet_flat`) aligned with the implementation.
+- **Flagged risks**: the ramp geometry (`ramp_cz`, the quaternion's sign) to be confirmed in the viewer; the exact mjlab API names (`terrain.terrain_levels`, `TerrainEntityCfg`, the registration id) to be validated against the existing `roller_crouch` pattern during implementation.

--- a/docs/superpowers/plans/2026-07-24-ground-pick-pose-following.md
+++ b/docs/superpowers/plans/2026-07-24-ground-pick-pose-following.md
@@ -2,38 +2,38 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Réécrire la tâche `Mjlab-GroundPick-Flat-MicroDuck` pour piloter le geste par un suivi de pose articulaire interpolé par la phase (STAND→DOWN→STAND) au lieu de l'objectif espace-tâche actuel (proximité bouche-sol + retour de pose).
+**Goal:** Rewrite the `Mjlab-GroundPick-Flat-MicroDuck` task to drive the gesture through phase-interpolated joint-pose following (STAND→DOWN→STAND) instead of the current task-space objective (mouth-to-ground proximity + pose return).
 
-**Architecture:** On ajoute trois fonctions mdp pures/quasi-pures (`phase_pose_blend`, `phase_pose_track`, `phase_pose_track_l1`) qui calculent une cible articulaire interpolée entre HOME (STAND) et un dict `DOWN_POSE` selon un profil de phase à 4 segments, résolue **par nom**. On ajoute un flag `randomize_phase` à la commande de phase existante. On réécrit ensuite le bloc rewards de `microduck_ground_pick_env_cfg.py` en gardant tout le reste (DR, obs 61D, curricula, RlCfg).
+**Architecture:** We add three pure/near-pure mdp functions (`phase_pose_blend`, `phase_pose_track`, `phase_pose_track_l1`) that compute a joint target interpolated between HOME (STAND) and a `DOWN_POSE` dict along a 4-segment phase profile, resolved **by name**. We add a `randomize_phase` flag to the existing phase command. We then rewrite the rewards block of `microduck_ground_pick_env_cfg.py`, keeping everything else (DR, 61D obs, curricula, RlCfg).
 
 **Tech Stack:** Python, PyTorch, mjlab 1.3.0, MuJoCo, uv, pytest (via `uv run --with pytest`).
 
 ## Global Constraints
 
-- Résolution des joints **PAR NOM** (`asset.find_joints([name])[0][0]`), jamais par index en dur.
-- Obs 61D unifié **inchangé** (padding head/body zéro) → policy interchangeable dans le slot runtime.
-- Task id inchangé : `Mjlab-GroundPick-Flat-MicroDuck` (+ variante `-Rough-`).
-- Période de phase = **4.0 s** (défaut du slot `--ground-pick-period`).
-- Profil de phase (fractions) : `DESCENT_END=0.15`, `HOLD_END=0.50`, `RISE_END=0.65`.
-- `randomize_phase=False` pour la tâche ground_pick (parité déploiement bouton A à φ=0) ; défaut `True` de la cfg pour ne pas casser sit/stand.
-- STAND = HOME (`asset.data.default_joint_pos`, ne pas redéfinir). DOWN = dict `DOWN_POSE` par nom.
-- 14 joints actifs (mouth exclu). Robot `MICRODUCK_GROUND_PICK_ROBOT_CFG` (pas de roues → indices 0-4 jambe G, 5-8 cou/tête, 9-13 jambe D, mais on résout quand même par nom).
-- Fichiers mdp : imports déjà présents (`torch`, `Optional`, `Entity`, `SceneEntityCfg`, `ManagerBasedRlEnv`, `_DEFAULT_ASSET_CFG`).
+- Joints resolved **BY NAME** (`asset.find_joints([name])[0][0]`), never by hardcoded index.
+- The unified 61D obs is **unchanged** (zero head/body padding) → the policy stays hot-swappable in the runtime slot.
+- Task id unchanged: `Mjlab-GroundPick-Flat-MicroDuck` (+ the `-Rough-` variant).
+- Phase period = **4.0 s** (the `--ground-pick-period` slot default).
+- Phase profile (fractions): `DESCENT_END=0.15`, `HOLD_END=0.50`, `RISE_END=0.65`.
+- `randomize_phase=False` for the ground_pick task (deployment parity with button A at φ=0); the cfg default stays `True` so as not to break sit/stand.
+- STAND = HOME (`asset.data.default_joint_pos`, do not redefine). DOWN = the `DOWN_POSE` by-name dict.
+- 14 active joints (mouth excluded). Robot `MICRODUCK_GROUND_PICK_ROBOT_CFG` (no wheels → indices 0-4 left leg, 5-8 neck/head, 9-13 right leg, but we still resolve by name).
+- mdp file: the imports are already present (`torch`, `Optional`, `Entity`, `SceneEntityCfg`, `ManagerBasedRlEnv`, `_DEFAULT_ASSET_CFG`).
 
 ---
 
-### Task 1: Fonction `phase_pose_blend` (blend 4 segments, pure)
+### Task 1: `phase_pose_blend` function (4-segment blend, pure)
 
 **Files:**
-- Modify: `src/mjlab_microduck/tasks/mdp.py` (ajout d'une fonction ; l'insérer juste avant `phase_pose_match` ~ligne 2041)
+- Modify: `src/mjlab_microduck/tasks/mdp.py` (add one function; insert it just before `phase_pose_match`, ~line 2041)
 - Test: `tests/test_ground_pick_pose.py` (create)
 
 **Interfaces:**
-- Produces: `phase_pose_blend(phase: torch.Tensor, descent_end: float, hold_end: float, rise_end: float) -> torch.Tensor` — renvoie un blend ∈ [0,1] de même shape que `phase` (0 = STAND, 1 = DOWN).
+- Produces: `phase_pose_blend(phase: torch.Tensor, descent_end: float, hold_end: float, rise_end: float) -> torch.Tensor` — returns a blend ∈ [0,1] with the same shape as `phase` (0 = STAND, 1 = DOWN).
 
 - [ ] **Step 1: Write the failing test**
 
-Créer `tests/test_ground_pick_pose.py` :
+Create `tests/test_ground_pick_pose.py`:
 
 ```python
 import torch
@@ -62,7 +62,7 @@ Expected: FAIL — `ImportError: cannot import name 'phase_pose_blend'`
 
 - [ ] **Step 3: Write minimal implementation**
 
-Dans `src/mjlab_microduck/tasks/mdp.py`, juste avant `def phase_pose_match(` (~ligne 2041) :
+In `src/mjlab_microduck/tasks/mdp.py`, just before `def phase_pose_match(` (~line 2041):
 
 ```python
 def phase_pose_blend(
@@ -71,12 +71,12 @@ def phase_pose_blend(
     hold_end: float,
     rise_end: float,
 ) -> torch.Tensor:
-    """Blend 0..1 le long de la phase [0,1) — 0 = pose STAND, 1 = pose DOWN.
+    """Blend 0..1 along the phase [0,1) — 0 = STAND pose, 1 = DOWN pose.
 
-    [0, descent_end)       : 0 -> 1  (se baisser)
-    [descent_end, hold_end): 1       (bas)
-    [hold_end, rise_end)   : 1 -> 0  (se lever)
-    [rise_end, 1.0)        : 0       (haut / repos)
+    [0, descent_end)       : 0 -> 1  (go down)
+    [descent_end, hold_end): 1       (low)
+    [hold_end, rise_end)   : 1 -> 0  (rise)
+    [rise_end, 1.0)        : 0       (high / rest)
     """
     b = torch.zeros_like(phase)
     descend = phase < descent_end
@@ -97,27 +97,27 @@ Expected: PASS (2 passed)
 
 ```bash
 git add tests/test_ground_pick_pose.py src/mjlab_microduck/tasks/mdp.py
-git commit -m "feat(mdp): phase_pose_blend — blend 4 segments STAND<->DOWN par la phase"
+git commit -m "feat(mdp): phase_pose_blend - 4-segment STAND<->DOWN blend along the phase"
 ```
 
 ---
 
-### Task 2: Rewards `phase_pose_track` / `phase_pose_track_l1` (+ helper `_phase_pose_error`)
+### Task 2: `phase_pose_track` / `phase_pose_track_l1` rewards (+ the `_phase_pose_error` helper)
 
 **Files:**
-- Modify: `src/mjlab_microduck/tasks/mdp.py` (ajout juste après `phase_pose_blend`)
+- Modify: `src/mjlab_microduck/tasks/mdp.py` (add just after `phase_pose_blend`)
 - Test: `tests/test_ground_pick_pose.py` (append)
 
 **Interfaces:**
 - Consumes: `phase_pose_blend` (Task 1).
 - Produces:
-  - `_phase_pose_error(env, asset_cfg, command_name, target_pose: dict, descent_end, hold_end, rise_end, source_pose: dict | None = None) -> (cur: Tensor, target: Tensor)` — tenseurs (B, k) résolus par nom.
-  - `phase_pose_track(env, command_name="twist", target_pose: dict | None = None, source_pose: dict | None = None, std=0.3, descent_end=0.15, hold_end=0.50, rise_end=0.65, asset_cfg=_DEFAULT_ASSET_CFG) -> Tensor` — gaussienne `exp(-((cur-target)/std)²).mean(-1)`.
+  - `_phase_pose_error(env, asset_cfg, command_name, target_pose: dict, descent_end, hold_end, rise_end, source_pose: dict | None = None) -> (cur: Tensor, target: Tensor)` — (B, k) tensors resolved by name.
+  - `phase_pose_track(env, command_name="twist", target_pose: dict | None = None, source_pose: dict | None = None, std=0.3, descent_end=0.15, hold_end=0.50, rise_end=0.65, asset_cfg=_DEFAULT_ASSET_CFG) -> Tensor` — gaussian `exp(-((cur-target)/std)²).mean(-1)`.
   - `phase_pose_track_l1(env, command_name="twist", target_pose=None, source_pose=None, descent_end=0.15, hold_end=0.50, rise_end=0.65, asset_cfg=_DEFAULT_ASSET_CFG) -> Tensor` — `-(cur-target).abs().mean(-1)`.
 
 - [ ] **Step 1: Write the failing test**
 
-Ajouter à `tests/test_ground_pick_pose.py` un faux env léger + les assertions :
+Add a lightweight fake env + the assertions to `tests/test_ground_pick_pose.py`:
 
 ```python
 from mjlab_microduck.tasks.mdp import phase_pose_track, phase_pose_track_l1
@@ -135,7 +135,7 @@ class _FakeAsset:
         self.data = _FakeData(joint_pos, default_pos)
 
     def find_joints(self, query):
-        # mjlab renvoie (ids, names) ; on ne gère que la requête [name]
+        # mjlab returns (ids, names); we only handle the [name] query form
         (name,) = query
         return ([self._ids[name]], [name])
 
@@ -160,7 +160,7 @@ class _FakeEnv:
 
 NAMES = ["j0", "j1"]
 DOWN = {"j0": 1.0, "j1": -1.0}
-# HOME (STAND source) = 0 pour les deux joints
+# HOME (STAND source) = 0 for both joints
 HOME = torch.tensor([[0.0, 0.0]])
 
 
@@ -169,7 +169,7 @@ def _env(cur, phase):
 
 
 def test_phase_pose_track_perfect_at_down():
-    # phase 0.30 -> blend 1 -> cible = DOWN ; cur == DOWN -> gaussienne 1, l1 0
+    # phase 0.30 -> blend 1 -> target = DOWN; cur == DOWN -> gaussian 1, l1 0
     from mjlab.managers.scene_entity_config import SceneEntityCfg
     cfg = SceneEntityCfg("robot")
     env = _env([1.0, -1.0], phase=0.30)
@@ -181,7 +181,7 @@ def test_phase_pose_track_perfect_at_down():
 
 
 def test_phase_pose_track_l1_at_home_when_down_target():
-    # phase 0.30 -> cible DOWN=[1,-1] ; cur=HOME=[0,0] -> l1 = -mean(|1|,|1|) = -1
+    # phase 0.30 -> target DOWN=[1,-1]; cur=HOME=[0,0] -> l1 = -mean(|1|,|1|) = -1
     from mjlab.managers.scene_entity_config import SceneEntityCfg
     cfg = SceneEntityCfg("robot")
     env = _env([0.0, 0.0], phase=0.30)
@@ -190,7 +190,7 @@ def test_phase_pose_track_l1_at_home_when_down_target():
 
 
 def test_phase_pose_track_returns_to_stand():
-    # phase 0.80 -> blend 0 -> cible = HOME ; cur=HOME -> gaussienne 1
+    # phase 0.80 -> blend 0 -> target = HOME; cur=HOME -> gaussian 1
     from mjlab.managers.scene_entity_config import SceneEntityCfg
     cfg = SceneEntityCfg("robot")
     env = _env([0.0, 0.0], phase=0.80)
@@ -205,7 +205,7 @@ Expected: FAIL — `ImportError: cannot import name 'phase_pose_track'`
 
 - [ ] **Step 3: Write minimal implementation**
 
-Dans `src/mjlab_microduck/tasks/mdp.py`, juste après `phase_pose_blend` :
+In `src/mjlab_microduck/tasks/mdp.py`, just after `phase_pose_blend`:
 
 ```python
 def _phase_pose_error(
@@ -218,10 +218,10 @@ def _phase_pose_error(
     rise_end: float,
     source_pose: Optional[dict] = None,
 ):
-    """(cur, target) pour la pose interpolée par la phase, résolue PAR NOM.
+    """(cur, target) for the phase-interpolated pose, resolved BY NAME.
 
-    Cible = source + blend(phase)·(target_pose - source), source = STAND
-    (`source_pose` si fourni, sinon le DEFAULT/HOME du modèle). blend ∈ [0,1]
+    Target = source + blend(phase)·(target_pose - source), source = STAND
+    (`source_pose` if given, otherwise the model's DEFAULT/HOME). blend ∈ [0,1]
     (0 = STAND, 1 = target_pose) via `phase_pose_blend`.
     """
     asset: Entity = env.scene[asset_cfg.name]
@@ -258,11 +258,11 @@ def phase_pose_track(
     rise_end: float = 0.65,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Gaussienne sur la pose articulaire vs cible interpolée STAND<->DOWN.
+    """Gaussian on joint pose vs the interpolated STAND<->DOWN target.
 
-    Reward directif : indique la config articulaire exacte à chaque phase. Se
-    relever (cible → STAND) est récompensé exactement comme se baisser (cible →
-    DOWN) — symétrique par construction. Résolution PAR NOM.
+    A directive reward: it prescribes the exact joint configuration at each
+    phase. Rising (target → STAND) is rewarded exactly like going down (target →
+    DOWN) — symmetric by construction. Resolution BY NAME.
     """
     cur, target = _phase_pose_error(
         env, asset_cfg, command_name, target_pose or {},
@@ -281,10 +281,10 @@ def phase_pose_track_l1(
     rise_end: float = 0.65,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Bootstrap L1 vers la cible interpolée (pénalité négative).
+    """L1 bootstrap toward the interpolated target (negative penalty).
 
-    Gradient constant partout — donne une direction vers la cible même quand la
-    gaussienne ci-dessus a saturé à ~0 loin de la cible.
+    Constant gradient everywhere — gives a direction toward the target even when
+    the Gaussian above has saturated to ~0 far from it.
     """
     cur, target = _phase_pose_error(
         env, asset_cfg, command_name, target_pose or {},
@@ -302,29 +302,29 @@ Expected: PASS (5 passed)
 
 ```bash
 git add tests/test_ground_pick_pose.py src/mjlab_microduck/tasks/mdp.py
-git commit -m "feat(mdp): phase_pose_track/_l1 — suivi de pose interpolée par la phase (par nom)"
+git commit -m "feat(mdp): phase_pose_track/_l1 - phase-interpolated pose following (by name)"
 ```
 
 ---
 
-### Task 3: Flag `randomize_phase` sur `GroundPickPhaseCommandCfg`
+### Task 3: `randomize_phase` flag on `GroundPickPhaseCommandCfg`
 
 **Files:**
-- Modify: `src/mjlab_microduck/tasks/mdp.py` (classe `GroundPickPhaseCommand` ~3611/3626, cfg ~3644)
+- Modify: `src/mjlab_microduck/tasks/mdp.py` (the `GroundPickPhaseCommand` class ~3611/3626, cfg ~3644)
 - Test: `tests/test_ground_pick_pose.py` (append)
 
 **Interfaces:**
-- Produces: `GroundPickPhaseCommandCfg.randomize_phase: bool = True` ; `GroundPickPhaseCommand.reset()` met la phase à 0 quand `randomize_phase=False`, sinon `torch.rand`.
+- Produces: `GroundPickPhaseCommandCfg.randomize_phase: bool = True`; `GroundPickPhaseCommand.reset()` sets the phase to 0 when `randomize_phase=False`, otherwise `torch.rand`.
 
 - [ ] **Step 1: Write the failing test**
 
-Ajouter à `tests/test_ground_pick_pose.py` :
+Add to `tests/test_ground_pick_pose.py`:
 
 ```python
 def test_ground_pick_cmd_cfg_has_randomize_phase_default_true():
     from mjlab_microduck.tasks.mdp import GroundPickPhaseCommandCfg
     from mjlab.tasks.velocity.mdp import UniformVelocityCommandCfg
-    # construit une cfg minimale en copiant une cfg velocity par défaut
+    # build a minimal cfg by copying a default velocity cfg
     base = UniformVelocityCommandCfg(
         asset_name="robot", resampling_time_range=(10.0, 10.0),
         ranges=UniformVelocityCommandCfg.Ranges(
@@ -336,7 +336,7 @@ def test_ground_pick_cmd_cfg_has_randomize_phase_default_true():
     assert cfg.period == 4.0
 ```
 
-Note : si la signature de `UniformVelocityCommandCfg.Ranges` diffère localement, adapter les champs — l'assertion clé est `cfg.randomize_phase is True`.
+Note: if the local `UniformVelocityCommandCfg.Ranges` signature differs, adapt the fields — the key assertion is `cfg.randomize_phase is True`.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -345,26 +345,26 @@ Expected: FAIL — `AttributeError: 'GroundPickPhaseCommandCfg' object has no at
 
 - [ ] **Step 3: Write minimal implementation**
 
-Dans `src/mjlab_microduck/tasks/mdp.py`, classe `GroundPickPhaseCommand`, modifier `__init__` et `reset` :
+In `src/mjlab_microduck/tasks/mdp.py`, class `GroundPickPhaseCommand`, modify `__init__` and `reset`:
 
-Remplacer (dans `__init__`, ~ligne 3614) :
+Replace (in `__init__`, ~line 3614):
 ```python
         self._period = float(getattr(cfg, "period", self.PERIOD))
 ```
-par :
+with:
 ```python
         self._period = float(getattr(cfg, "period", self.PERIOD))
         self._randomize_phase = bool(getattr(cfg, "randomize_phase", True))
 ```
 
-Remplacer la méthode `reset` (~ligne 3626) :
+Replace the `reset` method (~line 3626):
 ```python
     def reset(self, env_ids: torch.Tensor | None) -> dict:
         if env_ids is not None and len(env_ids) > 0:
             self._gp_phase[env_ids] = torch.rand(len(env_ids), device=self.device)
         return {}
 ```
-par :
+with:
 ```python
     def reset(self, env_ids: torch.Tensor | None) -> dict:
         if env_ids is not None and len(env_ids) > 0:
@@ -375,13 +375,13 @@ par :
         return {}
 ```
 
-Dans la cfg `GroundPickPhaseCommandCfg` (~ligne 3644), ajouter le champ après `period` :
+In the `GroundPickPhaseCommandCfg` cfg (~line 3644), add the field after `period`:
 ```python
 @_dataclass(kw_only=True)
 class GroundPickPhaseCommandCfg(UniformVelocityCommandCfg):
     class_type: type = GroundPickPhaseCommand
     period: float = 4.0  # cycle length in seconds; sitstand uses 8.0
-    randomize_phase: bool = True  # False = chaque épisode démarre à φ=0 (parité slot bouton A)
+    randomize_phase: bool = True  # False = every episode starts at φ=0 (button-A slot parity)
 
     def build(self, env: ManagerBasedRlEnv) -> "GroundPickPhaseCommand":
         return GroundPickPhaseCommand(self, env)
@@ -390,30 +390,30 @@ class GroundPickPhaseCommandCfg(UniformVelocityCommandCfg):
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `uv run --with pytest pytest tests/test_ground_pick_pose.py::test_ground_pick_cmd_cfg_has_randomize_phase_default_true -q`
-Expected: PASS. Si la construction de `UniformVelocityCommandCfg` échoue pour une raison d'API locale, ajuster les champs du `base` dans le test (l'implémentation, elle, est correcte).
+Expected: PASS. If constructing `UniformVelocityCommandCfg` fails for a local API reason, adjust the `base` fields in the test (the implementation itself is correct).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add tests/test_ground_pick_pose.py src/mjlab_microduck/tasks/mdp.py
-git commit -m "feat(mdp): flag randomize_phase sur GroundPickPhaseCommandCfg (défaut True)"
+git commit -m "feat(mdp): randomize_phase flag on GroundPickPhaseCommandCfg (default True)"
 ```
 
 ---
 
-### Task 4: Réécriture du bloc rewards + poses dans l'env cfg
+### Task 4: Rewriting the rewards block + poses in the env cfg
 
 **Files:**
 - Modify: `src/mjlab_microduck/tasks/microduck_ground_pick_env_cfg.py`
 - Test: `tests/test_ground_pick_cfg.py` (create)
 
 **Interfaces:**
-- Consumes: `phase_pose_track`, `phase_pose_track_l1` (Task 2) ; `randomize_phase` (Task 3).
-- Produces: `make_microduck_ground_pick_env_cfg(play=False, rough=False)` renvoie une cfg dont : commande `GroundPickPhaseCommand` avec `randomize_phase=False`, `period=4.0` ; rewards contiennent `phase_pose_track` (6.0) et `phase_pose_track_l1` (2.0), `mouth_ground_proximity` (1.0) ; ne contiennent plus `mouth_perpendicular_to_ground`, `ground_pick_return_pose_legs`, `ground_pick_return_pose_neck`.
+- Consumes: `phase_pose_track`, `phase_pose_track_l1` (Task 2); `randomize_phase` (Task 3).
+- Produces: `make_microduck_ground_pick_env_cfg(play=False, rough=False)` returns a cfg whose: command is a `GroundPickPhaseCommand` with `randomize_phase=False`, `period=4.0`; rewards contain `phase_pose_track` (6.0) and `phase_pose_track_l1` (2.0), `mouth_ground_proximity` (1.0); and no longer contain `mouth_perpendicular_to_ground`, `ground_pick_return_pose_legs`, `ground_pick_return_pose_neck`.
 
 - [ ] **Step 1: Write the failing test**
 
-Créer `tests/test_ground_pick_cfg.py` :
+Create `tests/test_ground_pick_cfg.py`:
 
 ```python
 from mjlab_microduck.tasks.microduck_ground_pick_env_cfg import (
@@ -429,10 +429,10 @@ def test_ground_pick_cfg_builds_with_pose_rewards():
     assert "phase_pose_track_l1" in rewards
     assert rewards["phase_pose_track"].weight == 6.0
     assert rewards["phase_pose_track_l1"].weight == 2.0
-    # filet bouche-sol conservé mais allégé
+    # mouth-to-ground safety net kept but lightened
     assert "mouth_ground_proximity" in rewards
     assert rewards["mouth_ground_proximity"].weight == 1.0
-    # anciennes mécaniques retirées
+    # old mechanisms removed
     assert "mouth_perpendicular_to_ground" not in rewards
     assert "ground_pick_return_pose_legs" not in rewards
     assert "ground_pick_return_pose_neck" not in rewards
@@ -453,16 +453,16 @@ Expected: FAIL — `assert 'phase_pose_track' in rewards` (KeyError/False).
 
 - [ ] **Step 3: Write minimal implementation**
 
-Dans `src/mjlab_microduck/tasks/microduck_ground_pick_env_cfg.py` :
+In `src/mjlab_microduck/tasks/microduck_ground_pick_env_cfg.py`:
 
-(a) Ajouter les constantes de poses/phase juste avant `def make_microduck_ground_pick_env_cfg(` :
+(a) Add the pose/phase constants just before `def make_microduck_ground_pick_env_cfg(`:
 
 ```python
-# ── Poses cibles du geste (rad, par NOM) ──────────────────────────────────────
-# STAND = HOME (default_joint_pos du modèle) — ne pas redéfinir ici : source du
-# blend. DOWN = pli avant profond (bouche vers le sol), valeurs initiales tirées
-# du keyframe FOLD de scene_walk.xml. ⚠️ REMPLAÇABLE par une lecture read_pose.py
-# du vrai robot posé bouche-au-sol quand disponible.
+# ── Target poses of the gesture (rad, BY NAME) ────────────────────────────────
+# STAND = HOME (the model's default_joint_pos) — do not redefine it here: it is
+# the blend source. DOWN = deep forward fold (mouth toward the ground), initial
+# values taken from the FOLD keyframe of scene_walk.xml. ⚠️ REPLACEABLE with a
+# read_pose.py reading of the real robot placed mouth-to-ground when available.
 DOWN_POSE = {
     "left_hip_yaw": 0.0, "left_hip_roll": 0.0, "left_hip_pitch": 1.57,
     "left_knee": 1.57, "left_ankle": 0.0,
@@ -471,9 +471,9 @@ DOWN_POSE = {
     "right_knee": -1.57, "right_ankle": 0.0,
 }
 
-# Timing du cycle (fractions de phase), période 4 s :
-#   descente [0, DESCENT_END) ~0.6s / bas [DESCENT_END, HOLD_END) ~1.4s /
-#   remontée [HOLD_END, RISE_END) ~0.6s / repos [RISE_END, 1) ~1.4s
+# Cycle timing (phase fractions), 4 s period:
+#   descent [0, DESCENT_END) ~0.6s / low [DESCENT_END, HOLD_END) ~1.4s /
+#   rise [HOLD_END, RISE_END) ~0.6s / rest [RISE_END, 1) ~1.4s
 GP_PERIOD    = 4.0
 DESCENT_END  = 0.15
 HOLD_END     = 0.50
@@ -481,19 +481,19 @@ RISE_END     = 0.65
 POSE_STD     = 0.3
 ```
 
-(b) Dans la boucle de suppression des rewards (~ligne 145-155), remplacer le contenu du geste. **Retirer** les deux blocs `mouth_perpendicular_to_ground` (~176-183) et les deux `ground_pick_return_pose_*` (~189-212), et **retuner** `mouth_ground_proximity` à `weight=1.0` (~163-172, changer `weight=2.0` → `weight=1.0`).
+(b) In the reward-removal loop (~lines 145-155), replace the gesture content. **Remove** the two `mouth_perpendicular_to_ground` blocks (~176-183) and the two `ground_pick_return_pose_*` blocks (~189-212), and **retune** `mouth_ground_proximity` to `weight=1.0` (~163-172, change `weight=2.0` → `weight=1.0`).
 
-Concrètement :
-- Éditer le bloc `cfg.rewards["mouth_ground_proximity"]` : `weight=2.0` → `weight=1.0`.
-- Supprimer entièrement le bloc `cfg.rewards["mouth_perpendicular_to_ground"] = RewardTermCfg(...)`.
-- Supprimer les blocs `_LEG_JOINTS = [...]` / `cfg.rewards["ground_pick_return_pose_legs"]` et `_NECK_JOINTS = [...]` / `cfg.rewards["ground_pick_return_pose_neck"]`.
-- Retirer `"pose"` de la liste de suppression de rewards si présent (inchangé) — mais **retirer** aussi la ligne de commentaire `# replaced by phase-conditioned ground_pick_return_pose` devenue obsolète (optionnel).
+Concretely:
+- Edit the `cfg.rewards["mouth_ground_proximity"]` block: `weight=2.0` → `weight=1.0`.
+- Delete the `cfg.rewards["mouth_perpendicular_to_ground"] = RewardTermCfg(...)` block entirely.
+- Delete the `_LEG_JOINTS = [...]` / `cfg.rewards["ground_pick_return_pose_legs"]` and `_NECK_JOINTS = [...]` / `cfg.rewards["ground_pick_return_pose_neck"]` blocks.
+- Remove `"pose"` from the reward-removal list if present (unchanged) — but **also remove** the now-obsolete `# replaced by phase-conditioned ground_pick_return_pose` comment line (optional).
 
-(c) Ajouter les deux nouveaux rewards de suivi de pose (à la place des blocs retirés, dans la section « main ground pick objectives ») :
+(c) Add the two new pose-following rewards (in place of the removed blocks, in the "main ground pick objectives" section):
 
 ```python
-    # Suivi de pose interpolée par la phase (STAND<->DOWN<->STAND). Directif et
-    # symétrique : le retour debout est récompensé exactement comme la descente.
+    # Phase-interpolated pose following (STAND<->DOWN<->STAND). Directive and
+    # symmetric: the return to standing is rewarded exactly like the descent.
     cfg.rewards["phase_pose_track"] = RewardTermCfg(
         func=microduck_mdp.phase_pose_track,
         weight=6.0,
@@ -521,15 +521,15 @@ Concrètement :
     )
 ```
 
-(d) Dans le bloc « Command » (~ligne 368), passer la période et désactiver la randomisation de phase :
+(d) In the "Command" block (~line 368), pass the period and disable phase randomization:
 
-Remplacer :
+Replace:
 ```python
     cfg.commands["twist"] = microduck_mdp.GroundPickPhaseCommandCfg(
         **{**vars(command), "class_type": microduck_mdp.GroundPickPhaseCommand}
     )
 ```
-par :
+with:
 ```python
     cfg.commands["twist"] = microduck_mdp.GroundPickPhaseCommandCfg(
         **{
@@ -546,30 +546,30 @@ par :
 Run: `uv run --with pytest pytest tests/test_ground_pick_cfg.py -q`
 Expected: PASS (2 passed).
 
-Puis vérifier que l'ensemble de la suite passe :
+Then check that the whole suite passes:
 Run: `uv run --with pytest pytest tests/ -q`
-Expected: PASS (tous).
+Expected: PASS (all).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add tests/test_ground_pick_cfg.py src/mjlab_microduck/tasks/microduck_ground_pick_env_cfg.py
-git commit -m "feat(ground_pick): suivi de pose interpolée par la phase (STAND->DOWN->STAND)"
+git commit -m "feat(ground_pick): phase-interpolated pose following (STAND->DOWN->STAND)"
 ```
 
 ---
 
-### Task 5: Vérification de bout en bout (construction runtime de la tâche)
+### Task 5: End-to-end verification (runtime construction of the task)
 
 **Files:**
 - Test: `tests/test_ground_pick_cfg.py` (append)
 
 **Interfaces:**
-- Consumes: tout ce qui précède.
+- Consumes: everything above.
 
 - [ ] **Step 1: Write the failing/uncovered test**
 
-Ajouter à `tests/test_ground_pick_cfg.py` :
+Add to `tests/test_ground_pick_cfg.py`:
 
 ```python
 def test_ground_pick_rough_variant_builds():
@@ -587,32 +587,32 @@ def test_ground_pick_play_variant_builds():
 Run: `uv run --with pytest pytest tests/test_ground_pick_cfg.py -q`
 Expected: PASS.
 
-- [ ] **Step 3: Vérifier l'enregistrement de la tâche (import du package)**
+- [ ] **Step 3: Verify the task registration (package import)**
 
 Run: `uv run python -c "import mjlab_microduck.tasks; print('ok')"`
-Expected: affiche les lignes `✓ ... registered` dont `GroundPick`, puis `ok`, sans exception.
+Expected: prints the `✓ ... registered` lines including `GroundPick`, then `ok`, without an exception.
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add tests/test_ground_pick_cfg.py
-git commit -m "test(ground_pick): variantes rough/play + import du package"
+git commit -m "test(ground_pick): rough/play variants + package import"
 ```
 
 ---
 
 ## Self-Review
 
-**1. Spec coverage :**
-- §1 objectif directif par pose → Tasks 1,2,4. ✓
-- §2 poses (STAND=HOME source, DOWN=FOLD par nom) → Task 4 (a), Task 2 (`source_pose=None`→default). ✓
-- §3 profil 4 segments période 4 s + `randomize_phase=False` → Task 1, Task 3, Task 4 (a,d). ✓
-- §4 fonctions mdp `phase_pose_blend/track/_l1` par nom → Tasks 1,2. ✓
-- §5 rewards (ajouts + retraits + retune mouth 1.0) → Task 4 (b,c), test Task 4. ✓
-- §6 déploiement (période 4, kp-ratio 1.0) → documenté dans spec ; period=4 vérifié en test Task 4. ✓
-- §7 tests (fonctions pures + construction env) → Tasks 1,2,4,5. ✓
-- §9 doublon `pose_target_match` hors scope → non modifié (conforme). ✓
+**1. Spec coverage:**
+- §1 directive pose objective → Tasks 1,2,4. ✓
+- §2 poses (STAND=HOME source, DOWN=FOLD by name) → Task 4 (a), Task 2 (`source_pose=None`→default). ✓
+- §3 4-segment profile, 4 s period + `randomize_phase=False` → Task 1, Task 3, Task 4 (a,d). ✓
+- §4 mdp functions `phase_pose_blend/track/_l1` by name → Tasks 1,2. ✓
+- §5 rewards (additions + removals + mouth retune to 1.0) → Task 4 (b,c), Task 4 test. ✓
+- §6 deployment (period 4, kp-ratio 1.0) → documented in the spec; period=4 verified in the Task 4 test. ✓
+- §7 tests (pure functions + env construction) → Tasks 1,2,4,5. ✓
+- §9 duplicate `pose_target_match` out of scope → not modified (compliant). ✓
 
-**2. Placeholder scan :** aucun TODO/TBD ; tout le code est fourni. ✓
+**2. Placeholder scan:** no TODO/TBD; all the code is provided. ✓
 
-**3. Type consistency :** `phase_pose_track(target_pose=..., std=..., asset_cfg=...)` et `phase_pose_track_l1(target_pose=..., asset_cfg=...)` identiques entre Task 2 (def), Task 4 (appel) et tests. `randomize_phase` cohérent entre Task 3 (def) et Task 4/tests (usage). `GroundPickPhaseCommand`/`GroundPickPhaseCommandCfg` noms inchangés. ✓
+**3. Type consistency:** `phase_pose_track(target_pose=..., std=..., asset_cfg=...)` and `phase_pose_track_l1(target_pose=..., asset_cfg=...)` are identical across Task 2 (def), Task 4 (call) and the tests. `randomize_phase` is consistent between Task 3 (def) and Task 4/the tests (usage). `GroundPickPhaseCommand`/`GroundPickPhaseCommandCfg` names unchanged. ✓

--- a/docs/superpowers/plans/2026-07-24-ground-pick-pose-following.md
+++ b/docs/superpowers/plans/2026-07-24-ground-pick-pose-following.md
@@ -1,4 +1,4 @@
-# Ground-pick par suivi de pose — Implementation Plan
+# Ground-pick by pose following — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 

--- a/docs/superpowers/plans/2026-07-24-shoot-pose-following.md
+++ b/docs/superpowers/plans/2026-07-24-shoot-pose-following.md
@@ -1,47 +1,47 @@
-# Tâche shoot par suivi de poses — Plan d'implémentation
+# Kick task by pose following — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ajouter une tâche RL `Mjlab-Shoot-Flat-MicroDuck` qui apprend un geste de shoot one-shot (jambe droite) par suivi d'une trajectoire de poses à 4 keyframes (STAND → PIED_ARRIÈRE → PIED_AVANT → STAND) interpolée par la phase.
+**Goal:** Add an RL task `Mjlab-Shoot-Flat-MicroDuck` that learns a one-shot kick gesture (right leg) by following a 4-keyframe pose trajectory (STAND → FOOT_BACK → FOOT_FORWARD → STAND) interpolated along the phase.
 
-**Architecture:** Même moule que la tâche `ground_pick` de cette branche. Une commande de phase (`GroundPickPhaseCommand`, `[cos,sin,0]`) pilote une cible articulaire interpolée entre 3 poses ; des rewards gaussien + L1 récompensent le suivi ; obs 61D unifiée pour déploiement dans un slot bouton du runtime. Aucune balle simulée.
+**Architecture:** The same mold as this branch's `ground_pick` task. A phase command (`GroundPickPhaseCommand`, `[cos,sin,0]`) drives a joint target interpolated between 3 poses; gaussian + L1 rewards pay for the tracking; a unified 61D obs for deployment in a runtime button slot. No simulated ball.
 
 **Tech Stack:** Python, PyTorch, mjlab 1.3.0, MuJoCo, uv, pytest.
 
 ## Global Constraints
 
-- Obs **61D unifiée** identique aux autres policies microduck (`[gyro(3), projected_gravity(3), joint_pos(14), joint_vel(14), last_action(14), command(13)]`, head+body command zero-paddés). Ne pas casser cette forme.
-- Résolution des joints **PAR NOM** (`asset.find_joints([name])`), jamais par index en dur.
-- **14 joints** actifs (mouth exclu). Robot `MICRODUCK_WALK_ROBOT_CFG`.
-- Ne pas modifier le runtime Rust ni la classe de commande de façon cassante : le flag `randomize_phase` ajouté DOIT défaut à `True` pour préserver `ground_pick`.
-- Jambe **droite** frappe, **gauche** en appui.
-- Tests : `uv run --with pytest pytest tests/ -q`.
-- Convention commits : messages en français, style `feat:`/`docs:`/`test:`.
+- **Unified 61D obs**, identical to the other microduck policies (`[gyro(3), projected_gravity(3), joint_pos(14), joint_vel(14), last_action(14), command(13)]`, head+body command zero-padded). Do not break this shape.
+- Joints resolved **BY NAME** (`asset.find_joints([name])`), never by hardcoded index.
+- **14 active joints** (mouth excluded). Robot `MICRODUCK_WALK_ROBOT_CFG`.
+- Do not modify the Rust runtime, and do not change the command class in a breaking way: the added `randomize_phase` flag MUST default to `True` to preserve `ground_pick`.
+- The **right** leg kicks, the **left** provides support.
+- Tests: `uv run --with pytest pytest tests/ -q`.
+- Commit convention: `feat:`/`docs:`/`test:` style messages.
 
 ---
 
 ## File Structure
 
-- `src/mjlab_microduck/tasks/mdp.py` — MODIFIER : ajouter `kick_pose_target` (pure), `_kick_pose_error`, `kick_pose_track`, `kick_pose_track_l1` ; ajouter le flag `randomize_phase` à `GroundPickPhaseCommand` / `GroundPickPhaseCommandCfg`.
-- `src/mjlab_microduck/tasks/microduck_shoot_env_cfg.py` — CRÉER : `make_microduck_shoot_env_cfg`, `MicroduckShootRlCfg`, `STAND_POSE`/`KICK_BACK_POSE`/`KICK_FWD_POSE`, timings.
-- `src/mjlab_microduck/tasks/__init__.py` — MODIFIER : import + `register_mjlab_task("Mjlab-Shoot-Flat-MicroDuck", …)`.
-- `tests/test_shoot.py` — CRÉER : tests des fonctions pures (`kick_pose_target`) + rewards via stub-env.
-- `tests/test_shoot_cfg.py` — CRÉER : test d'intégration (l'env se construit, bonne commande/rewards).
+- `src/mjlab_microduck/tasks/mdp.py` — MODIFY: add `kick_pose_target` (pure), `_kick_pose_error`, `kick_pose_track`, `kick_pose_track_l1`; add the `randomize_phase` flag to `GroundPickPhaseCommand` / `GroundPickPhaseCommandCfg`.
+- `src/mjlab_microduck/tasks/microduck_shoot_env_cfg.py` — CREATE: `make_microduck_shoot_env_cfg`, `MicroduckShootRlCfg`, `STAND_POSE`/`KICK_BACK_POSE`/`KICK_FWD_POSE`, timings.
+- `src/mjlab_microduck/tasks/__init__.py` — MODIFY: import + `register_mjlab_task("Mjlab-Shoot-Flat-MicroDuck", …)`.
+- `tests/test_shoot.py` — CREATE: tests of the pure functions (`kick_pose_target`) + the rewards via a stub env.
+- `tests/test_shoot_cfg.py` — CREATE: integration test (the env builds, with the right command/rewards).
 
 ---
 
-### Task 1: Flag `randomize_phase` sur la commande de phase
+### Task 1: `randomize_phase` flag on the phase command
 
 **Files:**
 - Modify: `src/mjlab_microduck/tasks/mdp.py:3618-3672` (`GroundPickPhaseCommand` + `GroundPickPhaseCommandCfg`)
 - Test: `tests/test_shoot.py`
 
 **Interfaces:**
-- Produces: `GroundPickPhaseCommandCfg(randomize_phase: bool = True, period: float = 4.0, …)` ; à l'exécution `reset()` met φ=0 quand `randomize_phase=False`, sinon `rand()`.
+- Produces: `GroundPickPhaseCommandCfg(randomize_phase: bool = True, period: float = 4.0, …)`; at runtime `reset()` sets φ=0 when `randomize_phase=False`, otherwise `rand()`.
 
-- [ ] **Step 1: Écrire le test qui échoue**
+- [ ] **Step 1: Write the failing test**
 
-Créer `tests/test_shoot.py` avec :
+Create `tests/test_shoot.py` with:
 
 ```python
 from mjlab_microduck.tasks.mdp import GroundPickPhaseCommandCfg
@@ -57,27 +57,27 @@ def test_phase_cmd_randomize_flag_settable_false():
     assert cfg.randomize_phase is False
 ```
 
-- [ ] **Step 2: Lancer le test, vérifier l'échec**
+- [ ] **Step 2: Run the test, verify it fails**
 
 Run: `uv run --with pytest pytest tests/test_shoot.py -q`
 Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'randomize_phase'`.
 
-- [ ] **Step 3: Ajouter le champ au cfg + threading dans la classe**
+- [ ] **Step 3: Add the field to the cfg + thread it through the class**
 
-Dans `GroundPickPhaseCommandCfg` (dataclass, ~ligne 3667) ajouter le champ :
+In `GroundPickPhaseCommandCfg` (dataclass, ~line 3667) add the field:
 
 ```python
 @_dataclass(kw_only=True)
 class GroundPickPhaseCommandCfg(UniformVelocityCommandCfg):
     class_type: type = GroundPickPhaseCommand
     period: float = 4.0  # cycle length in seconds; sitstand uses 8.0
-    randomize_phase: bool = True  # False -> chaque épisode démarre à φ=0 (STAND)
+    randomize_phase: bool = True  # False -> every episode starts at φ=0 (STAND)
 
     def build(self, env: ManagerBasedRlEnv) -> "GroundPickPhaseCommand":
         return GroundPickPhaseCommand(self, env)
 ```
 
-Dans `GroundPickPhaseCommand.__init__` (~ligne 3634) lire le flag :
+In `GroundPickPhaseCommand.__init__` (~line 3634) read the flag:
 
 ```python
     def __init__(self, cfg, env: ManagerBasedRlEnv):
@@ -87,7 +87,7 @@ Dans `GroundPickPhaseCommand.__init__` (~ligne 3634) lire le flag :
         self._randomize_phase = bool(getattr(cfg, "randomize_phase", True))
 ```
 
-Dans `GroundPickPhaseCommand.reset` (~ligne 3649) respecter le flag :
+In `GroundPickPhaseCommand.reset` (~line 3649) honor the flag:
 
 ```python
     def reset(self, env_ids: torch.Tensor | None) -> dict:
@@ -99,7 +99,7 @@ Dans `GroundPickPhaseCommand.reset` (~ligne 3649) respecter le flag :
         return {}
 ```
 
-- [ ] **Step 4: Lancer le test, vérifier le succès**
+- [ ] **Step 4: Run the test, verify it passes**
 
 Run: `uv run --with pytest pytest tests/test_shoot.py -q`
 Expected: PASS (2 tests).
@@ -108,23 +108,23 @@ Expected: PASS (2 tests).
 
 ```bash
 git add src/mjlab_microduck/tasks/mdp.py tests/test_shoot.py
-git commit -m "feat: flag randomize_phase sur GroundPickPhaseCommand (défaut True)"
+git commit -m "feat: randomize_phase flag on GroundPickPhaseCommand (default True)"
 ```
 
 ---
 
-### Task 2: Fonction pure `kick_pose_target`
+### Task 2: Pure function `kick_pose_target`
 
 **Files:**
-- Modify: `src/mjlab_microduck/tasks/mdp.py` (ajouter près de `phase_pose_blend`, ~ligne 2062)
+- Modify: `src/mjlab_microduck/tasks/mdp.py` (add near `phase_pose_blend`, ~line 2062)
 - Test: `tests/test_shoot.py`
 
 **Interfaces:**
-- Produces: `kick_pose_target(phase: Tensor(B,), stand, back, forward, windup_end: float, kick_end: float, return_end: float) -> Tensor(B,k)`. `stand/back/forward` sont des tenseurs `(k,)` ou `(1,k)`. Segments : [0,windup_end) STAND→BACK, [windup_end,kick_end) BACK→FORWARD, [kick_end,return_end) FORWARD→STAND, [return_end,1) STAND.
+- Produces: `kick_pose_target(phase: Tensor(B,), stand, back, forward, windup_end: float, kick_end: float, return_end: float) -> Tensor(B,k)`. `stand/back/forward` are `(k,)` or `(1,k)` tensors. Segments: [0,windup_end) STAND→BACK, [windup_end,kick_end) BACK→FORWARD, [kick_end,return_end) FORWARD→STAND, [return_end,1) STAND.
 
-- [ ] **Step 1: Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Ajouter à `tests/test_shoot.py` :
+Add to `tests/test_shoot.py`:
 
 ```python
 import torch
@@ -141,37 +141,37 @@ def _t(phase):
 
 
 def test_kick_target_keypoints():
-    assert torch.allclose(_t(0.0), STAND)          # début: STAND
-    assert torch.allclose(_t(W), BACK)             # fin armement: BACK
-    assert torch.allclose(_t(K), FWD)              # fin frappe: FORWARD
-    assert torch.allclose(_t(R), STAND)            # fin retour: STAND
-    assert torch.allclose(_t(0.9), STAND)          # repos: STAND
+    assert torch.allclose(_t(0.0), STAND)          # start: STAND
+    assert torch.allclose(_t(W), BACK)             # end of wind-up: BACK
+    assert torch.allclose(_t(K), FWD)              # end of strike: FORWARD
+    assert torch.allclose(_t(R), STAND)            # end of return: STAND
+    assert torch.allclose(_t(0.9), STAND)          # rest: STAND
 
 
 def test_kick_target_midsegments():
-    assert torch.allclose(_t(W / 2), 0.5 * BACK)                    # mi-armement
-    assert torch.allclose(_t((W + K) / 2), 0.5 * (BACK + FWD))      # mi-frappe
-    assert torch.allclose(_t((K + R) / 2), 0.5 * FWD)              # mi-retour
+    assert torch.allclose(_t(W / 2), 0.5 * BACK)                    # mid wind-up
+    assert torch.allclose(_t((W + K) / 2), 0.5 * (BACK + FWD))      # mid strike
+    assert torch.allclose(_t((K + R) / 2), 0.5 * FWD)              # mid return
 
 
 def test_kick_target_batch_shape():
     phase = torch.linspace(0.0, 1.0, 50)
     out = kick_pose_target(phase, STAND, BACK, FWD, W, K, R)
     assert out.shape == (50, 2)
-    # chaque composante reste dans l'enveloppe des 3 poses
+    # each component stays within the envelope of the 3 poses
     lo = torch.minimum(torch.minimum(STAND, BACK), FWD)
     hi = torch.maximum(torch.maximum(STAND, BACK), FWD)
     assert (out >= lo - 1e-6).all() and (out <= hi + 1e-6).all()
 ```
 
-- [ ] **Step 2: Lancer, vérifier l'échec**
+- [ ] **Step 2: Run, verify it fails**
 
 Run: `uv run --with pytest pytest tests/test_shoot.py -q`
 Expected: FAIL — `ImportError: cannot import name 'kick_pose_target'`.
 
-- [ ] **Step 3: Implémenter la fonction pure**
+- [ ] **Step 3: Implement the pure function**
 
-Ajouter dans `mdp.py` juste après `phase_pose_blend` (~ligne 2062) :
+Add to `mdp.py` just after `phase_pose_blend` (~line 2062):
 
 ```python
 def kick_pose_target(
@@ -183,14 +183,14 @@ def kick_pose_target(
     kick_end: float,
     return_end: float,
 ) -> torch.Tensor:
-    """Cible articulaire interpolée d'un geste de shoot à 4 keyframes.
+    """Interpolated joint target for a 4-keyframe kick gesture.
 
-    phase (B,) ∈ [0,1). stand/back/forward (k,) ou (1,k). Retour (B,k).
+    phase (B,) ∈ [0,1). stand/back/forward (k,) or (1,k). Returns (B,k).
 
-    [0, windup_end)        STAND   -> BACK     (armement)
-    [windup_end, kick_end) BACK    -> FORWARD  (frappe sèche)
-    [kick_end, return_end) FORWARD -> STAND    (retour)
-    [return_end, 1.0)      STAND             (repos)
+    [0, windup_end)        STAND   -> BACK     (wind-up)
+    [windup_end, kick_end) BACK    -> FORWARD  (sharp strike)
+    [kick_end, return_end) FORWARD -> STAND    (return)
+    [return_end, 1.0)      STAND             (rest)
     """
     p = phase.unsqueeze(-1)  # (B,1)
 
@@ -203,7 +203,7 @@ def kick_pose_target(
 
     seg1 = interp(stand, back, s1)
     seg2 = interp(back, forward, s2)
-    seg3 = interp(forward, stand, s3)  # à s3=1 (phase>=return_end) => STAND
+    seg3 = interp(forward, stand, s3)  # at s3=1 (phase>=return_end) => STAND
 
     out = seg1
     out = torch.where(p >= windup_end, seg2, out)
@@ -211,36 +211,36 @@ def kick_pose_target(
     return out
 ```
 
-- [ ] **Step 4: Lancer, vérifier le succès**
+- [ ] **Step 4: Run, verify it passes**
 
 Run: `uv run --with pytest pytest tests/test_shoot.py -q`
-Expected: PASS (tous les tests kick_target).
+Expected: PASS (all the kick_target tests).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/mdp.py tests/test_shoot.py
-git commit -m "feat: kick_pose_target — cible interpolée du geste de shoot (4 keyframes)"
+git commit -m "feat: kick_pose_target - interpolated target of the kick gesture (4 keyframes)"
 ```
 
 ---
 
-### Task 3: Rewards de suivi `kick_pose_track` / `kick_pose_track_l1`
+### Task 3: Tracking rewards `kick_pose_track` / `kick_pose_track_l1`
 
 **Files:**
-- Modify: `src/mjlab_microduck/tasks/mdp.py` (ajouter après `kick_pose_target`)
+- Modify: `src/mjlab_microduck/tasks/mdp.py` (add after `kick_pose_target`)
 - Test: `tests/test_shoot.py`
 
 **Interfaces:**
 - Consumes: `kick_pose_target` (Task 2).
 - Produces:
-  - `kick_pose_track(env, command_name="twist", stand_pose=None, back_pose=None, forward_pose=None, std=0.4, windup_end=0.35, kick_end=0.45, return_end=0.75, asset_cfg=_DEFAULT_ASSET_CFG) -> Tensor(B,)` — gaussienne `exp(-((q-cible)/std)²).mean`.
-  - `kick_pose_track_l1(env, …mêmes args sauf std) -> Tensor(B,)` — `-(|q-cible|).mean`.
+  - `kick_pose_track(env, command_name="twist", stand_pose=None, back_pose=None, forward_pose=None, std=0.4, windup_end=0.35, kick_end=0.45, return_end=0.75, asset_cfg=_DEFAULT_ASSET_CFG) -> Tensor(B,)` — gaussian `exp(-((q-target)/std)²).mean`.
+  - `kick_pose_track_l1(env, …same args without std) -> Tensor(B,)` — `-(|q-target|).mean`.
   - Helper `_kick_pose_error(env, asset_cfg, command_name, stand_pose, back_pose, forward_pose, windup_end, kick_end, return_end) -> (cur, target)`.
 
-- [ ] **Step 1: Écrire le test qui échoue (stub-env)**
+- [ ] **Step 1: Write the failing test (stub env)**
 
-Ajouter à `tests/test_shoot.py` :
+Add to `tests/test_shoot.py`:
 
 ```python
 from mjlab_microduck.tasks.mdp import kick_pose_track, kick_pose_track_l1
@@ -294,14 +294,14 @@ class _FakeEnv:
 
 
 def test_kick_track_perfect_at_stand_phase():
-    # phase=0 -> cible STAND=[0,0] ; joint_pos exactement STAND -> reward ~1
+    # phase=0 -> target STAND=[0,0]; joint_pos exactly STAND -> reward ~1
     env = _FakeEnv(torch.tensor([[0.0, 0.0]]), torch.tensor([0.0]))
     r = kick_pose_track(env, stand_pose=STAND_D, back_pose=BACK_D, forward_pose=FWD_D)
     assert torch.allclose(r, torch.tensor([1.0]), atol=1e-4)
 
 
 def test_kick_track_lower_when_off_target():
-    # phase=0.45 (kick_end) -> cible FORWARD=[-1,2] ; joint_pos=STAND -> reward < 0.5
+    # phase=0.45 (kick_end) -> target FORWARD=[-1,2]; joint_pos=STAND -> reward < 0.5
     env = _FakeEnv(torch.tensor([[0.0, 0.0]]), torch.tensor([0.45]))
     r = kick_pose_track(env, stand_pose=STAND_D, back_pose=BACK_D, forward_pose=FWD_D)
     assert (r < 0.5).all()
@@ -313,14 +313,14 @@ def test_kick_track_l1_zero_when_perfect():
     assert torch.allclose(r, torch.tensor([0.0]), atol=1e-6)
 ```
 
-- [ ] **Step 2: Lancer, vérifier l'échec**
+- [ ] **Step 2: Run, verify it fails**
 
 Run: `uv run --with pytest pytest tests/test_shoot.py -q`
 Expected: FAIL — `ImportError: cannot import name 'kick_pose_track'`.
 
-- [ ] **Step 3: Implémenter helper + rewards**
+- [ ] **Step 3: Implement the helper + rewards**
 
-Ajouter dans `mdp.py` après `kick_pose_target` :
+Add to `mdp.py` after `kick_pose_target`:
 
 ```python
 def _kick_pose_error(
@@ -334,10 +334,10 @@ def _kick_pose_error(
     kick_end: float,
     return_end: float,
 ):
-    """(cur, target) pour le geste de shoot, joints résolus PAR NOM.
+    """(cur, target) for the kick gesture, joints resolved BY NAME.
 
-    Les 3 poses partagent les mêmes clés (14 joints). L'ordre des noms est
-    donné par `stand_pose`.
+    The 3 poses share the same keys (14 joints). The name ordering comes from
+    `stand_pose`.
     """
     if not stand_pose:
         raise ValueError("_kick_pose_error requires a non-empty stand_pose dict")
@@ -371,10 +371,10 @@ def kick_pose_track(
     return_end: float = 0.75,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Gaussienne sur la pose articulaire vs cible interpolée du shoot.
+    """Gaussian on joint pose vs the interpolated kick target.
 
-    Reward directif et symétrique : chaque phase impose la config articulaire
-    exacte. Résolution PAR NOM.
+    A directive, symmetric reward: each phase prescribes the exact joint
+    configuration. Resolution BY NAME.
     """
     cur, target = _kick_pose_error(
         env, asset_cfg, command_name, stand_pose or {}, back_pose or {},
@@ -394,7 +394,7 @@ def kick_pose_track_l1(
     return_end: float = 0.75,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Bootstrap L1 vers la cible interpolée (gradient constant, pénalité<=0)."""
+    """L1 bootstrap toward the interpolated target (constant gradient, penalty<=0)."""
     cur, target = _kick_pose_error(
         env, asset_cfg, command_name, stand_pose or {}, back_pose or {},
         forward_pose or {}, windup_end, kick_end, return_end,
@@ -402,16 +402,16 @@ def kick_pose_track_l1(
     return -(cur - target).abs().mean(dim=-1)
 ```
 
-- [ ] **Step 4: Lancer, vérifier le succès**
+- [ ] **Step 4: Run, verify it passes**
 
 Run: `uv run --with pytest pytest tests/test_shoot.py -q`
-Expected: PASS (tous les tests, y compris les 3 nouveaux).
+Expected: PASS (all tests, including the 3 new ones).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/mdp.py tests/test_shoot.py
-git commit -m "feat: rewards kick_pose_track + kick_pose_track_l1 (suivi du geste de shoot)"
+git commit -m "feat: kick_pose_track + kick_pose_track_l1 rewards (kick gesture tracking)"
 ```
 
 ---
@@ -423,34 +423,34 @@ git commit -m "feat: rewards kick_pose_track + kick_pose_track_l1 (suivi du gest
 - Test: (via Task 5)
 
 **Interfaces:**
-- Consumes: `kick_pose_track`, `kick_pose_track_l1` (Task 3) ; `GroundPickPhaseCommandCfg(randomize_phase=…)` (Task 1) ; `feet_grounded_reward`, `feet_flat_penalty`, `neck_action_rate_l2`, `joint_torques_l2`, `zero_command_padding`, `robot_state_is_nan`, DR events (existants dans `mdp.py`).
-- Produces: `make_microduck_shoot_env_cfg(play=False, rough=False) -> ManagerBasedRlEnvCfg` ; `MicroduckShootRlCfg` ; constantes `SHOOT_PERIOD`, `WINDUP_END`, `KICK_END`, `RETURN_END`, `STAND_POSE`, `KICK_BACK_POSE`, `KICK_FWD_POSE`.
+- Consumes: `kick_pose_track`, `kick_pose_track_l1` (Task 3); `GroundPickPhaseCommandCfg(randomize_phase=…)` (Task 1); `feet_grounded_reward`, `feet_flat_penalty`, `neck_action_rate_l2`, `joint_torques_l2`, `zero_command_padding`, `robot_state_is_nan`, and the DR events (already in `mdp.py`).
+- Produces: `make_microduck_shoot_env_cfg(play=False, rough=False) -> ManagerBasedRlEnvCfg`; `MicroduckShootRlCfg`; the constants `SHOOT_PERIOD`, `WINDUP_END`, `KICK_END`, `RETURN_END`, `STAND_POSE`, `KICK_BACK_POSE`, `KICK_FWD_POSE`.
 
-- [ ] **Step 1: Partir du fichier ground_pick comme base**
+- [ ] **Step 1: Start from the ground_pick file as a base**
 
 ```bash
 cp src/mjlab_microduck/tasks/microduck_ground_pick_env_cfg.py \
    src/mjlab_microduck/tasks/microduck_shoot_env_cfg.py
 ```
 
-Ce fichier fournit déjà TOUT le boilerplate sim2real à conserver tel quel : DR (CoM, head CoM, mass/inertia, friction BAM, armature, IMU misalignment obs-level, encoder-bias, pushes), le bloc obs 61D (`del base_lin_vel` actor, critic base_lin_vel, suppression `foot_height`/`height_scan`, delays/noise, `head_command`/`body_command` zero-padding), la terminaison `nan_state`, les events `expand_bam_friction_fields` / `reset_action_history`, le curriculum action_rate/CoM. On ne modifie que : robot cfg, capteurs, commande, et le bloc rewards.
+That file already provides ALL the sim2real boilerplate to keep as-is: the DR (CoM, head CoM, mass/inertia, BAM friction, armature, obs-level IMU misalignment, encoder bias, pushes), the 61D obs block (`del base_lin_vel` on the actor, critic base_lin_vel, removal of `foot_height`/`height_scan`, delays/noise, `head_command`/`body_command` zero-padding), the `nan_state` termination, the `expand_bam_friction_fields` / `reset_action_history` events, and the action_rate/CoM curriculum. We modify only: the robot cfg, the sensors, the command, and the rewards block.
 
-- [ ] **Step 2: Adapter l'en-tête, le nom de fonction et les constantes**
+- [ ] **Step 2: Adapt the header, the function name and the constants**
 
-Remplacer le docstring de tête par une description shoot, et juste avant `def make_microduck_ground_pick_env_cfg`, ajouter les constantes + poses (placeholders — à remplacer par lecture `read_pose.py`). Renommer la fonction en `make_microduck_shoot_env_cfg`.
+Replace the top docstring with a kick description, and just before `def make_microduck_ground_pick_env_cfg`, add the constants + poses (placeholders — to be replaced with a `read_pose.py` reading). Rename the function to `make_microduck_shoot_env_cfg`.
 
 ```python
-# ── Timings du geste (phase normalisée [0,1)) ────────────────────────────────
-SHOOT_PERIOD = 2.5   # s — durée d'un cycle (doit matcher --ground-pick-period au déploiement)
+# ── Gesture timings (normalized phase [0,1)) ─────────────────────────────────
+SHOOT_PERIOD = 2.5   # s — cycle duration (must match --ground-pick-period at deployment)
 WINDUP_END = 0.35    # STAND -> BACK
-KICK_END = 0.45      # BACK -> FORWARD (segment court = frappe sèche)
-RETURN_END = 0.75    # FORWARD -> STAND, puis repos jusqu'à 1.0
+KICK_END = 0.45      # BACK -> FORWARD (short segment = sharp strike)
+RETURN_END = 0.75    # FORWARD -> STAND, then rest until 1.0
 
-# ── Poses (rad, 14 joints, mouth exclu) ──────────────────────────────────────
-# Convention: jambe droite frappe (hanche/genou droit actifs), gauche en appui.
-# STAND_POSE = pose HOME du sim (HOME_FRAME / default_joint_pos) pour que φ=0
-# coïncide avec la config de reset (invariant randomize_phase=False). BACK/FWD
-# sont des PLACEHOLDERS jambe droite, à affiner via read_pose.py.
+# ── Poses (rad, 14 joints, mouth excluded) ───────────────────────────────────
+# Convention: the right leg kicks (right hip/knee active), the left provides support.
+# STAND_POSE = the sim's HOME pose (HOME_FRAME / default_joint_pos) so that φ=0
+# coincides with the reset configuration (the randomize_phase=False invariant).
+# BACK/FWD are right-leg PLACEHOLDERS, to be refined via read_pose.py.
 STAND_POSE = {
     "left_hip_yaw": 0.0, "left_hip_roll": -0.0873, "left_hip_pitch": -0.4579,
     "left_knee": -0.0049, "left_ankle": 0.4530,
@@ -458,13 +458,13 @@ STAND_POSE = {
     "right_hip_yaw": 0.0, "right_hip_roll": 0.0873, "right_hip_pitch": 0.4579,
     "right_knee": 0.0049, "right_ankle": -0.4530,
 }
-KICK_BACK_POSE = {  # armement: hanche droite en extension arrière + genou fléchi
+KICK_BACK_POSE = {  # wind-up: right hip in backward extension + knee flexed
     **STAND_POSE,
     "right_hip_pitch": -0.6,
     "right_knee": 0.8,
     "right_ankle": -0.2,
 }
-KICK_FWD_POSE = {  # frappe: hanche droite fléchie avant + genou tendu
+KICK_FWD_POSE = {  # strike: right hip flexed forward + knee extended
     **STAND_POSE,
     "right_hip_pitch": 0.7,
     "right_knee": -0.1,
@@ -472,25 +472,25 @@ KICK_FWD_POSE = {  # frappe: hanche droite fléchie avant + genou tendu
 }
 ```
 
-> NOTE au releveur de poses : remplacer ces valeurs par des lectures `read_pose.py` (couple coupé, robot posé à la main dans chaque position). Garder les 14 clés identiques dans les 3 dicts.
+> NOTE for whoever records the poses: replace these values with `read_pose.py` readings (torque off, robot placed by hand in each position). Keep the same 14 keys in all 3 dicts.
 
-- [ ] **Step 3: Robot cfg et import**
+- [ ] **Step 3: Robot cfg and import**
 
-Dans les imports, remplacer `MICRODUCK_GROUND_PICK_ROBOT_CFG` par `MICRODUCK_WALK_ROBOT_CFG` :
+In the imports, replace `MICRODUCK_GROUND_PICK_ROBOT_CFG` with `MICRODUCK_WALK_ROBOT_CFG`:
 
 ```python
 from mjlab_microduck.robot.microduck_constants import MICRODUCK_WALK_ROBOT_CFG
 ```
 
-Dans la fonction, la ligne d'entités :
+In the function, the entities line:
 
 ```python
     cfg.scene.entities = {"robot": MICRODUCK_WALK_ROBOT_CFG}
 ```
 
-- [ ] **Step 4: Capteurs — garder self_collision, remplacer les capteurs pied**
+- [ ] **Step 4: Sensors — keep self_collision, replace the foot sensors**
 
-Remplacer la définition du capteur `feet_ground_contact` (2 pieds) par un capteur **pied gauche seul** (appui), et SUPPRIMER le capteur `head_impact_cfg` (inutile ici). Le capteur `self_collision_cfg` reste.
+Replace the `feet_ground_contact` sensor definition (2 feet) with a **left-foot-only** sensor (the support foot), and DELETE the `head_impact_cfg` sensor (useless here). The `self_collision_cfg` sensor stays.
 
 ```python
     left_foot_ground_cfg = ContactSensorCfg(
@@ -508,17 +508,17 @@ Remplacer la définition du capteur `feet_ground_contact` (2 pieds) par un capte
     )
 ```
 
-Et la ligne des capteurs de scène :
+And the scene sensors line:
 
 ```python
     cfg.scene.sensors = (left_foot_ground_cfg, self_collision_cfg)
 ```
 
-Supprimer la définition de `head_impact_cfg` et toute référence (le reward `head_impact_penalty` est retiré au Step 6).
+Delete the `head_impact_cfg` definition and every reference to it (the `head_impact_penalty` reward is removed in Step 6).
 
-- [ ] **Step 5: Commande de phase (randomize_phase=False, période shoot)**
+- [ ] **Step 5: Phase command (randomize_phase=False, kick period)**
 
-Remplacer le bloc commande (celui qui crée `GroundPickPhaseCommandCfg`) par :
+Replace the command block (the one that creates `GroundPickPhaseCommandCfg`) with:
 
 ```python
     command: UniformVelocityCommandCfg = cfg.commands["twist"]
@@ -531,12 +531,12 @@ Remplacer le bloc commande (celui qui crée `GroundPickPhaseCommandCfg`) par :
     cfg.commands["twist"].randomize_phase = False
 ```
 
-- [ ] **Step 6: Rewards — retirer ground_pick, ajouter shoot**
+- [ ] **Step 6: Rewards — remove ground_pick, add the kick**
 
-Supprimer les rewards spécifiques ground_pick : `mouth_ground_proximity`, `mouth_perpendicular_to_ground`, `ground_pick_return_pose_legs`, `ground_pick_return_pose_neck`, `feet_grounded` (les 2 pieds), `head_impact_penalty`. Remplacer par le bloc shoot :
+Delete the ground_pick-specific rewards: `mouth_ground_proximity`, `mouth_perpendicular_to_ground`, `ground_pick_return_pose_legs`, `ground_pick_return_pose_neck`, `feet_grounded` (both feet), `head_impact_penalty`. Replace them with the kick block:
 
 ```python
-    # ── Objectif : suivi de la pose interpolée du shoot ───────────────────────
+    # ── Objective: follow the interpolated kick pose ──────────────────────────
     _pose_params = {
         "command_name": "twist",
         "stand_pose": STAND_POSE,
@@ -557,21 +557,21 @@ Supprimer les rewards spécifiques ground_pick : `mouth_ground_proximity`, `mout
         params=dict(_pose_params),
     )
 
-    # ── Équilibre / appui (jambe unique) ──────────────────────────────────────
+    # ── Balance / support (single leg) ────────────────────────────────────────
     cfg.rewards["upright"].params["asset_cfg"].body_names = ("trunk_base",)
     cfg.rewards["upright"].weight = 2.0
     cfg.rewards["body_ang_vel"].params["asset_cfg"].body_names = ("trunk_base",)
     cfg.rewards["body_ang_vel"].weight = -0.05
 
-    # Pied GAUCHE planté (appui). feet_grounded_reward avec un capteur mono-pied
-    # -> found ∈ {0,1} -> reward ∈ {0,0.5} ; poids 6.0 => contribution max ~3.0.
+    # LEFT foot planted (support). feet_grounded_reward with a single-foot sensor
+    # -> found ∈ {0,1} -> reward ∈ {0,0.5}; weight 6.0 => max contribution ~3.0.
     cfg.rewards["support_foot_grounded"] = RewardTermCfg(
         func=microduck_mdp.feet_grounded_reward,
         weight=6.0,
         params={"sensor_name": left_foot_ground_cfg.name},
     )
 
-    # Pied gauche à plat.
+    # Left foot flat.
     cfg.rewards["feet_flat_left"] = RewardTermCfg(
         func=microduck_mdp.feet_flat_penalty,
         weight=-1.0,
@@ -585,9 +585,9 @@ Supprimer les rewards spécifiques ground_pick : `mouth_ground_proximity`, `mout
     )
 ```
 
-- [ ] **Step 7: Régularisation allégée (laisser passer le snap)**
+- [ ] **Step 7: Lighter regularization (let the snap through)**
 
-Le fichier ground_pick met `action_rate_l2=-2.0`, `neck_action_rate_l2=-1.0`, `joint_torques_l2=-5e-3` + un curriculum action_rate qui finit à -2.0. Pour le shoot on allège. Remplacer ces 3 blocs par :
+The ground_pick file sets `action_rate_l2=-2.0`, `neck_action_rate_l2=-1.0`, `joint_torques_l2=-5e-3` plus an action_rate curriculum that ends at -2.0. For the kick we lighten it. Replace those 3 blocks with:
 
 ```python
     cfg.rewards["action_rate_l2"] = RewardTermCfg(
@@ -601,7 +601,7 @@ Le fichier ground_pick met `action_rate_l2=-2.0`, `neck_action_rate_l2=-1.0`, `j
     )
 ```
 
-Et alléger le curriculum action_rate (garder la structure, viser -0.5) :
+And lighten the action_rate curriculum (keep the structure, target -0.5):
 
 ```python
     cfg.curriculum["action_rate_weight"] = CurriculumTermCfg(
@@ -617,26 +617,26 @@ Et alléger le curriculum action_rate (garder la structure, viser -0.5) :
     )
 ```
 
-- [ ] **Step 8: Reset — hauteur de station debout**
+- [ ] **Step 8: Reset — standing stance height**
 
-Garder la **hauteur debout** `(0.12, 0.13)` — c'est la valeur de l'env velocity
-(marche) ET de ground_pick. ⚠️ Ce n'est PAS un offset additif « station accroupie » :
-le `pos` racine par défaut de `InitialStateCfg` est (0,0,0), donc la hauteur de reset
-est z ∈ [0.12, 0.13] m **absolue** = debout (aucune chute). Vérifier/mettre :
+Keep the **standing height** `(0.12, 0.13)` — that is the value used by the velocity
+(walking) env AND by ground_pick. ⚠️ This is NOT an additive "crouched stance" offset:
+the default root `pos` of `InitialStateCfg` is (0,0,0), so the reset height is
+z ∈ [0.12, 0.13] m **absolute** = standing (no fall). Check/set:
 
 ```python
     cfg.events["reset_base"].params["pose_range"]["z"] = (0.12, 0.13)
 ```
 
-(Ne PAS injecter de vitesse d'entrée — c'est un shoot debout, pas de glisse.)
+(Do NOT inject an entry velocity — this is a standing kick, not a glide.)
 
-- [ ] **Step 9: Renommer la RlCfg**
+- [ ] **Step 9: Rename the RlCfg**
 
-En bas du fichier, renommer `MicroduckGroundPickRlCfg` en `MicroduckShootRlCfg` et changer les noms d'expérience :
+At the bottom of the file, rename `MicroduckGroundPickRlCfg` to `MicroduckShootRlCfg` and change the experiment names:
 
 ```python
 MicroduckShootRlCfg = RslRlOnPolicyRunnerCfg(
-    # … (garder actor/critic/algorithm identiques) …
+    # … (keep actor/critic/algorithm identical) …
     wandb_project="mjlab_microduck",
     experiment_name="shoot",
     run_name="shoot",
@@ -646,21 +646,21 @@ MicroduckShootRlCfg = RslRlOnPolicyRunnerCfg(
 )
 ```
 
-- [ ] **Step 10: Vérifier que le module s'importe**
+- [ ] **Step 10: Check that the module imports**
 
 Run: `uv run python -c "from mjlab_microduck.tasks.microduck_shoot_env_cfg import make_microduck_shoot_env_cfg, MicroduckShootRlCfg; print('ok')"`
-Expected: `ok` (pas d'ImportError / NameError — en particulier plus aucune référence à `head_impact_cfg`, `MICRODUCK_GROUND_PICK_ROBOT_CFG`, ni aux rewards ground_pick supprimés).
+Expected: `ok` (no ImportError / NameError — in particular, no remaining reference to `head_impact_cfg`, `MICRODUCK_GROUND_PICK_ROBOT_CFG`, or the deleted ground_pick rewards).
 
 - [ ] **Step 11: Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/microduck_shoot_env_cfg.py
-git commit -m "feat: env config Mjlab-Shoot (geste de shoot par suivi de poses)"
+git commit -m "feat: Mjlab-Shoot env config (kick gesture by pose following)"
 ```
 
 ---
 
-### Task 5: Enregistrement + test d'intégration
+### Task 5: Registration + integration test
 
 **Files:**
 - Modify: `src/mjlab_microduck/tasks/__init__.py`
@@ -668,11 +668,11 @@ git commit -m "feat: env config Mjlab-Shoot (geste de shoot par suivi de poses)"
 
 **Interfaces:**
 - Consumes: `make_microduck_shoot_env_cfg`, `MicroduckShootRlCfg` (Task 4).
-- Produces: tâche enregistrée `Mjlab-Shoot-Flat-MicroDuck`.
+- Produces: the registered task `Mjlab-Shoot-Flat-MicroDuck`.
 
-- [ ] **Step 1: Écrire le test d'intégration qui échoue**
+- [ ] **Step 1: Write the failing integration test**
 
-Créer `tests/test_shoot_cfg.py` :
+Create `tests/test_shoot_cfg.py`:
 
 ```python
 from mjlab_microduck.tasks.microduck_shoot_env_cfg import (
@@ -706,14 +706,14 @@ def test_shoot_cfg_has_kick_rewards_and_no_walking():
         assert gone not in cfg.rewards
 ```
 
-- [ ] **Step 2: Lancer, vérifier l'échec**
+- [ ] **Step 2: Run, verify it fails**
 
 Run: `uv run --with pytest pytest tests/test_shoot_cfg.py -q`
-Expected: PASS possible sur les tests de poses, mais l'ensemble doit être vert seulement une fois l'env construit sans erreur ; si `make_...` lève, FAIL. (À ce stade l'import du fichier fonctionne déjà via Task 4.)
+Expected: the pose tests may PASS, but the whole file should only go green once the env builds without error; if `make_...` raises, FAIL. (At this stage importing the file already works thanks to Task 4.)
 
-- [ ] **Step 3: Enregistrer la tâche**
+- [ ] **Step 3: Register the task**
 
-Dans `src/mjlab_microduck/tasks/__init__.py`, après le bloc d'import ground_pick (~ligne 50), ajouter :
+In `src/mjlab_microduck/tasks/__init__.py`, after the ground_pick import block (~line 50), add:
 
 ```python
 from .microduck_shoot_env_cfg import (
@@ -722,7 +722,7 @@ from .microduck_shoot_env_cfg import (
 )
 ```
 
-Après le bloc `register_mjlab_task` de GroundPick-Rough (~ligne 161), ajouter :
+After the GroundPick-Rough `register_mjlab_task` block (~line 161), add:
 
 ```python
 register_mjlab_task(
@@ -735,40 +735,40 @@ register_mjlab_task(
 print("✓ Shoot task registered: Mjlab-Shoot-Flat-MicroDuck")
 ```
 
-- [ ] **Step 4: Lancer tout, vérifier le succès**
+- [ ] **Step 4: Run everything, verify it passes**
 
 Run: `uv run --with pytest pytest tests/ -q`
-Expected: PASS (test_shoot.py + test_shoot_cfg.py + tests existants).
+Expected: PASS (test_shoot.py + test_shoot_cfg.py + the existing tests).
 
-- [ ] **Step 5: Vérifier l'enregistrement de la tâche**
+- [ ] **Step 5: Verify the task registration**
 
 Run: `uv run python -c "import mjlab_microduck.tasks"`
-Expected: la sortie contient `✓ Shoot task registered: Mjlab-Shoot-Flat-MicroDuck`.
+Expected: the output contains `✓ Shoot task registered: Mjlab-Shoot-Flat-MicroDuck`.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/__init__.py tests/test_shoot_cfg.py
-git commit -m "feat: enregistre Mjlab-Shoot-Flat-MicroDuck + test d'intégration"
+git commit -m "feat: register Mjlab-Shoot-Flat-MicroDuck + integration test"
 ```
 
 ---
 
-## Après implémentation (hors plan TDD)
+## After implementation (outside the TDD plan)
 
-1. **Relever les vraies poses** avec `read_pose.py` (STAND, PIED_ARRIÈRE, PIED_AVANT), remplacer les placeholders dans `microduck_shoot_env_cfg.py`.
-2. **Entraîner** : `uv run train Mjlab-Shoot-Flat-MicroDuck --env.scene.num-envs 4096 --agent.max_iterations 8000`. Surveiller `Episode_Reward/kick_pose_track` (doit monter).
-3. **Play** : script play_latest ; vérifier l'équilibre sur le pied gauche pendant la frappe.
-4. **Export ONNX** + déploiement dans un slot phase (`--ground-pick shoot.onnx --ground-pick-period 2.5 --ground-pick-kp-ratio 1.0`).
-5. **Réglages probables** : période/timings (snap), poids `action_rate`, et éventuel reward « vitesse pied vers l'avant » (segment frappe) si le suivi manque de punch.
+1. **Record the real poses** with `read_pose.py` (STAND, FOOT_BACK, FOOT_FORWARD), and replace the placeholders in `microduck_shoot_env_cfg.py`.
+2. **Train**: `uv run train Mjlab-Shoot-Flat-MicroDuck --env.scene.num-envs 4096 --agent.max_iterations 8000`. Watch `Episode_Reward/kick_pose_track` (it must rise).
+3. **Play**: the play_latest script; check the balance on the left foot during the strike.
+4. **ONNX export** + deployment into a phase slot (`--ground-pick shoot.onnx --ground-pick-period 2.5 --ground-pick-kp-ratio 1.0`).
+5. **Likely adjustments**: period/timings (snap), the `action_rate` weight, and possibly a "forward foot velocity" reward (strike segment) if the pose following lacks punch.
 
-## Self-review — couverture de la spec
+## Self-review — spec coverage
 
-- Fichier & enregistrement → Tasks 4, 5. ✅
-- Poses placeholders 14 joints → Task 4 Step 2, testé Task 5. ✅
-- Commande de phase + `randomize_phase=False` + période → Tasks 1, 4 Step 5, testé Task 5. ✅
+- File & registration → Tasks 4, 5. ✅
+- 14-joint placeholder poses → Task 4 Step 2, tested in Task 5. ✅
+- Phase command + `randomize_phase=False` + period → Tasks 1, 4 Step 5, tested in Task 5. ✅
 - `kick_pose_target` + `kick_pose_track` + `kick_pose_track_l1` → Tasks 2, 3. ✅
-- Équilibre/appui (upright, pied gauche planté, feet_flat gauche, self_collisions, body_ang_vel) → Task 4 Step 6. ✅
-- Régularisation allégée → Task 4 Step 7. ✅
-- Obs 61D parité (hérité ground_pick, conservé) → Task 4 Step 1. ✅
-- Tests pures + cfg → Tasks 2, 3, 5. ✅
+- Balance/support (upright, left foot planted, left feet_flat, self_collisions, body_ang_vel) → Task 4 Step 6. ✅
+- Lighter regularization → Task 4 Step 7. ✅
+- 61D obs parity (inherited from ground_pick, preserved) → Task 4 Step 1. ✅
+- Pure-function + cfg tests → Tasks 2, 3, 5. ✅

--- a/docs/superpowers/plans/2026-08-04-roller-standup.md
+++ b/docs/superpowers/plans/2026-08-04-roller-standup.md
@@ -177,7 +177,7 @@ def test_task_is_registered():
 ```bash
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
-Expected: erreur de collecte, `ModuleNotFoundError: No module named 'mjlab_microduck.tasks.microduck_roller_standup_env_cfg'`.
+Expected: a collection error, `ModuleNotFoundError: No module named 'mjlab_microduck.tasks.microduck_roller_standup_env_cfg'`.
 
 - [ ] **Step 3: Create the env file**
 
@@ -866,7 +866,7 @@ Expected: 20 passed.
 ```bash
 git add src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py \
         tests/test_roller_standup_cfg.py
-git commit -m "roller-standup: depart au sol (ventre/dos/debout) + curriculum des poses"
+git commit -m "roller-standup: ground starts (belly/back/standing) + pose curriculum"
 ```
 
 ---
@@ -968,9 +968,9 @@ uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
 Expected: `test_wheel_friction_curriculum_is_decreasing` fails on `assert lows == sorted(lows, reverse=True)` (the roller env ramps 0 → 0.0015), `test_wheel_friction_event_starts_at_stage_zero` fails, `test_action_rate_ramp_is_the_standup_one_not_the_roller_one` fails on `[-1.0, -1.5, -2.0] != [-0.4, -0.8, -1.0]`, and `test_push_curriculum_ramps_from_zero` fails on `KeyError: 'push_magnitude'`. `test_inherited_dr_curricula_survive` already passes (a non-regression check).
 
-- [ ] **Step 3 : Remplacer les curricula**
+- [ ] **Step 3: Replace the curricula**
 
-In `microduck_roller_standup_env_cfg.py`, insert this block **after** the `ground_state_mix` curriculum et **avant** le `return cfg` :
+In `microduck_roller_standup_env_cfg.py`, insert this block **after** the `ground_state_mix` curriculum and **before** the `return cfg`:
 
 ```python
     # ── REVERSED rolling friction: braked → free ─────────────────────────────
@@ -1005,7 +1005,7 @@ In `microduck_roller_standup_env_cfg.py`, insert this block **after** the `groun
     # The event's STARTING value must match stage 0: the curriculum is only
     # evaluated from the first step onward, otherwise the very first resets
     # would use the (0, 0) inherited from the roller env — FREE wheels during
-    # le bootstrap, soit exactement l'inverse du but.
+    # the bootstrap, i.e. exactly the opposite of the goal.
     cfg.events["randomize_wheel_friction"].params["ranges"] = _WHEEL_FRICTION_STAGE0
 
     # ── action_rate: standup's ramp, not the roller's ────────────────────────
@@ -1065,7 +1065,7 @@ Expected: `4 failed, 71 passed` — only the 4 pre-existing failures in `tests/t
 ```bash
 git add src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py \
         tests/test_roller_standup_cfg.py
-git commit -m "roller-standup: curriculum de friction de roulement inverse + pousses rampees"
+git commit -m "roller-standup: reverse wheel-friction curriculum + ramped pushes"
 ```
 
 ---
@@ -1076,7 +1076,7 @@ The Task 1–4 tests are **static**: they check the config, not execution. They 
 
 **Files:**
 - Create: `docs/roller_standup_policy_summary.md`
-- (aucune modification de code attendue si tout passe)
+- (no code change expected if everything passes)
 
 **Interfaces:**
 - Consumes: the registered task `Mjlab-RollerStandUp-Flat-MicroDuck` (Task 1) and the complete env (Tasks 2–4).
@@ -1095,8 +1095,8 @@ uv run train Mjlab-RollerStandUp-Flat-MicroDuck \
 
 Expected: `✓ RollerStandUp task registered: Mjlab-RollerStandUp-Flat-MicroDuck`, then 3 iterations that run without an exception, with a reward table showing the terms `pose_stand_legs`, `height_stand`, `standing_composite`, etc.
 
-Erreurs plausibles et leur cause :
-- `IndexError` on `joint_pos[:, joint_indices]` → the `_LEG_JOINTS` indices exceed the number de joints ; relire Task 2.
+Plausible errors and their cause:
+- `IndexError` on `joint_pos[:, joint_indices]` → the `_LEG_JOINTS` indices exceed the number of joints; re-read Task 2.
 - `TypeError: ... unexpected keyword argument` → a parameter name does not match the mdp function's signature; compare with Task 2's **Interfaces** block.
 - `KeyError` on a sensor name → a removed reward was the only user of a sensor, or a kept reward requires one that is missing.
 

--- a/docs/superpowers/plans/2026-08-04-roller-standup.md
+++ b/docs/superpowers/plans/2026-08-04-roller-standup.md
@@ -1,43 +1,43 @@
-# Roller StandUp — Plan d'implémentation
+# Roller StandUp — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Une policy dédiée `Mjlab-RollerStandUp-Flat-MicroDuck` qui remet le microduck debout sur ses rollers après une chute (à plat ventre ou à plat dos) et qui sait tenir la station sur roues.
+**Goal:** A dedicated policy `Mjlab-RollerStandUp-Flat-MicroDuck` that puts the microduck back upright on its rollers after a fall (face down or face up) and can then hold the stance on wheels.
 
-**Architecture:** Un seul fichier d'env nouveau, dérivé de `make_microduck_velocity_rollers_env_cfg()` — il hérite ainsi du robot rollers, des capteurs, de toute la domain randomization et de l'observation 61D (condition dure pour l'interchangeabilité au runtime). On retire les récompenses de patinage, on greffe les dix récompenses de relevé du `standup` (remappées sur les indices de joints du modèle rollers, où les roues passives sont intercalées), on remplace le reset par un départ au sol, et on inverse le curriculum de friction de roulement (roues freinées → libres) pour bootstrapper le geste avant d'imposer la physique réelle des roues.
+**Architecture:** A single new env file, derived from `make_microduck_velocity_rollers_env_cfg()` — it thereby inherits the roller robot, the sensors, the whole domain randomization stack and the 61D observation (a hard requirement for runtime hot-swappability). We remove the skating rewards, graft on `standup`'s ten standup rewards (remapped onto the roller model's joint indices, where the passive wheels are interleaved), replace the reset with a start on the ground, and reverse the rolling-friction curriculum (braked wheels → free) to bootstrap the gesture before imposing the real wheel physics.
 
 **Tech Stack:** Python 3.12, mjlab 1.3.0, MuJoCo / mujoco-warp, rsl_rl (PPO), uv, pytest.
 
-Spec de référence : `docs/superpowers/specs/2026-08-04-roller-standup-design.md`
+Reference spec: `docs/superpowers/specs/2026-08-04-roller-standup-design.md`
 
 ## Global Constraints
 
-- **Aucune modification** de `src/mjlab_microduck/tasks/mdp.py`, ni des envs `roller`, `roller_crouch`, `roller_slope`, `standup`, `velstand`. Toutes les fonctions mdp nécessaires existent déjà.
-- **Parité d'observation 61D obligatoire** avec `make_microduck_velocity_rollers_env_cfg()` : `[gyro(3), projected_gravity(3), joint_pos(14), joint_vel(14), last_action(14), command(13)]`. Les slots `head_pose` (4) et `body_pose` (6) restent **zero-paddés**. Sans cette parité l'ONNX ne se charge pas dans un slot du runtime.
-- **Indices de joints du modèle rollers** (roues passives intercalées ; vérifiés dans MuJoCo) :
+- **No modification** to `src/mjlab_microduck/tasks/mdp.py`, nor to the `roller`, `roller_crouch`, `roller_slope`, `standup`, `velstand` envs. All the required mdp functions already exist.
+- **61D observation parity is mandatory** with `make_microduck_velocity_rollers_env_cfg()`: `[gyro(3), projected_gravity(3), joint_pos(14), joint_vel(14), last_action(14), command(13)]`. The `head_pose` (4) and `body_pose` (6) slots stay **zero-padded**. Without this parity the ONNX will not load in a runtime slot.
+- **Roller-model joint indices** (passive wheels interleaved; verified in MuJoCo):
   `_LEG_JOINTS = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]`, `_NECK_JOINTS = [7, 8, 9, 10]`, `_WHEEL_JOINTS = [5, 6, 16, 17]`.
-  Ne **jamais** réutiliser les indices du `standup` (`[0-4, 9-13]` / `[5-8]`), qui valent pour le modèle sans roues.
-- **Hauteurs mesurées** : `ROLLER_STAND_Z = 0.138`, `ROLLER_PRONE_Z = 0.075`. Ne pas les remplacer par les valeurs du `standup` (0.115 / 0.07).
-- `EPISODE_LENGTH_S = 6.0`, `NUM_STEPS_PER_ENV = 24`. Les `step` des curricula s'expriment en `iters × NUM_STEPS_PER_ENV`.
-- **Symétrie OFF** : `symmetry_cfg=None`. `SYMMETRY_CFG` est câblé pour l'ancien layout 51D et casse sur le 61D.
-- Style du repo : commentaires en français dans les envs roller, indentation 4 espaces, `SceneEntityCfg` **reconstruit à chaque terme** (jamais un objet partagé — mjlab résout et mute ces objets en place).
-- Commits simples, sans `Co-Authored-By`.
-- **Pré-existant, hors périmètre** : `tests/test_wheel_glide.py` a 4 tests en échec avant ce travail (faux asset avec une regex obsolète `passive_LF_?wheel`). Ne pas les corriger, ne pas s'en alarmer. Le reste de la suite passe (46 tests).
+  **Never** reuse `standup`'s indices (`[0-4, 9-13]` / `[5-8]`), which hold for the model without wheels.
+- **Measured heights**: `ROLLER_STAND_Z = 0.138`, `ROLLER_PRONE_Z = 0.075`. Do not replace them with `standup`'s values (0.115 / 0.07).
+- `EPISODE_LENGTH_S = 6.0`, `NUM_STEPS_PER_ENV = 24`. Curriculum `step` values are expressed as `iters × NUM_STEPS_PER_ENV`.
+- **Symmetry OFF**: `symmetry_cfg=None`. `SYMMETRY_CFG` is wired for the old 51D layout and breaks on the 61D one.
+- Repo style: 4-space indentation, and `SceneEntityCfg` **rebuilt for each term** (never a shared object — mjlab resolves and mutates these objects in place).
+- Simple commits, no `Co-Authored-By`.
+- **Pre-existing, out of scope**: `tests/test_wheel_glide.py` has 4 failing tests before this work (a fake asset with an obsolete `passive_LF_?wheel` regex). Do not fix them, and do not be alarmed by them. The rest of the suite passes (46 tests).
 
 ---
 
-## Structure des fichiers
+## File structure
 
-| Fichier | Responsabilité |
+| File | Responsibility |
 |---|---|
-| `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py` (créer) | Toute la config de l'env + `MicroduckRollerStandUpRlCfg`. Un seul fichier, comme tous les autres envs du repo. |
-| `src/mjlab_microduck/tasks/__init__.py` (modifier) | Import + `register_mjlab_task` de la nouvelle tâche. |
-| `tests/test_roller_standup_cfg.py` (créer) | Tests de construction de config + verrou des indices de joints. Pas de sim, pas de GPU (comme `test_roller_slope_cfg.py`). |
-| `docs/roller_standup_policy_summary.md` (créer, Task 5) | Résumé de passation, sur le modèle de `docs/roller_slope_policy_summary.md`. |
+| `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py` (create) | The whole env config + `MicroduckRollerStandUpRlCfg`. A single file, like every other env in the repo. |
+| `src/mjlab_microduck/tasks/__init__.py` (modify) | Import + `register_mjlab_task` for the new task. |
+| `tests/test_roller_standup_cfg.py` (create) | Config-construction tests + the joint-index lock-in. No sim, no GPU (like `test_roller_slope_cfg.py`). |
+| `docs/roller_standup_policy_summary.md` (create, Task 5) | Handover summary, modeled on `docs/roller_slope_policy_summary.md`. |
 
 ---
 
-## Task 1 : Squelette de l'env — dérivation, commande neutralisée, patinage retiré, enregistrement
+## Task 1: Env skeleton — derivation, neutralized command, skating removed, registration
 
 **Files:**
 - Create: `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`
@@ -45,12 +45,12 @@ Spec de référence : `docs/superpowers/specs/2026-08-04-roller-standup-design.m
 - Test: `tests/test_roller_standup_cfg.py`
 
 **Interfaces:**
-- Consumes: `make_microduck_velocity_rollers_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg` (existant), `microduck_mdp.VelocityCommandCommandOnlyCfg` (existant).
-- Produces: `make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg` ; `MicroduckRollerStandUpRlCfg: RslRlOnPolicyRunnerCfg` ; les constantes de module `ROLLER_STAND_Z: float`, `ROLLER_PRONE_Z: float`, `EPISODE_LENGTH_S: float`, `NUM_STEPS_PER_ENV: int`, `_LEG_JOINTS: list[int]`, `_NECK_JOINTS: list[int]`, `_WHEEL_JOINTS: list[int]` ; la tâche enregistrée `"Mjlab-RollerStandUp-Flat-MicroDuck"`.
+- Consumes: `make_microduck_velocity_rollers_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg` (existing), `microduck_mdp.VelocityCommandCommandOnlyCfg` (existing).
+- Produces: `make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg`; `MicroduckRollerStandUpRlCfg: RslRlOnPolicyRunnerCfg`; the module constants `ROLLER_STAND_Z: float`, `ROLLER_PRONE_Z: float`, `EPISODE_LENGTH_S: float`, `NUM_STEPS_PER_ENV: int`, `_LEG_JOINTS: list[int]`, `_NECK_JOINTS: list[int]`, `_WHEEL_JOINTS: list[int]`; and the registered task `"Mjlab-RollerStandUp-Flat-MicroDuck"`.
 
-- [ ] **Step 1 : Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Créer `tests/test_roller_standup_cfg.py` :
+Create `tests/test_roller_standup_cfg.py`:
 
 ```python
 from mjlab_microduck.tasks.microduck_roller_standup_env_cfg import (
@@ -61,7 +61,7 @@ from mjlab_microduck.tasks.microduck_velocity_rollers_env_cfg import (
     make_microduck_velocity_rollers_env_cfg,
 )
 
-# Récompenses de PATINAGE : elles ne doivent pas survivre dans un env de relevé.
+# SKATING rewards: they must not survive in a standup env.
 SKATING_REWARDS = (
     "wheel_speed",
     "braking",
@@ -85,7 +85,7 @@ def test_env_builds_train_and_play():
 
 
 def test_episode_is_short():
-    # Épisode court : monter puis stabiliser, comme standup (6 s).
+    # Short episode: rise then stabilize, like standup (6 s).
     cfg = make_microduck_roller_standup_env_cfg()
     assert cfg.episode_length_s == EPISODE_LENGTH_S == 6.0
 
@@ -93,12 +93,12 @@ def test_episode_is_short():
 def test_no_skating_rewards_survive():
     cfg = make_microduck_roller_standup_env_cfg()
     for name in SKATING_REWARDS:
-        assert name not in cfg.rewards, f"reward de patinage survivante : {name}"
+        assert name not in cfg.rewards, f"skating reward survived: {name}"
 
 
 def test_smoothness_regularisers_kept():
-    # Gardées de l'héritage roller : le relevé a besoin de douceur sim2real, mais
-    # body_ang_vel doit rester LÉGER (standup documente qu'à -0.15 il gelait).
+    # Kept from the roller inheritance: the standup needs sim2real smoothness, but
+    # body_ang_vel must stay LIGHT (standup documents that it froze at -0.15).
     cfg = make_microduck_roller_standup_env_cfg()
     for name in (
         "action_over_limit",
@@ -110,13 +110,13 @@ def test_smoothness_regularisers_kept():
         "neck_joint_pos_l2",
         "joint_torques_l2",
     ):
-        assert name in cfg.rewards, f"régularisateur perdu : {name}"
+        assert name in cfg.rewards, f"regularizer lost: {name}"
     assert cfg.rewards["body_ang_vel"].weight == -0.05
 
 
 def test_twist_command_is_neutralised():
-    # Pas de pilotage : la policy se déploie en --standing, où le runtime laisse
-    # le slot twist à zéro (cf. infer_policy.py:239).
+    # No steering: the policy deploys in --standing, where the runtime leaves the
+    # twist slot at zero (cf. infer_policy.py:239).
     cfg = make_microduck_roller_standup_env_cfg()
     cmd = cfg.commands["twist"]
     assert cmd.ranges.lin_vel_x == (-0.01, 0.01)
@@ -128,8 +128,8 @@ def test_twist_command_is_neutralised():
 
 
 def test_twist_command_is_not_heading_relative():
-    # L'env roller installe un RelativeHeadingVelocityCommandCfg (cmd[2] = erreur
-    # de cap, calculée en interne). Ici cmd[2] doit être un vrai zéro bruité.
+    # The roller env installs a RelativeHeadingVelocityCommandCfg (cmd[2] =
+    # heading error, computed internally). Here cmd[2] must be a real noisy zero.
     from mjlab_microduck.tasks import mdp as microduck_mdp
 
     cfg = make_microduck_roller_standup_env_cfg()
@@ -139,26 +139,26 @@ def test_twist_command_is_not_heading_relative():
 
 
 def test_obs_nan_policy_sanitize():
-    # Un contact rare fait diverger le free-joint en NaN : on assainit l'obs
-    # plutôt que de tuer l'entraînement (même choix que roller_slope).
+    # A rare contact makes the free joint diverge to NaN: we sanitize the obs
+    # rather than kill training (same choice as roller_slope).
     cfg = make_microduck_roller_standup_env_cfg()
     assert cfg.observations["actor"].nan_policy == "sanitize"
     assert cfg.observations["critic"].nan_policy == "sanitize"
 
 
 def test_obs_parity_with_roller_env():
-    # Parité 61D obligatoire : sinon l'ONNX ne se charge pas dans un slot runtime.
+    # 61D parity is mandatory: otherwise the ONNX will not load in a runtime slot.
     standup = make_microduck_roller_standup_env_cfg()
     roller = make_microduck_velocity_rollers_env_cfg()
     for grp in ("actor", "critic"):
         assert list(standup.observations[grp].terms.keys()) == list(
             roller.observations[grp].terms.keys()
-        ), f"layout d'observation divergent sur le groupe {grp}"
+        ), f"observation layout diverged on group {grp}"
 
 
 def test_terrain_is_plain_plane():
-    # Hérité de l'env roller : sol plat, pas de générateur. Pas de variante rough
-    # pour cette v1.
+    # Inherited from the roller env: flat ground, no generator. No rough variant
+    # for this v1.
     cfg = make_microduck_roller_standup_env_cfg()
     assert cfg.scene.terrain.terrain_type == "plane"
     assert cfg.scene.terrain.terrain_generator is None
@@ -167,52 +167,50 @@ def test_terrain_is_plain_plane():
 def test_task_is_registered():
     from mjlab.tasks.registry import list_tasks
 
-    import mjlab_microduck.tasks  # noqa: F401  (l'import déclenche l'enregistrement)
+    import mjlab_microduck.tasks  # noqa: F401  (the import triggers registration)
 
     assert "Mjlab-RollerStandUp-Flat-MicroDuck" in list_tasks()
 ```
 
-- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
-Attendu : erreur de collecte, `ModuleNotFoundError: No module named 'mjlab_microduck.tasks.microduck_roller_standup_env_cfg'`.
+Expected: erreur de collecte, `ModuleNotFoundError: No module named 'mjlab_microduck.tasks.microduck_roller_standup_env_cfg'`.
 
-- [ ] **Step 3 : Créer le fichier d'env**
+- [ ] **Step 3: Create the env file**
 
-Créer `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py` :
+Create `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`:
 
 ```python
-"""Microduck roller standup — se relever sur rollers.
+"""Microduck roller standup — standing up on rollers.
 
-Policy DÉDIÉE épisodique : le robot démarre au sol (à plat ventre, à plat dos) ou
-déjà debout, et doit se remettre debout sur ses rollers puis TENIR la station.
-Portage de la recette `standup` (canard marcheur) vers le modèle rollers.
+DEDICATED episodic policy: the robot starts on the ground (face down, face up)
+or already standing, and must get back up on its rollers and then HOLD the
+stance. Port of the `standup` recipe (walking duck) to the roller model.
 
-Dérive de l'env roller (`make_microduck_velocity_rollers_env_cfg`) → hérite tel
-quel le robot rollers, les capteurs, toute la DR et l'observation 61D, donc
-interchangeable au runtime (--new-cmd-obs). C'est le pattern de roller_slope.
+Derives from the roller env (`make_microduck_velocity_rollers_env_cfg`) → inherits
+the roller robot, the sensors, the whole DR stack and the 61D observation as-is,
+so it is hot-swappable at runtime (--new-cmd-obs). Same pattern as roller_slope.
 
-Deux différences structurelles avec `standup` :
-  - les roues passives sont INTERCALÉES dans l'ordre des joints → indices
-    remappés (_LEG_JOINTS ci-dessous), verrouillés par
-    tests/test_roller_standup_cfg.py ;
-  - pas de commande head_pose : les slots head/body restent zero-paddés
-    (convention de la famille roller) et la tête est tenue droite par
-    neck_joint_pos_l2, qui résout par NOM.
+Two structural differences from `standup`:
+  - the passive wheels are INTERLEAVED in the joint ordering → remapped indices
+    (_LEG_JOINTS below), locked in by tests/test_roller_standup_cfg.py;
+  - no head_pose command: the head/body slots stay zero-padded (roller family
+    convention) and the head is held upright by neck_joint_pos_l2, which
+    resolves by NAME.
 
-La pièce nouvelle est le curriculum de friction de roulement, INVERSÉ (roues
-freinées → libres) : les roues roulent, donc il n'y a aucune adhérence pour
-pousser sur le sol. On bootstrappe avec des roues quasi bloquées puis on rampe
-vers la vraie valeur. Si `standing_composite` s'écroule à un palier, le geste
-« pieds adhérents » ne transfère pas et il faudra guider une technique de
-patineur (appui genou, un patin à la fois).
+The genuinely new piece is the rolling-friction curriculum, REVERSED (braked
+wheels → free wheels): the wheels roll, so there is no traction at all to push
+against the ground. We bootstrap with near-locked wheels and then ramp toward
+the real value. If `standing_composite` collapses at a stage, the "sticky feet"
+gesture does not transfer and we will have to guide a skater technique (knee
+support, one skate at a time).
 
-Déploiement visé : en `--standing` face à la policy roller en `--walking`, avec
-la bascule automatique sur la magnitude de la commande de vitesse
-(infer_policy.py:262, seuil 0.05) ; le slot twist y est laissé à zéro
-(infer_policy.py:239).
+Intended deployment: in `--standing` alongside the roller policy in `--walking`,
+with the automatic switch on velocity command magnitude (infer_policy.py:262,
+threshold 0.05); the twist slot is left at zero there (infer_policy.py:239).
 """
 
 import math
@@ -232,43 +230,44 @@ from mjlab_microduck.tasks.microduck_velocity_rollers_env_cfg import (
 )
 from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg
 
-# ── Hauteurs de tronc (m) ─────────────────────────────────────────────────────
-# Mesurées par cinématique exacte (minimum des sommets de maillage des géoms
-# collidantes, pose STAND, tronc ramené au contact) sur scene_rollers.xml :
-# debout 0.1407, repos à plat ventre 0.0752, repos à plat dos 0.0475.
-# Contrôle : le modèle SANS roues donne 0.1172 en cinématique contre STAND_Z=0.115
-# mesuré sous charge par standup → ~2 mm d'affaissement, appliqué ici aussi.
-# 0.138 tombe dans le reset_base z (0.1335–0.1435) déjà utilisé par l'env roller.
+# ── Trunk heights (m) ─────────────────────────────────────────────────────────
+# Measured by exact kinematics (minimum over the mesh vertices of the colliding
+# geoms, STAND pose, trunk lowered to contact) on scene_rollers.xml:
+# standing 0.1407, face-down rest 0.0752, face-up rest 0.0475.
+# Cross-check: the model WITHOUT wheels gives 0.1172 kinematically against
+# STAND_Z=0.115 measured under load by standup → ~2 mm of sag, applied here too.
+# 0.138 falls inside the reset_base z range (0.1335–0.1435) already used by the
+# roller env.
 ROLLER_STAND_Z = 0.138
 ROLLER_PRONE_Z = 0.075
 
-EPISODE_LENGTH_S  = 6.0   # monter + stabiliser, comme standup
+EPISODE_LENGTH_S  = 6.0   # rise + stabilize, same as standup
 NUM_STEPS_PER_ENV = 24
 
-# ── Indices de joints — les roues passives sont INTERCALÉES ───────────────────
-# Ordre réel du modèle rollers (18 joints après le free-joint), vérifié dans
-# MuJoCo via get_walk_rollers_spec().compile() :
+# ── Joint indices — the passive wheels are INTERLEAVED ────────────────────────
+# Actual ordering of the roller model (18 joints after the free joint), verified
+# in MuJoCo via get_walk_rollers_spec().compile():
 #   0-4   left_hip_yaw, left_hip_roll, left_hip_pitch, left_knee, left_ankle
 #   5-6   passive_LF_wheel, passive_LR_wheel
 #   7-10  neck_pitch, head_pitch, head_yaw, head_roll
 #   11-15 right_hip_yaw, right_hip_roll, right_hip_pitch, right_knee, right_ankle
 #   16-17 passive_RF_wheel, passive_RR_wheel
-# Le standup utilise [0-4, 9-13] / [5-8] : ce sont les indices du modèle SANS
-# roues, ils ne valent PAS ici. Verrouillé par tests/test_roller_standup_cfg.py.
+# standup uses [0-4, 9-13] / [5-8]: those are the indices of the model WITHOUT
+# wheels, they do NOT hold here. Locked in by tests/test_roller_standup_cfg.py.
 #
-# Seul _LEG_JOINTS est consommé (par les récompenses de pose). _NECK_JOINTS et
-# _WHEEL_JOINTS servent à la documentation et au test d'indices : le cou est
-# résolu par NOM (neck_joint_pos_l2 appelle find_joints(r".*(neck|head).*") à
-# chaque pas) et les roues par la regex ^passive_.*.
+# Only _LEG_JOINTS is consumed (by the pose rewards). _NECK_JOINTS and
+# _WHEEL_JOINTS exist for documentation and for the index test: the neck is
+# resolved by NAME (neck_joint_pos_l2 calls find_joints(r".*(neck|head).*") every
+# step) and the wheels by the ^passive_.* regex.
 _LEG_JOINTS   = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]
 _NECK_JOINTS  = [7, 8, 9, 10]
 _WHEEL_JOINTS = [5, 6, 16, 17]
 
-# Récompenses de PATINAGE de l'env roller : aucun sens quand on est par terre.
-# feet_flat : les lames ne sont PAS à plat pendant la montée → combattrait le geste.
-# hip_roll_neutral : se relever demande d'écarter les jambes.
-# pose / com_height_target : remplacés par les cibles pose/hauteur du relevé.
-# upright (gaussienne de base) : remplacée par upright_linear + upright_sharp.
+# SKATING rewards from the roller env: meaningless while lying on the ground.
+# feet_flat: the blades are NOT flat during the rise → would fight the gesture.
+# hip_roll_neutral: standing up requires spreading the legs.
+# pose / com_height_target: replaced by the standup pose/height targets.
+# upright (base gaussian): replaced by upright_linear + upright_sharp.
 _SKATING_REWARDS = (
     "wheel_speed",
     "braking",
@@ -287,20 +286,20 @@ _SKATING_REWARDS = (
 
 
 def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
-    """Env « se relever sur rollers » : départ au sol, cible = debout sur roues."""
+    """"Stand up on rollers" env: start on the ground, target = standing on wheels."""
     cfg = make_microduck_velocity_rollers_env_cfg(play=play)
 
     cfg.episode_length_s = EPISODE_LENGTH_S
 
-    # ── Récompenses de patinage retirées ─────────────────────────────────────
+    # ── Skating rewards removed ──────────────────────────────────────────────
     for name in _SKATING_REWARDS:
         cfg.rewards.pop(name, None)
 
-    # ── Commande : slot twist neutralisé (≈ 0) ───────────────────────────────
-    # L'env roller installe un RelativeHeadingVelocityCommandCfg (cmd[2] = erreur
-    # de cap calculée en interne). Ici on ne pilote rien : on repasse au
-    # command-only neutralisé, comme standup. Les slots head_pose (4) et
-    # body_pose (6) restent zero-paddés → parité d'obs 61D préservée.
+    # ── Command: twist slot neutralized (≈ 0) ────────────────────────────────
+    # The roller env installs a RelativeHeadingVelocityCommandCfg (cmd[2] =
+    # heading error computed internally). Here we steer nothing: we go back to
+    # the neutralized command-only variant, like standup. The head_pose (4) and
+    # body_pose (6) slots stay zero-padded → 61D obs parity preserved.
     command = cfg.commands["twist"]
     command.rel_standing_envs = 0.0
     command.rel_heading_envs  = 0.0
@@ -313,22 +312,22 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
     command.ranges.ang_vel_z = (-0.05, 0.05)
     cfg.commands["twist"] = microduck_mdp.VelocityCommandCommandOnlyCfg(**vars(command))
 
-    # ── Robustesse numérique (même choix que roller_slope) ───────────────────
-    # Un contact rare (~1/25M pas) fait diverger le free-joint en NaN : on
-    # assainit l'obs (→ 0) pour ne pas tuer l'entraînement, l'env fautif se reset
-    # au pas suivant.
+    # ── Numerical robustness (same choice as roller_slope) ───────────────────
+    # A rare contact (~1 in 25M steps) makes the free joint diverge to NaN: we
+    # sanitize the obs (→ 0) so training is not killed, and the offending env
+    # resets on the next step.
     for grp in ("actor", "critic"):
         cfg.observations[grp].nan_policy = "sanitize"
 
     return cfg
 
 
-# ── Config du runner RL — identique à standup ─────────────────────────────────
+# ── RL runner config — identical to standup ───────────────────────────────────
 MicroduckRollerStandUpRlCfg = RslRlOnPolicyRunnerCfg(
     actor=RslRlModelCfg(
         hidden_dims=(512, 256, 128),
         activation="elu",
-        obs_normalization=True,  # le normaliseur DOIT être baké dans l'ONNX par export.py
+        obs_normalization=True,  # the normalizer MUST be baked into the ONNX by export.py
         distribution_cfg={
             "class_name": "GaussianDistribution",
             "init_std": 1.0,
@@ -353,8 +352,8 @@ MicroduckRollerStandUpRlCfg = RslRlOnPolicyRunnerCfg(
         lam=0.95,
         desired_kl=0.01,
         max_grad_norm=1.0,
-        # Symétrie OFF : SYMMETRY_CFG est câblé pour l'ancien layout 51D et casse
-        # sur le 61D (même situation que tous les envs v1.5+).
+        # Symmetry OFF: SYMMETRY_CFG is wired for the old 51D layout and breaks
+        # on the 61D one (same situation as every v1.5+ env).
         symmetry_cfg=None,
     ),
     wandb_project="mjlab_microduck",
@@ -366,9 +365,9 @@ MicroduckRollerStandUpRlCfg = RslRlOnPolicyRunnerCfg(
 )
 ```
 
-- [ ] **Step 4 : Enregistrer la tâche**
+- [ ] **Step 4: Register the task**
 
-Dans `src/mjlab_microduck/tasks/__init__.py`, ajouter l'import **après** le bloc d'import de `microduck_roller_slope_env_cfg` :
+In `src/mjlab_microduck/tasks/__init__.py`, add the import **after** the `microduck_roller_slope_env_cfg` import block:
 
 ```python
 from .microduck_roller_standup_env_cfg import (
@@ -377,10 +376,10 @@ from .microduck_roller_standup_env_cfg import (
 )
 ```
 
-Puis, tout à la fin du fichier (après l'enregistrement de `Mjlab-RollerSlope-Flat-MicroDuck`) :
+Then, at the very end of the file (after the `Mjlab-RollerSlope-Flat-MicroDuck` registration):
 
 ```python
-# Roller STANDUP — se relever sur rollers (policy dédiée, départ au sol).
+# Roller STANDUP — standing up on rollers (dedicated policy, starts on the ground).
 register_mjlab_task(
     task_id="Mjlab-RollerStandUp-Flat-MicroDuck",
     env_cfg=make_microduck_roller_standup_env_cfg(),
@@ -391,21 +390,21 @@ register_mjlab_task(
 print("✓ RollerStandUp task registered: Mjlab-RollerStandUp-Flat-MicroDuck")
 ```
 
-- [ ] **Step 5 : Lancer les tests pour vérifier qu'ils passent**
+- [ ] **Step 5: Run the tests to verify they pass**
 
 ```bash
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
-Attendu : 10 passed.
+Expected: 10 passed.
 
-Si `test_obs_parity_with_roller_env` échoue, c'est que quelque chose a touché aux observations — le corriger avant de continuer, c'est la contrainte dure du projet.
+If `test_obs_parity_with_roller_env` fails, something has touched the observations — fix it before continuing; that is the project's hard constraint.
 
-- [ ] **Step 6 : Vérifier qu'aucun autre test ne régresse**
+- [ ] **Step 6: Check that no other test regresses**
 
 ```bash
 uv run --with pytest pytest tests/ -q
 ```
-Attendu : `4 failed, 56 passed` — les 4 échecs sont ceux, pré-existants, de `tests/test_wheel_glide.py` (la suite était à `4 failed, 46 passed` avant ce travail). Aucun autre échec.
+Expected: `4 failed, 56 passed` — the 4 failures are the pre-existing ones in `tests/test_wheel_glide.py` (the suite was at `4 failed, 46 passed` before this work). No other failure.
 
 - [ ] **Step 7 : Commit**
 
@@ -413,32 +412,32 @@ Attendu : `4 failed, 56 passed` — les 4 échecs sont ceux, pré-existants, de 
 git add src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py \
         src/mjlab_microduck/tasks/__init__.py \
         tests/test_roller_standup_cfg.py
-git commit -m "roller-standup: squelette de l'env (dérivé roller, twist neutralisé)"
+git commit -m "roller-standup: env skeleton (derived from roller, neutralized twist)"
 ```
 
 ---
 
-## Task 2 : Récompenses de relevé + verrou des indices de joints
+## Task 2: Standup rewards + joint-index lock-in
 
 **Files:**
 - Modify: `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`
 - Test: `tests/test_roller_standup_cfg.py`
 
 **Interfaces:**
-- Consumes: de la Task 1 — `make_microduck_roller_standup_env_cfg`, `ROLLER_STAND_Z`, `ROLLER_PRONE_Z`, `_LEG_JOINTS`, `_NECK_JOINTS`, `_WHEEL_JOINTS`. De `mdp.py` (existant, non modifié) : `pose_target_match(target_overrides, asset_cfg, std, joint_indices)`, `pose_l1_penalty(target_overrides, asset_cfg, joint_indices)`, `height_target_gaussian(target_height, asset_cfg, std)`, `height_l1_penalty(target_height, asset_cfg)`, `com_upward_velocity(asset_cfg, max_height)`, `trunk_vertical_accel_penalty(asset_cfg)`, `body_upright_linear(asset_cfg)`, `upright_gaussian_at_height(std, height_low, height_high, asset_cfg)`, `standing_composite_score(target_height, height_std, upright_std, pose_std, joint_indices, target_overrides, asset_cfg)`, `joint_torque_rate_l2()`.
-- Produces: les termes de récompense `pose_stand_legs`, `pose_stand_l1`, `height_stand`, `height_stand_sharp`, `height_stand_l1`, `com_upward_velocity`, `gentle_rise`, `upright_linear`, `upright_sharp`, `standing_composite`, `joint_torque_rate_l2` dans `cfg.rewards`.
+- Consumes: from Task 1 — `make_microduck_roller_standup_env_cfg`, `ROLLER_STAND_Z`, `ROLLER_PRONE_Z`, `_LEG_JOINTS`, `_NECK_JOINTS`, `_WHEEL_JOINTS`. From `mdp.py` (existing, unmodified): `pose_target_match(target_overrides, asset_cfg, std, joint_indices)`, `pose_l1_penalty(target_overrides, asset_cfg, joint_indices)`, `height_target_gaussian(target_height, asset_cfg, std)`, `height_l1_penalty(target_height, asset_cfg)`, `com_upward_velocity(asset_cfg, max_height)`, `trunk_vertical_accel_penalty(asset_cfg)`, `body_upright_linear(asset_cfg)`, `upright_gaussian_at_height(std, height_low, height_high, asset_cfg)`, `standing_composite_score(target_height, height_std, upright_std, pose_std, joint_indices, target_overrides, asset_cfg)`, `joint_torque_rate_l2()`.
+- Produces: the reward terms `pose_stand_legs`, `pose_stand_l1`, `height_stand`, `height_stand_sharp`, `height_stand_l1`, `com_upward_velocity`, `gentle_rise`, `upright_linear`, `upright_sharp`, `standing_composite`, `joint_torque_rate_l2` in `cfg.rewards`.
 
-- [ ] **Step 1 : Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Ajouter à la fin de `tests/test_roller_standup_cfg.py` :
+Add to the end of `tests/test_roller_standup_cfg.py`:
 
 ```python
 def test_joint_indices_match_actual_roller_model():
-    """Verrou : les roues passives sont intercalées dans l'ordre des joints.
+    """Lock-in: the passive wheels are interleaved in the joint ordering.
 
-    Réutiliser les indices du standup ([0-4, 9-13]) donnerait des récompenses
-    qui pointent sur des roues. Ce test compile le vrai MjSpec du robot rollers
-    et vérifie les noms aux indices utilisés. Pur CPU, pas de sim.
+    Reusing standup's indices ([0-4, 9-13]) would give rewards that point at
+    wheels. This test compiles the real MjSpec of the roller robot and checks the
+    names at the indices used. Pure CPU, no sim.
     """
     import mujoco
 
@@ -466,7 +465,7 @@ def test_joint_indices_match_actual_roller_model():
     assert [articulated[i] for i in _WHEEL_JOINTS] == [
         "passive_LF_wheel", "passive_LR_wheel", "passive_RF_wheel", "passive_RR_wheel",
     ]
-    # Aucun recouvrement, et les trois listes couvrent tous les joints.
+    # No overlap, and the three lists cover every joint.
     assert len(set(_LEG_JOINTS) | set(_NECK_JOINTS) | set(_WHEEL_JOINTS)) == len(articulated)
 
 
@@ -486,8 +485,8 @@ def test_recovery_rewards_present_with_expected_weights():
         "joint_torque_rate_l2": -2e-3,
     }
     for name, weight in expected.items():
-        assert name in cfg.rewards, f"récompense de relevé manquante : {name}"
-        assert cfg.rewards[name].weight == weight, f"poids inattendu sur {name}"
+        assert name in cfg.rewards, f"missing standup reward: {name}"
+        assert cfg.rewards[name].weight == weight, f"unexpected weight on {name}"
 
 
 def test_recovery_rewards_use_roller_heights_not_walker_heights():
@@ -497,14 +496,14 @@ def test_recovery_rewards_use_roller_heights_not_walker_heights():
     )
 
     cfg = make_microduck_roller_standup_env_cfg()
-    assert ROLLER_STAND_Z == 0.138  # PAS le 0.115 du modèle sans roues
+    assert ROLLER_STAND_Z == 0.138  # NOT the 0.115 of the model without wheels
     for name in ("height_stand", "height_stand_sharp", "height_stand_l1"):
         assert cfg.rewards[name].params["target_height"] == ROLLER_STAND_Z
     assert cfg.rewards["standing_composite"].params["target_height"] == ROLLER_STAND_Z
-    # com_upward_velocity se coupe juste AU-DESSUS de la cible (10 mm de marge),
-    # sinon la policy se gare à l'altitude de coupure sans finir la montée.
+    # com_upward_velocity cuts off just ABOVE the target (10 mm of margin),
+    # otherwise the policy parks at the cutoff altitude without finishing the rise.
     assert cfg.rewards["com_upward_velocity"].params["max_height"] == ROLLER_STAND_Z + 0.010
-    # upright_sharp est gatée entre le repos au sol et la station debout.
+    # upright_sharp is gated between the ground rest height and the standing height.
     assert cfg.rewards["upright_sharp"].params["height_low"] == ROLLER_PRONE_Z
     assert cfg.rewards["upright_sharp"].params["height_high"] == ROLLER_STAND_Z
 
@@ -515,13 +514,13 @@ def test_pose_rewards_target_legs_only_at_roller_indices():
     cfg = make_microduck_roller_standup_env_cfg()
     for name in ("pose_stand_legs", "pose_stand_l1", "standing_composite"):
         assert cfg.rewards[name].params["joint_indices"] == _LEG_JOINTS
-        # target_overrides=None → la cible est HOME (default_joint_pos).
+        # target_overrides=None → the target is HOME (default_joint_pos).
         assert cfg.rewards[name].params["target_overrides"] is None
 
 
 def test_trunk_asset_cfgs_are_distinct_objects():
-    """mjlab résout et MUTE les SceneEntityCfg en place : un objet partagé entre
-    plusieurs termes provoque des indices périmés. Chaque terme doit avoir le sien.
+    """mjlab resolves and MUTATES SceneEntityCfg in place: an object shared across
+    several terms causes stale indices. Each term must have its own.
     """
     cfg = make_microduck_roller_standup_env_cfg()
     names = (
@@ -530,30 +529,30 @@ def test_trunk_asset_cfgs_are_distinct_objects():
         "upright_sharp", "standing_composite",
     )
     seen = [id(cfg.rewards[n].params["asset_cfg"]) for n in names]
-    assert len(set(seen)) == len(seen), "asset_cfg partagé entre plusieurs termes"
+    assert len(set(seen)) == len(seen), "asset_cfg shared across several terms"
 ```
 
-- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
-Attendu : `test_joint_indices_match_actual_roller_model` **passe** (les constantes de la Task 1 sont déjà correctes — c'est un verrou de régression, pas un test rouge) ; les 4 autres échouent avec `KeyError: 'pose_stand_legs'` ou `assert 'pose_stand_legs' in cfg.rewards`.
+Expected: `test_joint_indices_match_actual_roller_model` **passes** (Task 1's constants are already correct — it is a regression lock-in, not a red test); the other 4 fail with `KeyError: 'pose_stand_legs'` or `assert 'pose_stand_legs' in cfg.rewards`.
 
-- [ ] **Step 3 : Ajouter les récompenses de relevé**
+- [ ] **Step 3: Add the standup rewards**
 
-Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le bloc « Robustesse numérique » et **avant** le `return cfg` :
+In `microduck_roller_standup_env_cfg.py`, insert this block **after** the "Numerical robustness" block and **before** the `return cfg`:
 
 ```python
-    # ── Récompenses de relevé — transplant du standup, remappé ───────────────
-    # Les poids viennent des itérations documentées dans
-    # microduck_standup_env_cfg.py : ne les retoucher qu'avec une raison. Seuls
-    # les indices de joints et les deux hauteurs changent ici.
-    # NB : un SceneEntityCfg NEUF par terme — mjlab les résout et les mute en
-    # place, un objet partagé donne des indices périmés.
+    # ── Standup rewards — transplanted from standup, remapped ────────────────
+    # The weights come from the iterations documented in
+    # microduck_standup_env_cfg.py: only touch them with a reason. Only the
+    # joint indices and the two heights change here.
+    # NB: a FRESH SceneEntityCfg per term — mjlab resolves and mutates them in
+    # place, so a shared object yields stale indices.
 
-    # Pose cible = HOME (target_overrides=None), JAMBES seulement : le cou et la
-    # tête sont tenus par neck_joint_pos_l2 (hérité), qui résout par NOM.
+    # Target pose = HOME (target_overrides=None), LEGS only: the neck and head
+    # are held by neck_joint_pos_l2 (inherited), which resolves by NAME.
     cfg.rewards["pose_stand_legs"] = RewardTermCfg(
         func=microduck_mdp.pose_target_match,
         weight=8.0,
@@ -563,7 +562,7 @@ Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le bloc 
             "target_overrides": None,
         },
     )
-    # Bootstrap L1 : gradient constant même loin de HOME (la gaussienne sature).
+    # L1 bootstrap: constant gradient even far from HOME (the gaussian saturates).
     cfg.rewards["pose_stand_l1"] = RewardTermCfg(
         func=microduck_mdp.pose_l1_penalty,
         weight=5.0,
@@ -573,10 +572,10 @@ Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le bloc 
         },
     )
 
-    # Hauteur en trois couches : gaussienne large (tire depuis le sol),
-    # gaussienne étroite (force les derniers cm, là où la large est saturée),
-    # et L1 fort qui rend « rester par terre » net NÉGATIF — sans lui, la policy
-    # se contente de l'optimum paresseux « immobile au sol ».
+    # Height in three layers: wide gaussian (pulls up from the ground), narrow
+    # gaussian (forces the last few cm, where the wide one is saturated), and a
+    # strong L1 that makes "stay on the ground" net NEGATIVE — without it the
+    # policy settles for the lazy optimum "motionless on the floor".
     cfg.rewards["height_stand"] = RewardTermCfg(
         func=microduck_mdp.height_target_gaussian,
         weight=4.0,
@@ -604,10 +603,10 @@ Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le bloc 
         },
     )
 
-    # Paye le MOUVEMENT de montée, pas seulement la destination : sans ça,
-    # « rester assis en collectant la pose partielle » domine. La coupure est
-    # 10 mm AU-DESSUS de la cible, sinon la policy se gare à l'altitude de
-    # coupure et ne finit pas la montée.
+    # Pays for the UPWARD MOTION, not just the destination: without it,
+    # "sit still and farm the partial pose reward" dominates. The cutoff is
+    # 10 mm ABOVE the target, otherwise the policy parks at the cutoff altitude
+    # and never finishes the rise.
     cfg.rewards["com_upward_velocity"] = RewardTermCfg(
         func=microduck_mdp.com_upward_velocity,
         weight=3.0,
@@ -616,19 +615,19 @@ Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le bloc 
             "max_height": ROLLER_STAND_Z + 0.010,
         },
     )
-    # Montée douce : pénalise |a_z|. Compatible avec com_upward_velocity — une
-    # vitesse verticale constante collecte l'une ET a a_z = 0 → les deux
-    # pressions sélectionnent ensemble une montée lisse à vitesse constante.
+    # Gentle rise: penalizes |a_z|. Compatible with com_upward_velocity — a
+    # constant vertical velocity collects the latter AND has a_z = 0 → the two
+    # pressures jointly select a smooth constant-speed rise.
     cfg.rewards["gentle_rise"] = RewardTermCfg(
         func=microduck_mdp.trunk_vertical_accel_penalty,
         weight=-0.02,
         params={"asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",))},
     )
 
-    # Tronc vertical en deux couches : cos(tilt) a un fort gradient quand on est
-    # couché mais s'essouffle près de la verticale ; la gaussienne serrée gatée
-    # en hauteur prend le relais et tue le penché-arrière (mode d'échec du
-    # standup : basculer en arrière en tendant les jambes).
+    # Trunk uprightness in two layers: cos(tilt) has a strong gradient while
+    # lying down but runs out of steam near vertical; the tight height-gated
+    # gaussian takes over and kills the backward lean (standup's failure mode:
+    # tipping backward while extending the legs).
     cfg.rewards["upright_linear"] = RewardTermCfg(
         func=microduck_mdp.body_upright_linear,
         weight=6.0,
@@ -645,11 +644,11 @@ Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le bloc 
         },
     )
 
-    # Score MULTIPLICATIF hauteur × verticalité × pose : comme les facteurs se
-    # multiplient, être bon sur 2 critères sur 3 ne rapporte rien → casse les
-    # compromis « penché à la bonne hauteur » que les récompenses additives
-    # laissent passer. Stds volontairement LARGES pour rester visible pendant la
-    # montée (des stds serrées donnaient un score ~5e-5, donc zéro gradient).
+    # MULTIPLICATIVE score height × uprightness × pose: since the factors
+    # multiply, being good on 2 criteria out of 3 pays nothing → it breaks the
+    # "leaning at the right height" compromises that additive rewards let
+    # through. Stds deliberately WIDE so the score stays visible during the rise
+    # (tight stds gave a score of ~5e-5, i.e. zero gradient).
     cfg.rewards["standing_composite"] = RewardTermCfg(
         func=microduck_mdp.standing_composite_score,
         weight=15.0,
@@ -664,52 +663,52 @@ Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le bloc 
         },
     )
 
-    # Anti-jitter : pénalise la VARIATION de couple, pas son amplitude ni la
-    # rotation du tronc → amortit la tremblote sans bloquer le retournement.
-    # Le standup l'a identifié comme le seul amortisseur qui ne tue pas le
-    # relevé depuis le dos.
+    # Anti-jitter: penalizes torque RATE, not its magnitude nor trunk rotation
+    # → damps the shakes without blocking the roll-over.
+    # standup identified this as the only damper that does not kill the rise
+    # from the back.
     cfg.rewards["joint_torque_rate_l2"] = RewardTermCfg(
         func=microduck_mdp.joint_torque_rate_l2,
         weight=-2e-3,
     )
 ```
 
-- [ ] **Step 4 : Lancer les tests pour vérifier qu'ils passent**
+- [ ] **Step 4: Run the tests to verify they pass**
 
 ```bash
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
-Attendu : 15 passed.
+Expected: 15 passed.
 
 - [ ] **Step 5 : Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py \
         tests/test_roller_standup_cfg.py
-git commit -m "roller-standup: recompenses de relevé + verrou des indices de joints"
+git commit -m "roller-standup: standup rewards + joint-index lock-in"
 ```
 
 ---
 
-## Task 3 : Départ au sol — reset, suppression de `fell_over`, curriculum des poses
+## Task 3: Starting on the ground — reset, removing `fell_over`, the pose curriculum
 
 **Files:**
 - Modify: `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`
 - Test: `tests/test_roller_standup_cfg.py`
 
 **Interfaces:**
-- Consumes: `microduck_mdp.set_random_ground_state(env, env_ids, asset_cfg, face_down_prob, face_up_prob, sitting_prob, standing_prob, prone_z_min, prone_z_max, sitting_z_min, sitting_z_max, standing_z_min, standing_z_max, sitting_joint_overrides, sitting_joint_noise_std, sitting_tilt_max)` et `microduck_mdp.event_param_curriculum(env, env_ids, event_name, param_stages)` — existants, non modifiés.
-- Produces: l'événement `cfg.events["set_ground_state"]` et le curriculum `cfg.curriculum["ground_state_mix"]` ; `cfg.terminations` sans `fell_over`.
+- Consumes: `microduck_mdp.set_random_ground_state(env, env_ids, asset_cfg, face_down_prob, face_up_prob, sitting_prob, standing_prob, prone_z_min, prone_z_max, sitting_z_min, sitting_z_max, standing_z_min, standing_z_max, sitting_joint_overrides, sitting_joint_noise_std, sitting_tilt_max)` and `microduck_mdp.event_param_curriculum(env, env_ids, event_name, param_stages)` — existing, unmodified.
+- Produces: the `cfg.events["set_ground_state"]` event and the `cfg.curriculum["ground_state_mix"]` curriculum; `cfg.terminations` without `fell_over`.
 
-- [ ] **Step 1 : Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Ajouter à la fin de `tests/test_roller_standup_cfg.py` :
+Add to the end of `tests/test_roller_standup_cfg.py`:
 
 ```python
 def test_starts_from_ground_states():
-    # Ventre + dos + debout. Pas de bucket "assis" : il n'existait dans standup
-    # que pour le hand-off depuis la policy sit, dont il n'y a pas d'équivalent
-    # roller — et ses sitting_joint_overrides sont des indices du modèle SANS roues.
+    # Face down + face up + standing. No "sitting" bucket: in standup it existed
+    # only for the hand-off from the sit policy, which has no roller equivalent —
+    # and its sitting_joint_overrides are indices of the model WITHOUT wheels.
     cfg = make_microduck_roller_standup_env_cfg()
     assert "set_ground_state" in cfg.events
     params = cfg.events["set_ground_state"].params
@@ -717,26 +716,26 @@ def test_starts_from_ground_states():
     assert params["sitting_joint_overrides"] is None
     assert params["face_down_prob"] > 0.0
     assert params["standing_prob"] > 0.0
-    # face_up (le dos) démarre à 0 : introduit tard par le curriculum.
+    # face_up starts at 0: introduced late by the curriculum.
     assert params["face_up_prob"] == 0.0
 
 
 def test_ground_state_heights_are_roller_specific():
     cfg = make_microduck_roller_standup_env_cfg()
     params = cfg.events["set_ground_state"].params
-    # Repos au sol : géométrie identique aux deux modèles (c'est la coque du
-    # tronc qui touche, pas les pieds) → plages du standup réutilisées.
+    # Ground rest: identical geometry on both models (it is the trunk shell
+    # that touches, not the feet) → standup's ranges reused.
     assert (params["prone_z_min"], params["prone_z_max"]) == (0.05, 0.09)
-    # [Corrigé à 0.076 après la revue finale — voir docs/superpowers/specs/2026-08-04-roller-standup-design.md]
-    # Debout : hauteur ROLLER (+23 mm vs le modèle sans roues, qui est à 0.11–0.12).
+    # [Corrected to 0.076 after the final review — see docs/superpowers/specs/2026-08-04-roller-standup-design.md]
+    # Standing: ROLLER height (+23 mm vs the model without wheels, at 0.11–0.12).
     assert params["standing_z_min"] == 0.134
     assert params["standing_z_max"] == 0.144
     assert params["standing_z_min"] < 0.138 < params["standing_z_max"]
 
 
 def test_ground_state_event_runs_after_base_reset():
-    # set_ground_state écrase la pose posée par reset_base / reset_robot_joints :
-    # l'ordre des événements suit l'ordre d'insertion, il doit donc venir APRÈS.
+    # set_ground_state overwrites the pose set by reset_base / reset_robot_joints:
+    # event order follows insertion order, so it must come AFTER them.
     cfg = make_microduck_roller_standup_env_cfg()
     order = list(cfg.events.keys())
     assert order.index("set_ground_state") > order.index("reset_base")
@@ -744,8 +743,8 @@ def test_ground_state_event_runs_after_base_reset():
 
 
 def test_no_fall_termination():
-    # Le robot DÉMARRE tombé : une terminaison sur inclinaison tuerait l'épisode
-    # au premier pas. nan_state (hérité) reste, lui.
+    # The robot STARTS fallen: a tilt termination would kill the episode on the
+    # first step. nan_state (inherited) does stay.
     cfg = make_microduck_roller_standup_env_cfg()
     assert "fell_over" not in cfg.terminations
     assert "nan_state" in cfg.terminations
@@ -756,16 +755,17 @@ def test_ground_state_curriculum_ramps_easy_to_hard():
     assert "ground_state_mix" in cfg.curriculum
     stages = cfg.curriculum["ground_state_mix"].params["param_stages"]
     assert cfg.curriculum["ground_state_mix"].params["event_name"] == "set_ground_state"
-    # Les steps sont croissants et démarrent à 0.
+    # The steps are increasing and start at 0.
     steps = [s["step"] for s in stages]
     assert steps[0] == 0 and steps == sorted(steps) and len(set(steps)) == len(steps)
-    # Le dos (face_up) est introduit tard puis croît de façon monotone.
+    # face_up is introduced late and then grows monotonically.
     face_up = [s["params"]["face_up_prob"] for s in stages]
     assert face_up[0] == 0.0
     assert face_up == sorted(face_up)
     assert face_up[-1] >= 0.35
-    # Chaque palier est une distribution valide, et le "déjà debout" ne disparaît
-    # jamais (sinon la policy se relève puis retombe faute d'apprendre à tenir).
+    # Every stage is a valid distribution, and "already standing" never
+    # disappears (otherwise the policy stands up then falls back, never learning
+    # to hold).
     for stage in stages:
         p = stage["params"]
         total = (
@@ -777,61 +777,61 @@ def test_ground_state_curriculum_ramps_easy_to_hard():
         assert p["standing_prob"] > 0.0
 ```
 
-- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
-Attendu : les 5 nouveaux échouent — `assert 'set_ground_state' in cfg.events` (KeyError / AssertionError), `assert 'fell_over' not in cfg.terminations`, `assert 'ground_state_mix' in cfg.curriculum`.
+Expected: the 5 new ones fail — `assert 'set_ground_state' in cfg.events` (KeyError / AssertionError), `assert 'fell_over' not in cfg.terminations`, `assert 'ground_state_mix' in cfg.curriculum`.
 
-- [ ] **Step 3 : Ajouter le reset au sol, la suppression de `fell_over` et le curriculum**
+- [ ] **Step 3: Add the ground reset, the removal of `fell_over` and the curriculum**
 
-Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** les récompenses de relevé et **avant** le `return cfg` :
+In `microduck_roller_standup_env_cfg.py`, insert this block **after** the standup rewards and **before** the `return cfg`:
 
 ```python
-    # ── Départ AU SOL : à plat ventre / à plat dos / déjà debout ─────────────
-    # Ajouté en DERNIER dans cfg.events : l'ordre d'exécution suit l'ordre
-    # d'insertion, et ce terme doit écraser la pose posée par reset_base /
-    # reset_robot_joints.
-    # Le bucket « déjà debout » n'est pas décoratif : sans lui la policy apprend
-    # à monter mais pas à TENIR, et elle retombe juste après s'être relevée.
-    # Pas de bucket « assis » → aucun sitting_joint_overrides à remapper (ceux du
-    # standup sont des indices du modèle SANS roues).
-    # Les probabilités ci-dessous = palier 0 du curriculum ground_state_mix.
+    # ── Start ON THE GROUND: face down / face up / already standing ─────────
+    # Added LAST in cfg.events: execution order follows insertion order, and this
+    # term must overwrite the pose set by reset_base / reset_robot_joints.
+    # The "already standing" bucket is not decorative: without it the policy
+    # learns to rise but not to HOLD, and it falls right back down after standing
+    # up.
+    # No "sitting" bucket → no sitting_joint_overrides to remap (standup's are
+    # indices of the model WITHOUT wheels).
+    # The probabilities below = stage 0 of the ground_state_mix curriculum.
     cfg.events["set_ground_state"] = EventTermCfg(
         func=microduck_mdp.set_random_ground_state,
         mode="reset",
         params={
-            "face_down_prob": 0.50,   # ventre (+90° de pitch)
-            "face_up_prob":   0.00,   # dos — le plus dur, introduit tard
+            "face_down_prob": 0.50,   # face down (+90° of pitch)
+            "face_up_prob":   0.00,   # face up — hardest, introduced late
             "sitting_prob":   0.00,
             "standing_prob":  0.50,
             "sitting_joint_overrides": None,
-            # Repos au sol : mesuré à 0.075 (ventre) / 0.048 (dos), identique aux
-            # deux modèles — c'est la coque du tronc qui touche, pas les pieds.
+            # Ground rest: measured at 0.075 (face down) / 0.048 (face up), identical
+            # on both models — it is the trunk shell that touches, not the feet.
             "prone_z_min":    0.05,
-            # [Corrigé à 0.076 après la revue finale — voir docs/superpowers/specs/2026-08-04-roller-standup-design.md]
+            # [Corrected to 0.076 after the final review — see docs/superpowers/specs/2026-08-04-roller-standup-design.md]
             "prone_z_max":    0.09,
-            # Debout sur roues : ROLLER_STAND_Z = 0.138 (contre 0.11–0.12 sans roues).
+            # Standing on wheels: ROLLER_STAND_Z = 0.138 (vs 0.11–0.12 without wheels).
             "standing_z_min": 0.134,
             "standing_z_max": 0.144,
-            # Bruit de pitch/roll au départ. Attention : dans
-            # set_random_ground_state le bucket « debout » réutilise le quaternion
-            # du bucket « assis », donc ce bruit s'applique AUSSI aux départs
-            # debout — c'est voulu (pas de sur-apprentissage du parfaitement droit).
+            # Pitch/roll noise at start. Careful: in set_random_ground_state the
+            # "standing" bucket reuses the "sitting" bucket's quaternion, so this
+            # noise applies to standing starts TOO — that is intended (no
+            # overfitting to perfectly upright).
             "sitting_tilt_max": math.radians(10),
         },
     )
 
-    # Le robot DÉMARRE tombé → la terminaison sur inclinaison n'a aucun sens ici
-    # (elle tuerait l'épisode au premier pas). nan_state, hérité, reste.
+    # The robot STARTS fallen → the tilt termination makes no sense here (it
+    # would kill the episode on the first step). nan_state, inherited, stays.
     cfg.terminations.pop("fell_over", None)
 
-    # Curriculum des poses de départ, easy → hard. Avec un mélange plat dès le
-    # départ, la policy optimise la majorité facile et laisse le dos sous-entraîné
-    # (leçon du standup : il gelait en « ne rien faire » sur cette pose). On
-    # introduit donc debout+ventre d'abord, le dos tard, et on biaise vers les
-    # poses dures à la fin pour qu'elles reçoivent le plus d'entraînement.
+    # Start-pose curriculum, easy → hard. With a flat mix from the start, the
+    # policy optimizes the easy majority and leaves the face-up case undertrained
+    # (standup's lesson: it froze into "do nothing" on that pose). So we
+    # introduce standing+face-down first, face-up late, and bias toward the hard
+    # poses at the end so they get the most training.
     cfg.curriculum["ground_state_mix"] = CurriculumTermCfg(
         func=microduck_mdp.event_param_curriculum,
         params={
@@ -854,12 +854,12 @@ Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** les réc
     )
 ```
 
-- [ ] **Step 4 : Lancer les tests pour vérifier qu'ils passent**
+- [ ] **Step 4: Run the tests to verify they pass**
 
 ```bash
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
-Attendu : 20 passed.
+Expected: 20 passed.
 
 - [ ] **Step 5 : Commit**
 
@@ -871,28 +871,28 @@ git commit -m "roller-standup: depart au sol (ventre/dos/debout) + curriculum de
 
 ---
 
-## Task 4 : Curricula — friction de roulement inversée, poussées, action_rate
+## Task 4: Curricula — reversed rolling friction, pushes, action_rate
 
 **Files:**
 - Modify: `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`
 - Test: `tests/test_roller_standup_cfg.py`
 
 **Interfaces:**
-- Consumes: `microduck_mdp.wheel_friction_curriculum(env, env_ids, event_name, ranges_stages)`, `microduck_mdp.push_curriculum(env, env_ids, event_name, push_stages)`, `microduck_mdp.reward_weight(env, env_ids, reward_name, weight_stages)` — existants, non modifiés. Événements hérités de l'env roller : `randomize_wheel_friction`, `push_robot`.
-- Produces: `cfg.curriculum["wheel_friction"]` (décroissant), `cfg.curriculum["push_magnitude"]`, `cfg.curriculum["action_rate_weight"]` (remplacé).
+- Consumes: `microduck_mdp.wheel_friction_curriculum(env, env_ids, event_name, ranges_stages)`, `microduck_mdp.push_curriculum(env, env_ids, event_name, push_stages)`, `microduck_mdp.reward_weight(env, env_ids, reward_name, weight_stages)` — existing, unmodified. Events inherited from the roller env: `randomize_wheel_friction`, `push_robot`.
+- Produces: `cfg.curriculum["wheel_friction"]` (decreasing), `cfg.curriculum["push_magnitude"]`, `cfg.curriculum["action_rate_weight"]` (replaced).
 
-- [ ] **Step 1 : Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Ajouter à la fin de `tests/test_roller_standup_cfg.py` :
+Add to the end of `tests/test_roller_standup_cfg.py`:
 
 ```python
 def test_wheel_friction_curriculum_is_decreasing():
-    """La pièce nouvelle : roues FREINÉES → LIBRES.
+    """The new piece: BRAKED → FREE wheels.
 
-    Les roues roulent, donc il n'y a aucune adhérence longitudinale pour pousser
-    sur le sol. On bootstrappe avec des roulements quasi bloqués (le relevé se
-    fait comme avec des pieds) puis on rampe vers la vraie valeur. L'env roller,
-    lui, fait MONTER cette friction (0 → 0.0015) : le sens est bien inversé ici.
+    The wheels roll, so there is no longitudinal traction to push against the
+    ground. We bootstrap with near-locked bearings (the rise happens as if on
+    feet), then ramp toward the real value. The roller env, by contrast, ramps
+    this friction UP (0 → 0.0015): the direction really is reversed here.
     """
     cfg = make_microduck_roller_standup_env_cfg()
     stages = cfg.curriculum["wheel_friction"].params["ranges_stages"]
@@ -902,27 +902,27 @@ def test_wheel_friction_curriculum_is_decreasing():
     assert steps[0] == 0 and steps == sorted(steps) and len(set(steps)) == len(steps)
 
     lows = [s["ranges"][0] for s in stages]
-    assert lows == sorted(lows, reverse=True), "la friction doit DÉCROÎTRE"
-    assert lows[0] >= 0.02, "départ franchement freiné pour bootstrapper le geste"
-    # Arrivée sur la vraie valeur du roulement (celle de l'env roller).
+    assert lows == sorted(lows, reverse=True), "friction must DECREASE"
+    assert lows[0] >= 0.02, "start clearly braked to bootstrap the gesture"
+    # Ends at the real rolling value (the roller env's).
     assert stages[-1]["ranges"] == (0.0015, 0.0015)
     for stage in stages:
         assert stage["ranges"][0] == stage["ranges"][1]
 
 
 def test_wheel_friction_event_starts_at_stage_zero():
-    # Le curriculum n'est évalué qu'à partir du premier pas : sans ça les tout
-    # premiers resets utiliseraient la valeur (0, 0) héritée de l'env roller,
-    # soit des roues LIBRES pendant le bootstrap — exactement l'inverse du but.
+    # The curriculum is only evaluated from the first step onward: without this,
+    # the very first resets would use the (0, 0) value inherited from the roller
+    # env, i.e. FREE wheels during the bootstrap — exactly the opposite of the goal.
     cfg = make_microduck_roller_standup_env_cfg()
     stage0 = cfg.curriculum["wheel_friction"].params["ranges_stages"][0]["ranges"]
     assert cfg.events["randomize_wheel_friction"].params["ranges"] == stage0
 
 
 def test_action_rate_ramp_is_the_standup_one_not_the_roller_one():
-    # L'env roller monte à -2.0 (gait calme) : c'est un bloqueur de mouvement,
-    # il ralentit l'action rapide dont le relevé depuis le dos a besoin. On
-    # reprend la rampe du standup, qui plafonne à -1.0.
+    # The roller env ramps to -2.0 (calm gait): that is a motion blocker, it slows
+    # the fast action the rise from the back needs. We reuse standup's ramp, which
+    # tops out at -1.0.
     cfg = make_microduck_roller_standup_env_cfg()
     weights = [
         s["weight"] for s in cfg.curriculum["action_rate_weight"].params["weight_stages"]
@@ -932,8 +932,8 @@ def test_action_rate_ramp_is_the_standup_one_not_the_roller_one():
 
 
 def test_push_curriculum_ramps_from_zero():
-    # Poussées héritées (±0.2 m/s), mais rampées : une bourrade dès le pas 0
-    # parasite le bootstrap du relevé.
+    # Inherited pushes (±0.2 m/s), but ramped: a shove from step 0 disturbs the
+    # bootstrap of the rise.
     cfg = make_microduck_roller_standup_env_cfg()
     assert "push_robot" in cfg.events
     stages = cfg.curriculum["push_magnitude"].params["push_stages"]
@@ -941,14 +941,14 @@ def test_push_curriculum_ramps_from_zero():
     assert stages[0]["velocity_range"]["x"] == (0.0, 0.0)
     assert stages[-1]["velocity_range"]["x"] == (-0.2, 0.2)
     highs = [s["velocity_range"]["x"][1] for s in stages]
-    assert highs == sorted(highs), "la poussée doit CROÎTRE"
+    assert highs == sorted(highs), "the push must GROW"
 
 
 def test_inherited_dr_curricula_survive():
-    # La DR héritée de l'env roller ne doit pas avoir été perdue en chemin.
+    # The DR inherited from the roller env must not have been lost along the way.
     cfg = make_microduck_roller_standup_env_cfg()
     for name in ("com_range", "head_com_range"):
-        assert name in cfg.curriculum, f"curriculum de DR perdu : {name}"
+        assert name in cfg.curriculum, f"DR curriculum lost: {name}"
     for name in (
         "randomize_com",
         "randomize_head_com",
@@ -958,37 +958,36 @@ def test_inherited_dr_curricula_survive():
         "randomize_wheel_friction",
         "encoder_bias",
     ):
-        assert name in cfg.events, f"événement de DR perdu : {name}"
+        assert name in cfg.events, f"DR event lost: {name}"
 ```
 
-- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
-Attendu : `test_wheel_friction_curriculum_is_decreasing` échoue sur `assert lows == sorted(lows, reverse=True)` (l'env roller monte 0 → 0.0015), `test_wheel_friction_event_starts_at_stage_zero` échoue, `test_action_rate_ramp_is_the_standup_one_not_the_roller_one` échoue sur `[-1.0, -1.5, -2.0] != [-0.4, -0.8, -1.0]`, `test_push_curriculum_ramps_from_zero` échoue sur `KeyError: 'push_magnitude'`. `test_inherited_dr_curricula_survive` passe déjà (vérification de non-régression).
+Expected: `test_wheel_friction_curriculum_is_decreasing` fails on `assert lows == sorted(lows, reverse=True)` (the roller env ramps 0 → 0.0015), `test_wheel_friction_event_starts_at_stage_zero` fails, `test_action_rate_ramp_is_the_standup_one_not_the_roller_one` fails on `[-1.0, -1.5, -2.0] != [-0.4, -0.8, -1.0]`, and `test_push_curriculum_ramps_from_zero` fails on `KeyError: 'push_magnitude'`. `test_inherited_dr_curricula_survive` already passes (a non-regression check).
 
 - [ ] **Step 3 : Remplacer les curricula**
 
-Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le curriculum `ground_state_mix` et **avant** le `return cfg` :
+In `microduck_roller_standup_env_cfg.py`, insert this block **after** the `ground_state_mix` curriculum et **avant** le `return cfg` :
 
 ```python
-    # ── Friction de roulement INVERSÉE : freinées → libres ───────────────────
-    # C'est la seule pièce vraiment nouvelle de cet env, et le cœur de la
-    # difficulté : les roues roulent, donc il n'y a AUCUNE adhérence
-    # longitudinale pour pousser sur le sol. L'env roller fait MONTER cette
-    # friction (0 → 0.0015) ; ici on la fait DESCENDRE, pour bootstrapper le
-    # geste sur un problème facile (roues quasi bloquées ≈ des pieds) avant
-    # d'imposer la physique réelle du roulement.
+    # ── REVERSED rolling friction: braked → free ─────────────────────────────
+    # This is the only genuinely new piece of this env, and the heart of the
+    # difficulty: the wheels roll, so there is NO longitudinal traction to push
+    # against the ground. The roller env ramps this friction UP (0 → 0.0015);
+    # here we ramp it DOWN, to bootstrap the gesture on an easy problem
+    # (near-locked wheels ≈ feet) before imposing the real rolling physics.
     #
-    # DIAGNOSTIC à surveiller : si Episode_Reward/standing_composite s'écroule à
-    # un palier, le geste « pieds adhérents » ne transfère pas aux roues libres
-    # → il faudra guider une technique de patineur (appui genou intermédiaire,
-    # un patin à la fois). C'est un résultat exploitable, pas un échec.
+    # DIAGNOSTIC to watch: if Episode_Reward/standing_composite collapses at a
+    # stage, the "sticky feet" gesture does not transfer to free wheels → we will
+    # have to guide a skater technique (intermediate knee support, one skate at a
+    # time). That is an actionable result, not a failure.
     #
-    # ATTENTION sim2real : seuls les checkpoints d'APRÈS le dernier palier
-    # (iter 4000+) sont candidats au déploiement. Avant, la policy s'appuie sur
-    # une friction de roulement qui n'existe pas sur le vrai robot.
+    # sim2real WARNING: only checkpoints from AFTER the last stage (iter 4000+)
+    # are deployment candidates. Before that, the policy relies on a rolling
+    # friction that does not exist on the real robot.
     _WHEEL_FRICTION_STAGE0 = (0.0500, 0.0500)
     cfg.curriculum["wheel_friction"] = CurriculumTermCfg(
         func=microduck_mdp.wheel_friction_curriculum,
@@ -1003,17 +1002,17 @@ Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le curri
             ],
         },
     )
-    # La valeur de DÉPART de l'événement doit matcher le palier 0 : le curriculum
-    # n'est évalué qu'à partir du premier pas, sinon les tout premiers resets
-    # utiliseraient le (0, 0) hérité de l'env roller — des roues LIBRES pendant
+    # The event's STARTING value must match stage 0: the curriculum is only
+    # evaluated from the first step onward, otherwise the very first resets
+    # would use the (0, 0) inherited from the roller env — FREE wheels during
     # le bootstrap, soit exactement l'inverse du but.
     cfg.events["randomize_wheel_friction"].params["ranges"] = _WHEEL_FRICTION_STAGE0
 
-    # ── action_rate : la rampe du standup, pas celle du roller ───────────────
-    # L'env roller monte à -2.0 pour un gait calme. C'est un bloqueur de
-    # mouvement : il ralentit l'action rapide dont le relevé depuis le dos a
-    # besoin (le standup documente qu'un action_rate trop fort tuait cette
-    # récupération). La douceur est portée ici par joint_torque_rate_l2.
+    # ── action_rate: standup's ramp, not the roller's ────────────────────────
+    # The roller env ramps to -2.0 for a calm gait. That is a motion blocker: it
+    # slows the fast action the rise from the back needs (standup documents that
+    # too strong an action_rate killed that recovery). Smoothness is carried here
+    # by joint_torque_rate_l2.
     cfg.rewards["action_rate_l2"].weight = -0.6
     cfg.curriculum["action_rate_weight"] = CurriculumTermCfg(
         func=microduck_mdp.reward_weight,
@@ -1027,10 +1026,10 @@ Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le curri
         },
     )
 
-    # ── Poussées rampées ────────────────────────────────────────────────────
-    # push_robot est hérité de l'env roller (±0.2 m/s, toutes les 3–6 s) mais
-    # sans curriculum. Une bourrade dès le pas 0 parasite le bootstrap du
-    # relevé : on la fait monter comme le standup.
+    # ── Ramped pushes ───────────────────────────────────────────────────────
+    # push_robot is inherited from the roller env (±0.2 m/s, every 3–6 s) but
+    # without a curriculum. A shove from step 0 disturbs the bootstrap of the
+    # rise: we ramp it up like standup does.
     cfg.curriculum["push_magnitude"] = CurriculumTermCfg(
         func=microduck_mdp.push_curriculum,
         params={
@@ -1047,19 +1046,19 @@ Dans `microduck_roller_standup_env_cfg.py`, insérer ce bloc **après** le curri
     )
 ```
 
-- [ ] **Step 4 : Lancer les tests pour vérifier qu'ils passent**
+- [ ] **Step 4: Run the tests to verify they pass**
 
 ```bash
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
-Attendu : 25 passed.
+Expected: 25 passed.
 
-- [ ] **Step 5 : Vérifier qu'aucun autre test ne régresse**
+- [ ] **Step 5: Check that no other test regresses**
 
 ```bash
 uv run --with pytest pytest tests/ -q
 ```
-Attendu : `4 failed, 71 passed` — uniquement les 4 échecs pré-existants de `tests/test_wheel_glide.py`.
+Expected: `4 failed, 71 passed` — only the 4 pre-existing failures in `tests/test_wheel_glide.py`.
 
 - [ ] **Step 6 : Commit**
 
@@ -1071,19 +1070,19 @@ git commit -m "roller-standup: curriculum de friction de roulement inverse + pou
 
 ---
 
-## Task 5 : Vérification bout-en-bout sur GPU + doc de passation
+## Task 5: End-to-end verification on GPU + handover doc
 
-Les tests des Tasks 1–4 sont **statiques** : ils vérifient la config, pas l'exécution. Ils ne peuvent pas attraper un `joint_indices` hors bornes, un nom de paramètre erroné passé à une fonction mdp, ou un capteur manquant. Cette tâche est le seul endroit où l'env tourne réellement.
+The Task 1–4 tests are **static**: they check the config, not execution. They cannot catch an out-of-bounds `joint_indices`, a wrong parameter name passed to an mdp function, or a missing sensor. This task is the only place where the env actually runs.
 
 **Files:**
 - Create: `docs/roller_standup_policy_summary.md`
 - (aucune modification de code attendue si tout passe)
 
 **Interfaces:**
-- Consumes: la tâche enregistrée `Mjlab-RollerStandUp-Flat-MicroDuck` (Task 1) et l'env complet (Tasks 2–4).
-- Produces: rien de programmatique — un doc de passation et la confirmation que l'env tourne.
+- Consumes: the registered task `Mjlab-RollerStandUp-Flat-MicroDuck` (Task 1) and the complete env (Tasks 2–4).
+- Produces: nothing programmatic — a handover doc and confirmation that the env runs.
 
-- [ ] **Step 1 : Lancer un entraînement très court**
+- [ ] **Step 1: Run a very short training**
 
 ```bash
 uv run train Mjlab-RollerStandUp-Flat-MicroDuck \
@@ -1092,114 +1091,114 @@ uv run train Mjlab-RollerStandUp-Flat-MicroDuck \
   --agent.logger tensorboard
 ```
 
-`--agent.logger tensorboard` évite de polluer wandb avec un run jetable.
+`--agent.logger tensorboard` avoids polluting wandb with a throwaway run.
 
-Attendu : `✓ RollerStandUp task registered: Mjlab-RollerStandUp-Flat-MicroDuck`, puis 3 itérations qui s'exécutent sans exception, avec un tableau de récompenses affichant les termes `pose_stand_legs`, `height_stand`, `standing_composite`, etc.
+Expected: `✓ RollerStandUp task registered: Mjlab-RollerStandUp-Flat-MicroDuck`, then 3 iterations that run without an exception, with a reward table showing the terms `pose_stand_legs`, `height_stand`, `standing_composite`, etc.
 
 Erreurs plausibles et leur cause :
-- `IndexError` sur `joint_pos[:, joint_indices]` → les indices de `_LEG_JOINTS` dépassent le nombre de joints ; relire Task 2.
-- `TypeError: ... unexpected keyword argument` → un nom de paramètre ne correspond pas à la signature de la fonction mdp ; comparer avec le bloc **Interfaces** de la Task 2.
-- `KeyError` sur un nom de capteur → une récompense retirée était la seule à utiliser un capteur, ou une récompense gardée en réclame un absent.
+- `IndexError` on `joint_pos[:, joint_indices]` → the `_LEG_JOINTS` indices exceed the number de joints ; relire Task 2.
+- `TypeError: ... unexpected keyword argument` → a parameter name does not match the mdp function's signature; compare with Task 2's **Interfaces** block.
+- `KeyError` on a sensor name → a removed reward was the only user of a sensor, or a kept reward requires one that is missing.
 
-- [ ] **Step 2 : Vérifier que les récompenses de relevé ne sont pas toutes nulles**
+- [ ] **Step 2: Check that the standup rewards are not all zero**
 
-Dans la sortie de l'étape précédente, vérifier que `Episode_Reward/standing_composite` et `Episode_Reward/height_stand` sont **non nuls**. Une valeur exactement 0.0 sur les trois itérations signale une récompense qui ne se déclenche jamais (mauvais `asset_cfg`, mauvaise hauteur cible).
+In the previous step's output, check that `Episode_Reward/standing_composite` and `Episode_Reward/height_stand` are **non-zero**. A value of exactly 0.0 across all three iterations signals a reward that never fires (wrong `asset_cfg`, wrong target height).
 
-- [ ] **Step 3 : Vérifier visuellement le départ au sol**
+- [ ] **Step 3: Visually check the start on the ground**
 
 ```bash
 uv run play Mjlab-RollerStandUp-Flat-MicroDuck --env.scene.num-envs 16
 ```
 
-Attendu : les robots apparaissent **au sol** (à plat ventre) ou **debout sur leurs roues**, jamais en l'air ni traversant le sol. Aucun robot à plat dos à ce stade — c'est normal, `face_up_prob = 0` au palier 0 du curriculum, et en play le curriculum ne tourne pas.
+Expected: the robots appear **on the ground** (face down) or **standing on their wheels**, never in mid-air and never through the ground. No robot face up at this stage — that is normal: `face_up_prob = 0` at the curriculum's stage 0, and at play time the curriculum does not run.
 
-Si des robots tombent de haut, les plages `prone_z` sont mal réglées ; si un robot traverse le sol, la pose de départ le fait spawner sous le plan.
+If robots drop from a height, the `prone_z` ranges are misconfigured; if a robot goes through the ground, the start pose is spawning it below the plane.
 
-- [ ] **Step 4 : Écrire le doc de passation**
+- [ ] **Step 4: Write the handover doc**
 
-Créer `docs/roller_standup_policy_summary.md`, sur le modèle de `docs/roller_slope_policy_summary.md` :
+Create `docs/roller_standup_policy_summary.md`, modeled on `docs/roller_slope_policy_summary.md` :
 
 ```markdown
-# Policy `roller_standup` — se relever sur rollers
+# Policy `roller_standup` — standing up on rollers
 
-**But** : le microduck (sur rollers) part du sol — à plat ventre ou à plat dos — et se remet **debout sur ses roues**, puis **tient** la station.
+**Goal**: the microduck (on rollers) starts on the ground — face down or face up — and gets back **up on its wheels**, then **holds** the stance.
 
-- **Tâche** : `Mjlab-RollerStandUp-Flat-MicroDuck`
-- **Fichier** : `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`
-- **Base** : dérivée de l'env roller (`velocity_rollers`) → même robot, même physique/DR, **même observation 61D** (interchangeable au runtime, chargeable via `--new-cmd-obs`).
-- **Spec** : `docs/superpowers/specs/2026-08-04-roller-standup-design.md`
-- **Politique aveugle** : pas de scan de terrain ; proprioception + `projected_gravity`.
+- **Task**: `Mjlab-RollerStandUp-Flat-MicroDuck`
+- **File**: `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`
+- **Base**: derived from the roller env (`velocity_rollers`) → same robot, same physics/DR, **same 61D observation** (hot-swappable at runtime, loadable via `--new-cmd-obs`).
+- **Spec**: `docs/superpowers/specs/2026-08-04-roller-standup-design.md`
+- **Blind policy**: no terrain scan; proprioception + `projected_gravity`.
 
-## Hauteurs (mesurées, pas devinées)
+## Heights (measured, not guessed)
 
-| pose | modèle pieds | modèle rollers |
+| pose | feet model | roller model |
 |---|---|---|
-| debout | 0.1172 → `STAND_Z=0.115` sous charge | 0.1407 → **`ROLLER_STAND_Z=0.138`** |
-| à plat ventre (repos) | 0.075 | 0.075 |
-| à plat dos (repos) | 0.048 | 0.048 |
+| standing | 0.1172 → `STAND_Z=0.115` under load | 0.1407 → **`ROLLER_STAND_Z=0.138`** |
+| face down (rest) | 0.075 | 0.075 |
+| face up (rest) | 0.048 | 0.048 |
 
-Les hauteurs de repos au sol sont identiques aux deux modèles : c'est la coque du tronc qui touche, pas les pieds.
+The ground rest heights are identical on both models: it is the trunk shell that touches, not the feet.
 
-## ⚠️ Indices de joints — les roues sont INTERCALÉES
+## ⚠️ Joint indices — the wheels are INTERLEAVED
 
 ```
-0-4   jambe gauche      5-6   roues gauches
-7-10  cou / tête       11-15  jambe droite      16-17  roues droites
+0-4   left leg          5-6   left wheels
+7-10  neck / head      11-15  right leg          16-17  right wheels
 ```
-`_LEG_JOINTS = [0-4, 11-15]`. Les indices du `standup` (`[0-4, 9-13]`) valent pour le modèle **sans** roues et pointeraient sur des roues ici. Verrouillé par `tests/test_roller_standup_cfg.py::test_joint_indices_match_actual_roller_model`.
+`_LEG_JOINTS = [0-4, 11-15]`. The `standup` indices (`[0-4, 9-13]`) hold for the model **without** wheels and would point at wheels here. Locked in by `tests/test_roller_standup_cfg.py::test_joint_indices_match_actual_roller_model`.
 
-## Reset — départ au sol
+## Reset — starting on the ground
 
-`set_random_ground_state` : ventre (`prone_z` 0.05–0.09) / dos / **déjà debout** (`standing_z` 0.134–0.144), ± 10° de bruit en pitch/roll. Pas de bucket « assis ». Le bucket « debout » est nécessaire : sans lui la policy monte mais ne tient pas.
+`set_random_ground_state`: face down (`prone_z` 0.05–0.09) / face up / **already standing** (`standing_z` 0.134–0.144), ± 10° of pitch/roll noise. No "sitting" bucket. The "standing" bucket is necessary: without it the policy rises but does not hold.
 
-**Curriculum `ground_state_mix`** (easy → hard, le dos en dernier) :
+**Curriculum `ground_state_mix`** (easy → hard, face up last):
 
-| iter | debout | ventre | dos |
+| iter | standing | face down | face up |
 |---|---|---|---|
 | 0 | 0.50 | 0.50 | 0.00 |
 | 600 | 0.35 | 0.45 | 0.20 |
 | 1500 | 0.25 | 0.40 | 0.35 |
 | 2500 | 0.20 | 0.40 | 0.40 |
 
-## Récompenses
+## Rewards
 
-Dix termes repris du `standup` avec leurs poids déjà réglés : `pose_stand_legs` (+8), `pose_stand_l1` (+5), `height_stand` (+4, std 0.04), `height_stand_sharp` (+4, std 0.015), `height_stand_l1` (+30), `com_upward_velocity` (+3), `gentle_rise` (−0.02), `upright_linear` (+6), `upright_sharp` (+6), `standing_composite` (+15). Plus `joint_torque_rate_l2` (−2e-3), l'anti-jitter qui n'empêche pas le retournement.
+Ten terms taken from `standup` with their already-tuned weights: `pose_stand_legs` (+8), `pose_stand_l1` (+5), `height_stand` (+4, std 0.04), `height_stand_sharp` (+4, std 0.015), `height_stand_l1` (+30), `com_upward_velocity` (+3), `gentle_rise` (−0.02), `upright_linear` (+6), `upright_sharp` (+6), `standing_composite` (+15). Plus `joint_torque_rate_l2` (−2e-3), the anti-jitter term that does not block the roll-over.
 
-Régularisateurs hérités : `body_ang_vel` **−0.05** (bloqueur de mouvement, à garder LÉGER), `angular_momentum` −0.02, `action_rate_l2` (rampe −0.4 → −1.0, **pas** le −2.0 du roller), `neck_action_rate_l2` −0.5, `neck_joint_pos_l2` −0.5 (tête droite), `joint_torques_l2` −1e-3, `action_over_limit` −0.5, `self_collisions` −1.0.
+Inherited regularizers: `body_ang_vel` **−0.05** (motion blocker, keep it LIGHT), `angular_momentum` −0.02, `action_rate_l2` (ramp −0.4 → −1.0, **not** the roller's −2.0), `neck_action_rate_l2` −0.5, `neck_joint_pos_l2` −0.5 (head upright), `joint_torques_l2` −1e-3, `action_over_limit` −0.5, `self_collisions` −1.0.
 
-Retirées : toutes les récompenses de patinage, plus `feet_flat` (les lames ne sont pas à plat pendant la montée) et `hip_roll_neutral` (se relever demande d'écarter les jambes).
+Removed: all the skating rewards, plus `feet_flat` (the blades are not flat during the rise) and `hip_roll_neutral` (standing up requires spreading the legs).
 
-## ⚠️ Le point dur : les roues roulent
+## ⚠️ The hard part: the wheels roll
 
-Aucune adhérence longitudinale pour pousser sur le sol. Le **curriculum de friction de roulement est INVERSÉ** (l'env roller la fait monter, ici elle descend) :
+There is no longitudinal traction to push against the ground. The **rolling-friction curriculum is REVERSED** (the roller env ramps it up, here it goes down):
 
 | iter | frictionloss | |
 |---|---|---|
-| 0 | 0.05 | roues quasi bloquées → se relève comme avec des pieds |
+| 0 | 0.05 | near-locked wheels → rises as if on feet |
 | 1000 | 0.02 | |
 | 2000 | 0.008 | |
 | 3000 | 0.003 | |
-| 4000 | 0.0015 | la vraie valeur du roulement |
+| 4000 | 0.0015 | the real rolling value |
 
-**Surveiller `Episode_Reward/standing_composite` aux paliers.** S'il s'écroule, le geste « pieds adhérents » ne transfère pas aux roues libres → il faudra guider une technique de patineur (appui genou intermédiaire, un patin à la fois). C'est un résultat, pas un échec.
+**Watch `Episode_Reward/standing_composite` at each stage.** If it collapses, the "sticky feet" gesture does not transfer to free wheels → we will have to guide a skater technique (intermediate knee support, one skate at a time). That is a result, not a failure.
 
-**Sim2real** : seuls les checkpoints d'après iter 4000 sont candidats au déploiement. Avant, la policy s'appuie sur une friction qui n'existe pas sur le vrai robot.
+**Sim2real**: only checkpoints from after iter 4000 are deployment candidates. Before that, the policy relies on a friction that does not exist on the real robot.
 
-## Commande
+## Command
 
-Slot `twist` neutralisé (± 0.01), slots `head_pose` / `body_pose` **zero-paddés** (convention roller). Déploiement visé : en `--standing` face à la policy roller en `--walking`, avec la bascule automatique sur la magnitude de la commande (`infer_policy.py:262`, seuil 0.05) ; le slot twist y est laissé à zéro (`infer_policy.py:239`).
+The `twist` slot is neutralized (± 0.01), and the `head_pose` / `body_pose` slots are **zero-padded** (roller convention). Intended deployment: in `--standing` alongside the roller policy in `--walking`, with the automatic switch on command magnitude (`infer_policy.py:262`, threshold 0.05); the twist slot is left at zero there (`infer_policy.py:239`).
 
-**Réserve** : `infer_policy.py` est le script de sim/clavier local. Le runtime robot est le binaire Rust `microduck_runtime`, absent du repo — il n'est pas vérifié qu'il expose un équivalent `--standing`. Le doc de passation du crouch ne liste que `--model`, `--ground-pick`, `--fold-policy`. À confirmer.
+**Caveat**: `infer_policy.py` is the local sim/keyboard script. The robot runtime is the Rust binary `microduck_runtime`, absent from this repo — it has not been verified that it exposes a `--standing` equivalent. The crouch handover doc only lists `--model`, `--ground-pick`, `--fold-policy`. To be confirmed.
 
-## Terminaisons
+## Terminations
 
-`fell_over` **supprimée** (le robot démarre tombé). `nan_state` héritée. `nan_policy="sanitize"` sur les obs actor/critic.
+`fell_over` **removed** (the robot starts fallen). `nan_state` inherited. `nan_policy="sanitize"` on the actor/critic obs.
 
-## Réseau / PPO
+## Network / PPO
 
-Actor et critic `(512, 256, 128)` elu, `obs_normalization=True`. PPO `lr=1e-3` adaptive, `desired_kl=0.01`, `gamma=0.99`, `lam=0.95`, `num_steps_per_env=24`, épisode 6 s, `max_iterations=15000`. **Symétrie OFF** (`SYMMETRY_CFG` est câblé pour le layout 51D).
+Actor and critic `(512, 256, 128)` elu, `obs_normalization=True`. PPO `lr=1e-3` adaptive, `desired_kl=0.01`, `gamma=0.99`, `lam=0.95`, `num_steps_per_env=24`, 6 s episode, `max_iterations=15000`. **Symmetry OFF** (`SYMMETRY_CFG` is wired for the 51D layout).
 
-## Commandes
+## Commands
 
 ```bash
 uv run train Mjlab-RollerStandUp-Flat-MicroDuck --env.scene.num-envs 4096 --agent.max_iterations 15000
@@ -1208,26 +1207,26 @@ uv run scripts/export_latest.py      # alias md-export
 uv run --with pytest pytest tests/test_roller_standup_cfg.py -q
 ```
 
-## Hors périmètre
+## Out of scope
 
-Intégrer le relevé dans la policy de roulage (recette `velstand`) ; buckets de départ sur le côté ; variante rough ; pénalités d'impact tronc/tête.
+Integrating the standup into the rolling policy (the `velstand` recipe); side-lying start buckets; a rough variant; trunk/head impact penalties.
 ```
 
-- [ ] **Step 5 : Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add docs/roller_standup_policy_summary.md
-git commit -m "roller-standup: doc de passation"
+git commit -m "roller-standup: handover doc"
 ```
 
 ---
 
-## Après le plan
+## After the plan
 
-Lancer un vrai entraînement :
+Run a real training:
 
 ```bash
 uv run train Mjlab-RollerStandUp-Flat-MicroDuck --env.scene.num-envs 4096 --agent.max_iterations 15000
 ```
 
-**Le signal à lire** : `Episode_Reward/standing_composite` doit monter, et surtout **son comportement aux iters 1000 / 2000 / 3000 / 4000** (les paliers de friction de roulement) répond à la question qui a motivé tout ce design — est-ce que se relever sur des roues libres est faisable avec le geste « pieds adhérents », ou faut-il enseigner une technique de patineur ?
+**The signal to read**: `Episode_Reward/standing_composite` must rise, and above all **its behavior at iters 1000 / 2000 / 3000 / 4000** (the rolling-friction stages) answers the question that motivated this whole design — is standing up on free wheels feasible with the "sticky feet" gesture, or must a skater technique be taught?

--- a/docs/superpowers/plans/2026-08-04-spin-env.md
+++ b/docs/superpowers/plans/2026-08-04-spin-env.md
@@ -2,46 +2,46 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ajouter une tâche RL `Mjlab-Spin-Flat-MicroDuck` qui apprend au microduck sur rollers à faire ~2 tours anti-horaire sur place à ~6 rad/s puis à s'arrêter, geste cyclique piloté par la phase du slot bouton du runtime.
+**Goal:** Add an RL task `Mjlab-Spin-Flat-MicroDuck` that teaches the microduck on rollers to do ~2 counter-clockwise turns in place at ~6 rad/s and then stop — a cyclic gesture driven by the phase of the runtime's button slot.
 
-**Architecture :** Nouvel env cfg qui clone la structure de `microduck_roller_crouch_env_cfg.py` (robot rollers, obs 61D, DR complète, `GroundPickPhaseCommand`) mais remplace les rewards de pose par des rewards de **résultat** (suivi d'une vitesse de lacet cible en trapèze sur la phase), plus deux amorces de *shaping* décroissantes qui poussent vers le roulement différentiel. Toutes les nouvelles fonctions de reward vont dans `src/mjlab_microduck/tasks/mdp.py`, chacune découpée en une **fonction pure sur valeurs** (testable sans simulateur) + un **wrapper env** — c'est l'idiome déjà présent dans le repo (`crouch_glide_reward_from_values`).
+**Architecture:** A new env cfg that clones the structure of `microduck_roller_crouch_env_cfg.py` (roller robot, 61D obs, full DR, `GroundPickPhaseCommand`) but replaces the pose rewards with **outcome** rewards (tracking a trapezoidal target yaw rate along the phase), plus two decaying *shaping* priming terms that push toward differential rolling. All the new reward functions go into `src/mjlab_microduck/tasks/mdp.py`, each split into a **pure value function** (testable without a simulator) + an **env wrapper** — the idiom already present in the repo (`crouch_glide_reward_from_values`).
 
-**Tech Stack :** Python 3.12, mjlab 1.3.0, MuJoCo / mujoco-warp, torch, rsl_rl, pytest, uv.
+**Tech Stack:** Python 3.12, mjlab 1.3.0, MuJoCo / mujoco-warp, torch, rsl_rl, pytest, uv.
 
-**Spec de référence :** `docs/superpowers/specs/2026-08-04-spin-env-design.md`
+**Reference spec:** `docs/superpowers/specs/2026-08-04-spin-env-design.md`
 
 ## Global Constraints
 
-- Toutes les valeurs numériques de l'enveloppe sont fixées par le spec : `SPIN_PERIOD = 4.0` s, `SPIN_RATE_MAX = 6.0` rad/s, `SPIN_ACCEL_END = 0.125`, `SPIN_HOLD_END = 0.525`, `SPIN_BRAKE_END = 0.650`. Ne pas les changer sans changer le spec.
-- Sens de rotation : **anti-horaire uniquement**, ω_z cible **positive**.
-- `ENABLE_SYMMETRY = False` et `symmetry_cfg=None` : l'augmentation de symétrie G/D détruirait un spin à sens unique.
-- La reward `angular_momentum` (norme 3D du moment angulaire) doit être **absente** de l'env : elle combattrait le spin.
-- L'obs actor doit rester à **61 dimensions** (layout identique à roller / ground_pick / crouch), sinon l'ONNX ne charge pas dans le slot du runtime.
-- Les joints sont **toujours** résolus par nom / regex via `asset.find_joints(...)`, jamais par index en dur : les 4 roues passives sont intercalées dans l'ordre des joints du modèle rollers.
-- La vitesse d'entrée est injectée via `cfg.events["reset_base"].params["velocity_range"]`, **jamais** via un `push_by_setting_velocity` en `mode="reset"` (régression NaN connue).
-- Style du repo : commentaires en français dans les env cfg, docstrings des fonctions `mdp.py` en anglais ou français selon le voisinage, pas de `Co-Authored-By` dans les commits.
-- Lancer les tests avec `uv run --with pytest pytest tests/ -q`.
+- All the envelope's numeric values are fixed by the spec: `SPIN_PERIOD = 4.0` s, `SPIN_RATE_MAX = 6.0` rad/s, `SPIN_ACCEL_END = 0.125`, `SPIN_HOLD_END = 0.525`, `SPIN_BRAKE_END = 0.650`. Do not change them without changing the spec.
+- Rotation direction: **counter-clockwise only**, target ω_z **positive**.
+- `ENABLE_SYMMETRY = False` and `symmetry_cfg=None`: L/R symmetry augmentation would destroy a one-directional spin.
+- The `angular_momentum` reward (3D norm of angular momentum) must be **absent** from the env: it would fight the spin.
+- The actor obs must stay at **61 dimensions** (layout identical to roller / ground_pick / crouch), otherwise the ONNX will not load in the runtime slot.
+- Joints are **always** resolved by name / regex via `asset.find_joints(...)`, never by hardcoded index: the 4 passive wheels are interleaved in the roller model's joint ordering.
+- The entry velocity is injected through `cfg.events["reset_base"].params["velocity_range"]`, **never** through a `push_by_setting_velocity` in `mode="reset"` (a known NaN regression).
+- Repo style: no `Co-Authored-By` in the commits.
+- Run the tests with `uv run --with pytest pytest tests/ -q`.
 
 ---
 
-### Task 1 : Enveloppe de phase (fonctions pures)
+### Task 1: Phase envelope (pure functions)
 
-Les deux fonctions purement mathématiques qui portent toute la définition du geste : le profil de vitesse de lacet cible et la porte de shaping qui s'en déduit.
+The two purely mathematical functions that carry the whole definition of the gesture: the target yaw-rate profile and the shaping gate derived from it.
 
 **Files:**
-- Modify: `src/mjlab_microduck/tasks/mdp.py` (ajouter à la fin du fichier, après `RelativeHeadingVelocityCommandCfg` et les rewards de patinage)
-- Test: `tests/test_spin.py` (créer)
+- Modify: `src/mjlab_microduck/tasks/mdp.py` (add at the end of the file, after `RelativeHeadingVelocityCommandCfg` and the skating rewards)
+- Test: `tests/test_spin.py` (create)
 
 **Interfaces:**
-- Consumes: rien (fonctions pures sur `torch.Tensor`)
+- Consumes: nothing (pure functions on `torch.Tensor`)
 - Produces:
   - `SPIN_PERIOD: float = 4.0`, `SPIN_RATE_MAX: float = 6.0`, `SPIN_ACCEL_END: float = 0.125`, `SPIN_HOLD_END: float = 0.525`, `SPIN_BRAKE_END: float = 0.650`
   - `spin_rate_by_phase(phase: torch.Tensor, rate_max: float = 6.0, accel_end: float = 0.125, hold_end: float = 0.525, brake_end: float = 0.650) -> torch.Tensor`
   - `spin_gate_by_phase(phase: torch.Tensor, rate_max: float = 6.0, accel_end: float = 0.125, hold_end: float = 0.525, brake_end: float = 0.650) -> torch.Tensor`
 
-- [ ] **Step 1 : Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Créer `tests/test_spin.py` :
+Create `tests/test_spin.py`:
 
 ```python
 import math
@@ -50,13 +50,14 @@ import torch
 
 from mjlab_microduck.tasks import mdp
 
-# Enveloppe du spec : accel 0.5s / régime 1.6s / freinage 0.5s / repos 1.4s sur 4s.
+# Envelope from the spec: accel 0.5s / steady 1.6s / brake 0.5s / rest 1.4s over 4s.
 _ENV = dict(rate_max=6.0, accel_end=0.125, hold_end=0.525, brake_end=0.650)
 
 
 def test_spin_rate_segment_boundaries():
-    # bornes des 4 segments : 0 au départ, plein régime sur [accel_end, hold_end],
-    # encore plein régime au tout début du freinage, 0 dès le segment de repos.
+    # boundaries of the 4 segments: 0 at the start, full rate over
+    # [accel_end, hold_end], still full rate at the very start of braking, 0 from
+    # the rest segment onward.
     phase = torch.tensor([0.0, 0.125, 0.30, 0.525, 0.650, 0.80, 0.999])
     w = mdp.spin_rate_by_phase(phase, **_ENV)
     expected = torch.tensor([0.0, 6.0, 6.0, 6.0, 0.0, 0.0, 0.0])
@@ -67,7 +68,7 @@ def test_spin_rate_accel_ramp_is_increasing():
     phase = torch.linspace(0.0, 0.125, 20)
     w = mdp.spin_rate_by_phase(phase, **_ENV)
     assert torch.all(w[1:] >= w[:-1])
-    # milieu de la rampe de lancement -> moitié de la cible
+    # midway through the launch ramp -> half the target
     mid = mdp.spin_rate_by_phase(torch.tensor([0.0625]), **_ENV)
     assert torch.allclose(mid, torch.tensor([3.0]), atol=1e-6)
 
@@ -76,15 +77,15 @@ def test_spin_rate_brake_ramp_is_decreasing():
     phase = torch.linspace(0.525, 0.6499, 20)
     w = mdp.spin_rate_by_phase(phase, **_ENV)
     assert torch.all(w[1:] <= w[:-1])
-    # milieu du freinage -> moitié de la cible
+    # midway through the braking -> half the target
     mid = mdp.spin_rate_by_phase(torch.tensor([0.5875]), **_ENV)
     assert torch.allclose(mid, torch.tensor([3.0]), atol=1e-6)
 
 
 def test_spin_rate_integral_is_two_turns():
-    # LE test qui protège la cible du spec : l'aire sous l'enveloppe sur un cycle
-    # de 4 s doit valoir ~4*pi rad = 2 tours. Enveloppe exacte = 12.6 rad,
-    # 4*pi = 12.566 -> tolérance 1 %.
+    # THE test that protects the spec's target: the area under the envelope over
+    # a 4 s cycle must be ~4*pi rad = 2 turns. Exact envelope = 12.6 rad,
+    # 4*pi = 12.566 -> 1% tolerance.
     n = 100_000
     phase = (torch.arange(n, dtype=torch.float64) + 0.5) / n
     w = mdp.spin_rate_by_phase(phase, **_ENV)
@@ -101,33 +102,33 @@ def test_spin_gate_is_normalized_rate():
 
 
 def test_spin_gate_is_zero_over_the_whole_rest_segment():
-    # pendant le repos aucune amorce ne doit pousser au ciseau -> porte nulle,
-    # c'est ce qui donne une sortie de trick propre vers la policy roller.
+    # during the rest segment no priming term should push toward the scissor ->
+    # zero gate, which is what gives a clean trick exit back to the roller policy.
     phase = torch.linspace(0.650, 0.999, 50)
     gate = mdp.spin_gate_by_phase(phase, **_ENV)
     assert torch.allclose(gate, torch.zeros_like(gate), atol=1e-6)
 ```
 
-- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `uv run --with pytest pytest tests/test_spin.py -q`
-Expected: FAIL avec `AttributeError: module 'mjlab_microduck.tasks.mdp' has no attribute 'spin_rate_by_phase'`
+Expected: FAIL with `AttributeError: module 'mjlab_microduck.tasks.mdp' has no attribute 'spin_rate_by_phase'`
 
-- [ ] **Step 3 : Implémenter les deux fonctions**
+- [ ] **Step 3: Implement the two functions**
 
-Ajouter à la fin de `src/mjlab_microduck/tasks/mdp.py` :
+Add at the end of `src/mjlab_microduck/tasks/mdp.py`:
 
 ```python
 # --------------------------------------------------------------------------- #
-# Tâche SPIN — rotation rapide sur place sur rollers                            #
+# SPIN task — fast spin in place on rollers                                     #
 # --------------------------------------------------------------------------- #
-# Enveloppe de phase : la commande du slot bouton porte une phase, qui pilote
-# une VITESSE DE LACET cible en trapèze (et non une pose comme le crouch).
-#   [0, accel_end)        0.5 s   0 -> rate_max    (lancement)
-#   [accel_end, hold_end) 1.6 s   rate_max         (régime)
-#   [hold_end, brake_end) 0.5 s   rate_max -> 0    (freinage)
-#   [brake_end, 1.0)      1.4 s   0                (repos debout)
-# Aire sous l'enveloppe sur un cycle de 4 s = 12.6 rad ~ 2 tours.
+# Phase envelope: the button-slot command carries a phase, which drives a
+# trapezoidal target YAW RATE (not a pose, unlike the crouch).
+#   [0, accel_end)        0.5 s   0 -> rate_max    (launch)
+#   [accel_end, hold_end) 1.6 s   rate_max         (steady state)
+#   [hold_end, brake_end) 0.5 s   rate_max -> 0    (braking)
+#   [brake_end, 1.0)      1.4 s   0                (standing rest)
+# Area under the envelope over a 4 s cycle = 12.6 rad ~ 2 turns.
 SPIN_PERIOD = 4.0
 SPIN_RATE_MAX = 6.0
 SPIN_ACCEL_END = 0.125
@@ -142,7 +143,7 @@ def spin_rate_by_phase(
     hold_end: float = SPIN_HOLD_END,
     brake_end: float = SPIN_BRAKE_END,
 ) -> torch.Tensor:
-    """Vitesse de lacet cible (rad/s, positive = anti-horaire) le long de la phase."""
+    """Target yaw rate (rad/s, positive = counter-clockwise) along the phase."""
     w = torch.zeros_like(phase)
     accel = phase < accel_end
     w = torch.where(accel, rate_max * phase / accel_end, w)
@@ -162,35 +163,35 @@ def spin_gate_by_phase(
     hold_end: float = SPIN_HOLD_END,
     brake_end: float = SPIN_BRAKE_END,
 ) -> torch.Tensor:
-    """Porte de shaping dans [0,1] = enveloppe normalisée.
+    """Shaping gate in [0,1] = the normalized envelope.
 
-    Vaut 0 sur tout le segment de repos : les amorces (ciseau des jambes,
-    différentiel des roues) ne s'appliquent que pendant lancement + régime, donc
-    le robot revient en station neutre avant de rendre la main à la policy roller.
+    Zero over the whole rest segment: the priming terms (leg scissor, wheel
+    differential) only apply during launch + steady state, so the robot returns
+    to a neutral stance before handing control back to the roller policy.
     """
     return spin_rate_by_phase(phase, rate_max, accel_end, hold_end, brake_end) / rate_max
 ```
 
-- [ ] **Step 4 : Lancer les tests pour vérifier qu'ils passent**
+- [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `uv run --with pytest pytest tests/test_spin.py -q`
 Expected: PASS (6 tests)
 
-- [ ] **Step 5 : Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/mdp.py tests/test_spin.py
-git commit -m "spin: enveloppe de phase (vitesse de lacet cible + porte de shaping)"
+git commit -m "spin: phase envelope (target yaw rate + shaping gate)"
 ```
 
 ---
 
-### Task 2 : Rewards de suivi de lacet et « sur place »
+### Task 2: Yaw-tracking and "in place" rewards
 
-L'objectif principal (`spin_rate_track`), son bootstrap L1, et la pénalité qui garde le robot sur place. Cette tâche introduit aussi le **faux env** partagé par les tests des tâches 2 à 4, ce qui permet de tester les wrappers env sans lancer MuJoCo.
+The main objective (`spin_rate_track`), its L1 bootstrap, and the penalty that keeps the robot in place. This task also introduces the **fake env** shared by the Task 2–4 tests, which lets us test the env wrappers without launching MuJoCo.
 
 **Files:**
-- Modify: `src/mjlab_microduck/tasks/mdp.py` (à la suite de la Task 1)
+- Modify: `src/mjlab_microduck/tasks/mdp.py` (following Task 1)
 - Modify: `tests/test_spin.py`
 
 **Interfaces:**
@@ -202,12 +203,12 @@ L'objectif principal (`spin_rate_track`), son bootstrap L1, et la pénalité qui
   - `spin_rate_l1(env, command_name="twist", rate_max=..., accel_end=..., hold_end=..., brake_end=..., asset_cfg=_DEFAULT_ASSET_CFG) -> torch.Tensor`
   - `spin_stay_in_place(env, asset_cfg=_DEFAULT_ASSET_CFG) -> torch.Tensor`
 
-- [ ] **Step 1 : Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Ajouter à `tests/test_spin.py` (le faux env sert aussi aux tâches 3 et 4) :
+Add to `tests/test_spin.py` (the fake env also serves Tasks 3 and 4):
 
 ```python
-# ── faux env minimal : permet de tester les wrappers de reward sans MuJoCo ────
+# ── minimal fake env: lets us test the reward wrappers without MuJoCo ────────
 class _FakeData:
     def __init__(self, ang_vel_b=None, lin_vel_b=None, joint_pos=None, joint_vel=None):
         self.root_link_ang_vel_b = ang_vel_b
@@ -217,7 +218,7 @@ class _FakeData:
 
 
 class _FakeEntity:
-    """Entity minimale : find_joints() résout par nom depuis un dict {nom: index}."""
+    """Minimal Entity: find_joints() resolves by name from a {name: index} dict."""
 
     def __init__(self, data, joint_ids=None):
         self.data = data
@@ -231,7 +232,7 @@ class _FakeEntity:
             matched = [n for n in names if n in pattern]
         else:
             matched = [n for n in names if re.fullmatch(pattern, n)]
-        assert matched, f"aucun joint ne matche {pattern!r} parmi {names}"
+        assert matched, f"no joint matches {pattern!r} among {names}"
         return [self._joint_ids[n] for n in matched], matched
 
 
@@ -261,7 +262,7 @@ class _FakeEnv:
 
 
 def _phase_cmd(phases):
-    """Commande du slot telle que la voit la policy : [cos(2*pi*phi), sin(...), 0]."""
+    """The slot command as the policy sees it: [cos(2*pi*phi), sin(...), 0]."""
     p = torch.as_tensor(phases, dtype=torch.float32)
     return torch.stack(
         [torch.cos(2 * math.pi * p), torch.sin(2 * math.pi * p), torch.zeros_like(p)],
@@ -281,13 +282,13 @@ def test_spin_rate_reward_peaks_on_exact_match():
     w = torch.tensor([6.0, 6.0])
     target = torch.tensor([6.0, 4.5])
     r = mdp.spin_rate_reward_from_values(w, target, std=1.5)
-    # erreur nulle -> 1.0 ; erreur = 1 std -> exp(-1)
+    # zero error -> 1.0; error = 1 std -> exp(-1)
     assert torch.allclose(r, torch.tensor([1.0, math.exp(-1.0)]), atol=1e-6)
 
 
 def test_spin_rate_track_uses_yaw_and_phase():
-    # phase 0.30 = plein régime -> cible 6 rad/s. Un robot qui tourne à 6 rad/s
-    # doit toucher 1.0 ; un robot immobile doit être largement en dessous.
+    # phase 0.30 = full rate -> target 6 rad/s. A robot spinning at 6 rad/s
+    # must hit 1.0; a motionless robot must be well below it.
     ang = torch.tensor([[0.0, 0.0, 6.0], [0.0, 0.0, 0.0]])
     env = _FakeEnv(
         _FakeEntity(_FakeData(ang_vel_b=ang)), cmd=_phase_cmd([0.30, 0.30])
@@ -298,7 +299,7 @@ def test_spin_rate_track_uses_yaw_and_phase():
 
 
 def test_spin_rate_track_wants_stillness_during_rest():
-    # phase 0.80 = repos -> cible 0 : tourner encore est puni, être immobile payé.
+    # phase 0.80 = rest -> target 0: still spinning is punished, being still pays.
     ang = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 6.0]])
     env = _FakeEnv(
         _FakeEntity(_FakeData(ang_vel_b=ang)), cmd=_phase_cmd([0.80, 0.80])
@@ -309,7 +310,7 @@ def test_spin_rate_track_wants_stillness_during_rest():
 
 
 def test_spin_rate_track_penalizes_wrong_direction():
-    # tourner à -6 rad/s (horaire) quand on demande +6 doit être pire qu'immobile
+    # spinning at -6 rad/s (clockwise) when +6 is requested must be worse than standing still
     ang = torch.tensor([[0.0, 0.0, -6.0], [0.0, 0.0, 0.0]])
     env = _FakeEnv(
         _FakeEntity(_FakeData(ang_vel_b=ang)), cmd=_phase_cmd([0.30, 0.30])
@@ -333,22 +334,22 @@ def test_spin_stay_in_place_is_squared_planar_speed():
     lin = torch.tensor([[0.0, 0.0, 0.0], [0.3, 0.4, 9.0]])
     env = _FakeEnv(_FakeEntity(_FakeData(lin_vel_b=lin)))
     c = mdp.spin_stay_in_place(env)
-    # 0.3^2 + 0.4^2 = 0.25 ; la composante z est ignorée
+    # 0.3^2 + 0.4^2 = 0.25; the z component is ignored
     assert torch.allclose(c, torch.tensor([0.0, 0.25]), atol=1e-6)
 ```
 
-- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `uv run --with pytest pytest tests/test_spin.py -q`
-Expected: FAIL — `AttributeError: ... has no attribute 'spin_phase_from_command'` (les 6 tests de la Task 1 continuent de passer)
+Expected: FAIL — `AttributeError: ... has no attribute 'spin_phase_from_command'` (Task 1's 6 tests keep passing)
 
-- [ ] **Step 3 : Implémenter les rewards**
+- [ ] **Step 3: Implement the rewards**
 
-Ajouter à la suite dans `src/mjlab_microduck/tasks/mdp.py` :
+Add, following on, in `src/mjlab_microduck/tasks/mdp.py`:
 
 ```python
 def spin_phase_from_command(cmd: torch.Tensor) -> torch.Tensor:
-    """Récupère la phase [0,1) depuis la commande [cos(2πφ), sin(2πφ), 0] du slot."""
+    """Recover the phase [0,1) from the slot command [cos(2πφ), sin(2πφ), 0]."""
     return (torch.atan2(cmd[:, 1], cmd[:, 0]) / (2 * torch.pi)) % 1.0
 
 
@@ -379,7 +380,7 @@ def _spin_gate(
 def spin_rate_reward_from_values(
     omega_z: torch.Tensor, omega_target: torch.Tensor, std: float
 ) -> torch.Tensor:
-    """Gaussienne sur l'erreur de vitesse de lacet (fonction pure, testable)."""
+    """Gaussian on the yaw-rate error (pure, testable function)."""
     return torch.exp(-(((omega_z - omega_target) / std) ** 2))
 
 
@@ -393,11 +394,11 @@ def spin_rate_track(
     brake_end: float = SPIN_BRAKE_END,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Objectif principal du spin : suivre la vitesse de lacet cible ω*(φ).
+    """Main spin objective: track the target yaw rate ω*(φ).
 
-    ω_z est pris en repère corps (c'est ce que voit le gyro de l'IMU, donc ce que
-    la policy observe). Une rotation dans le mauvais sens est plus punie que
-    l'immobilité, la gaussienne étant centrée sur une cible positive.
+    ω_z is taken in the body frame (that is what the IMU gyro sees, hence what
+    the policy observes). Spinning the wrong way is punished more than standing
+    still, since the Gaussian is centered on a positive target.
     """
     asset: Entity = env.scene[asset_cfg.name]
     omega_z = asset.data.root_link_ang_vel_b[:, 2]
@@ -414,9 +415,9 @@ def spin_rate_l1(
     brake_end: float = SPIN_BRAKE_END,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Bootstrap L1 : gradient constant vers la cible même quand la gaussienne
-    de `spin_rate_track` sature loin de la cible. À utiliser avec un poids
-    POSITIF (la valeur retournée est déjà négative)."""
+    """L1 bootstrap: constant gradient toward the target even when the Gaussian
+    of `spin_rate_track` saturates far from it. Use with a POSITIVE weight (the
+    returned value is already negative)."""
     asset: Entity = env.scene[asset_cfg.name]
     omega_z = asset.data.root_link_ang_vel_b[:, 2]
     target = _spin_target_rate(env, command_name, rate_max, accel_end, hold_end, brake_end)
@@ -426,17 +427,16 @@ def spin_rate_l1(
 def spin_stay_in_place(
     env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG
 ) -> torch.Tensor:
-    """Coût ‖v_xy‖² du tronc : tourner SUR PLACE, et tuer l'élan d'entrée.
+    """Trunk ‖v_xy‖² cost: spin IN PLACE, and kill the entry momentum.
 
-    Pas d'état de référence (contrairement à une dérive mesurée depuis le reset),
-    donc reste valide sur les 5 cycles d'un épisode. À utiliser avec un poids
-    NÉGATIF."""
+    No reference state (unlike a drift measured from the reset), so it stays
+    valid across the 5 cycles of an episode. Use with a NEGATIVE weight."""
     asset: Entity = env.scene[asset_cfg.name]
     v_xy = asset.data.root_link_lin_vel_b[:, :2]
     return torch.sum(torch.square(v_xy), dim=1)
 ```
 
-- [ ] **Step 4 : Lancer les tests pour vérifier qu'ils passent**
+- [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `uv run --with pytest pytest tests/test_spin.py -q`
 Expected: PASS (13 tests)
@@ -445,19 +445,19 @@ Expected: PASS (13 tests)
 
 ```bash
 git add src/mjlab_microduck/tasks/mdp.py tests/test_spin.py
-git commit -m "spin: rewards de suivi de lacet (gaussienne + L1) et sur-place"
+git commit -m "spin: yaw-tracking rewards (gaussian + L1) and stay-in-place"
 ```
 
 ---
 
-### Task 3 : Amorces du roulement différentiel
+### Task 3: Differential-rolling priming terms
 
-Les deux rewards qui injectent la physique connue : les patins roulent en sens opposés (`spin_wheel_differential`) et les deux lames restent au sol (`spin_grounded`). Toutes deux portées par la porte `gate(φ)`.
+The two rewards that inject the known physics: the skates roll in opposite directions (`spin_wheel_differential`) and both blades stay on the ground (`spin_grounded`). Both are carried by the `gate(φ)` gate.
 
-**Rappel des signes** (dérivé dans le spec) : pour une rotation anti-horaire, le patin gauche va vers l'**arrière** et le droit vers l'**avant** ; les 4 roues tournent positif en marche avant, donc **`ω_D − ω_G > 0`**.
+**Sign recap** (derived in the spec): for a counter-clockwise rotation, the left skate goes **backward** and the right one **forward**; all 4 wheels spin positive when moving forward, so **`ω_R − ω_L > 0`**.
 
 **Files:**
-- Modify: `src/mjlab_microduck/tasks/mdp.py` (à la suite de la Task 2)
+- Modify: `src/mjlab_microduck/tasks/mdp.py` (following Task 2)
 - Modify: `tests/test_spin.py`
 
 **Interfaces:**
@@ -467,9 +467,9 @@ Les deux rewards qui injectent la physique connue : les patins roulent en sens o
   - `spin_wheel_differential(env, command_name="twist", omega_scale=20.0, rate_max=..., accel_end=..., hold_end=..., brake_end=...) -> torch.Tensor`
   - `spin_grounded(env, sensor_name: str, command_name="twist", rate_max=..., accel_end=..., hold_end=..., brake_end=...) -> torch.Tensor`
 
-- [ ] **Step 1 : Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Ajouter à `tests/test_spin.py` :
+Add to `tests/test_spin.py`:
 
 ```python
 # ── spin_wheel_differential ──────────────────────────────────────────────────
@@ -488,13 +488,13 @@ def _wheel_env(vel_rows, phases):
 
 
 def test_wheel_differential_rewards_counter_rolling_wheels():
-    # anti-horaire : roues GAUCHE négatives (patin part en arrière), DROITE
-    # positives -> omega_D - omega_G > 0 -> récompensé.
+    # counter-clockwise: LEFT wheels negative (that skate goes backward), RIGHT
+    # positive -> omega_R - omega_L > 0 -> rewarded.
     env = _wheel_env(
         [
-            [-10.0, -10.0, 10.0, 10.0],  # bon différentiel
-            [10.0, 10.0, 10.0, 10.0],    # tout droit : différentiel nul
-            [10.0, 10.0, -10.0, -10.0],  # différentiel inversé (horaire)
+            [-10.0, -10.0, 10.0, 10.0],  # correct differential
+            [10.0, 10.0, 10.0, 10.0],    # straight ahead: zero differential
+            [10.0, 10.0, -10.0, -10.0],  # reversed differential (clockwise)
         ],
         [0.30, 0.30, 0.30],
     )
@@ -505,14 +505,14 @@ def test_wheel_differential_rewards_counter_rolling_wheels():
 
 
 def test_wheel_differential_is_gated_off_during_rest():
-    # même bon différentiel, mais en phase de repos -> porte nulle -> pas payé.
+    # same correct differential, but in the rest phase -> zero gate -> unpaid.
     env = _wheel_env([[-10.0, -10.0, 10.0, 10.0]], [0.80])
     r = mdp.spin_wheel_differential(env, omega_scale=20.0)
     assert torch.allclose(r, torch.zeros(1), atol=1e-6)
 
 
 def test_wheel_differential_saturates():
-    # tanh : au-delà de omega_scale la reward sature, pas de course à la vitesse.
+    # tanh: beyond omega_scale the reward saturates, no race to maximum speed.
     env = _wheel_env(
         [[-10.0, -10.0, 10.0, 10.0], [-100.0, -100.0, 100.0, 100.0]], [0.30, 0.30]
     )
@@ -539,28 +539,28 @@ def test_spin_grounded_rewards_both_blades_down_and_is_gated():
         sensors={"feet_ground_contact": _FakeSensor(contact)},
     )
     r = mdp.spin_grounded(env, sensor_name="feet_ground_contact")
-    # deux lames au sol en régime -> porte 1.0 ; une seule ou zéro -> 0 ;
-    # deux lames au sol mais en repos -> porte 0.
+    # both blades down at full rate -> gate 1.0; one or none -> 0;
+    # both blades down but in the rest phase -> gate 0.
     assert torch.allclose(r, torch.tensor([1.0, 0.0, 0.0, 0.0]), atol=1e-6)
 ```
 
-- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `uv run --with pytest pytest tests/test_spin.py -q`
 Expected: FAIL — `AttributeError: ... has no attribute 'spin_wheel_differential'`
 
-- [ ] **Step 3 : Implémenter les deux rewards**
+- [ ] **Step 3: Implement the two rewards**
 
-Ajouter à la suite dans `src/mjlab_microduck/tasks/mdp.py` :
+Add, following on, in `src/mjlab_microduck/tasks/mdp.py`:
 
 ```python
-SPIN_WHEEL_OMEGA_SCALE = 20.0  # rad/s ; voir le calibrage dans le spec
+SPIN_WHEEL_OMEGA_SCALE = 20.0  # rad/s; see the calibration in the spec
 
 
 def spin_wheel_differential_from_values(
     diff: torch.Tensor, gate: torch.Tensor, omega_scale: float
 ) -> torch.Tensor:
-    """Fonction pure : tanh du différentiel de roues, portée par gate, clampée ≥ 0."""
+    """Pure function: tanh of the wheel differential, carried by gate, clamped ≥ 0."""
     return gate * torch.tanh(torch.clamp(diff, min=0.0) / omega_scale)
 
 
@@ -573,11 +573,12 @@ def spin_wheel_differential(
     hold_end: float = SPIN_HOLD_END,
     brake_end: float = SPIN_BRAKE_END,
 ) -> torch.Tensor:
-    """Récompense la rotation EN ROULEMENT (et non en patinage).
+    """Reward spinning BY ROLLING (rather than by skidding).
 
-    Pour un spin anti-horaire, le patin gauche recule et le droit avance ; les 4
-    roues tournant positif en marche avant, cela donne ω_D − ω_G > 0. Le tanh
-    sature à `omega_scale` pour éviter la course à la vitesse de roue.
+    For a counter-clockwise spin the left skate goes backward and the right one
+    forward; since all 4 wheels spin positive when moving forward, this gives
+    ω_R − ω_L > 0. The tanh saturates at `omega_scale` to avoid a race to
+    maximum wheel speed.
     """
     asset: Entity = env.scene["robot"]
     lf_ids, _ = asset.find_joints("passive_LF_?wheel")
@@ -603,10 +604,10 @@ def spin_grounded(
     hold_end: float = SPIN_HOLD_END,
     brake_end: float = SPIN_BRAKE_END,
 ) -> torch.Tensor:
-    """Les deux lames au sol pendant le spin — empêche « je saute et je vrille ».
+    """Both blades on the ground during the spin — prevents "jump and twist".
 
-    Variante de `grounded_reward` du swizzle, qui n'est pas réutilisable ici :
-    elle se pondère par cmd_x, qui vaut cos(2πφ) sur la commande de phase.
+    Variant of the swizzle's `grounded_reward`, which is not reusable here: it
+    weights itself by cmd_x, which equals cos(2πφ) under the phase command.
     """
     from mjlab.sensor import ContactSensor
 
@@ -619,14 +620,14 @@ def spin_grounded(
     return grounded * gate
 ```
 
-- [ ] **Step 4 : Lancer les tests pour vérifier qu'ils passent**
+- [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `uv run --with pytest pytest tests/test_spin.py -q`
 Expected: PASS (18 tests)
 
-- [ ] **Step 5 : Mesurer la demi-voie réelle et ajuster `omega_scale`**
+- [ ] **Step 5: Measure the real half-track and adjust `omega_scale`**
 
-Le spec fixe `omega_scale = 20.0` sur une demi-voie **estimée** à 0.03 m. Mesurer la vraie valeur sur le modèle rollers, à la pose HOME :
+The spec sets `omega_scale = 20.0` based on a half-track **estimated** at 0.03 m. Measure the real value on the roller model, at the HOME pose:
 
 ```bash
 uv run python -c "
@@ -640,46 +641,46 @@ for name in ('left_foot', 'right_foot'):
     ys[name] = d.site_xpos[sid][1]
 half = abs(ys['left_foot'] - ys['right_foot']) / 2.0
 print('sites y =', ys)
-print('demi-voie =', round(half, 4), 'm')
-print('differentiel attendu a 6 rad/s =', round(2 * 6.0 * half / 0.0175, 1), 'rad/s')
+print('half-track =', round(half, 4), 'm')
+print('expected differential at 6 rad/s =', round(2 * 6.0 * half / 0.0175, 1), 'rad/s')
 "
 ```
 
-Si le différentiel attendu diffère de plus de 30 % de 20.0, mettre `SPIN_WHEEL_OMEGA_SCALE` à la valeur mesurée (arrondie à l'entier) et noter la mesure en commentaire au-dessus de la constante. Sinon laisser 20.0 et noter la mesure en commentaire. Dans les deux cas, le commentaire doit contenir la demi-voie mesurée.
+If the expected differential differs by more than 30% from 20.0, set `SPIN_WHEEL_OMEGA_SCALE` to the measured value (rounded to an integer) and record the measurement in a comment above the constant. Otherwise leave 20.0 and record the measurement in a comment. In both cases, the comment must contain the measured half-track.
 
-- [ ] **Step 6 : Relancer les tests**
+- [ ] **Step 6: Re-run the tests**
 
 Run: `uv run --with pytest pytest tests/test_spin.py -q`
-Expected: PASS (18 tests — les tests passent `omega_scale=20.0` explicitement, donc ils sont indépendants de la constante)
+Expected: PASS (18 tests — the tests pass `omega_scale=20.0` explicitly, so they are independent of the constant)
 
 - [ ] **Step 7 : Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/mdp.py tests/test_spin.py
-git commit -m "spin: amorces du roulement differentiel (roues opposees + lames au sol)"
+git commit -m "spin: differential-rolling priming terms (opposed wheels + blades on the ground)"
 ```
 
 ---
 
-### Task 4 : Ciseau des jambes et tête partiellement libre
+### Task 4: Leg scissor and partially free head
 
-L'amorce de pose (`leg_antisymmetry`) et l'ajustement de `neck_joint_pos_l2` pour laisser `head_yaw` libre de servir de volant d'inertie.
+The pose priming term (`leg_antisymmetry`), plus the tweak to `neck_joint_pos_l2` that leaves `head_yaw` free to act as a flywheel.
 
-**Piège de convention** : le robot a des conventions de signe **miroir** gauche/droite. Une pose *symétrique* satisfait `q_G + q_D ≈ 0` (c'est ce que mesure `leg_symmetry_reward`). Donc le **ciseau** (une jambe vers l'avant, l'autre vers l'arrière) satisfait `q_G ≈ q_D`, et se mesure par `−|q_G − q_D|`.
+**Convention trap**: the robot has **mirrored** left/right sign conventions. A *symmetric* pose satisfies `q_L + q_R ≈ 0` (that is what `leg_symmetry_reward` measures). So the **scissor** (one leg forward, the other back) satisfies `q_L ≈ q_R`, and is measured by `−|q_L − q_R|`.
 
 **Files:**
-- Modify: `src/mjlab_microduck/tasks/mdp.py` (`neck_joint_pos_l2` à la ligne ~1237, puis ajout à la suite de la Task 3)
+- Modify: `src/mjlab_microduck/tasks/mdp.py` (`neck_joint_pos_l2` at line ~1237, then append after Task 3)
 - Modify: `tests/test_spin.py`
 
 **Interfaces:**
 - Consumes: `_spin_gate`, `SPIN_*`, `_FakeEntity` / `_FakeEnv`
 - Produces:
   - `leg_antisymmetry(env, command_name="twist", asset_cfg=_DEFAULT_ASSET_CFG, joint_bases=("hip_pitch", "knee"), rate_max=..., accel_end=..., hold_end=..., brake_end=...) -> torch.Tensor`
-  - `neck_joint_pos_l2(env, asset_cfg=_NECK_JOINT_CFG, pattern: str = r".*(neck|head).*") -> torch.Tensor` (signature **élargie**, comportement par défaut inchangé)
+  - `neck_joint_pos_l2(env, asset_cfg=_NECK_JOINT_CFG, pattern: str = r".*(neck|head).*") -> torch.Tensor` (**widened** signature, default behavior unchanged)
 
-- [ ] **Step 1 : Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Ajouter à `tests/test_spin.py` :
+Add to `tests/test_spin.py`:
 
 ```python
 # ── leg_antisymmetry ─────────────────────────────────────────────────────────
@@ -698,12 +699,12 @@ def _leg_env(pos_rows, phases):
 
 
 def test_leg_antisymmetry_prefers_scissor_over_mirror():
-    # convention miroir : q_G = -q_D est une pose SYMÉTRIQUE (mauvais ici),
-    # q_G = q_D est le CISEAU (bon ici). Valeur = -mean|q_G - q_D|, donc <= 0.
+    # mirror convention: q_L = -q_R is a SYMMETRIC pose (bad here), q_L = q_R is
+    # the SCISSOR (good here). Value = -mean|q_L - q_R|, hence <= 0.
     env = _leg_env(
         [
-            [0.4, 0.3, 0.4, 0.3],    # ciseau parfait : q_G == q_D -> 0.0
-            [0.4, 0.3, -0.4, -0.3],  # miroir : écart 0.8 et 0.6 -> -0.7
+            [0.4, 0.3, 0.4, 0.3],    # perfect scissor: q_L == q_R -> 0.0
+            [0.4, 0.3, -0.4, -0.3],  # mirror: gaps of 0.8 and 0.6 -> -0.7
         ],
         [0.30, 0.30],
     )
@@ -713,13 +714,14 @@ def test_leg_antisymmetry_prefers_scissor_over_mirror():
 
 
 def test_leg_antisymmetry_is_gated_off_during_rest():
-    # en repos la porte est nulle : rien ne pousse au ciseau, station neutre libre.
+    # at rest the gate is zero: nothing pushes toward the scissor, the neutral
+    # stance is free.
     env = _leg_env([[0.4, 0.3, -0.4, -0.3]], [0.80])
     r = mdp.leg_antisymmetry(env)
     assert torch.allclose(r, torch.zeros(1), atol=1e-6)
 
 
-# ── neck_joint_pos_l2 : paramètre pattern ────────────────────────────────────
+# ── neck_joint_pos_l2: the pattern parameter ─────────────────────────────────
 _NECK_IDS = {
     "neck_pitch": 0,
     "head_pitch": 1,
@@ -734,16 +736,16 @@ def test_neck_joint_pos_l2_pattern_can_exclude_head_yaw():
             super().__init__(joint_pos=joint_pos)
             self.default_joint_pos = default_joint_pos
 
-    pos = torch.tensor([[0.0, 0.0, 0.0, 1.0]])  # seul head_yaw dévie, de 1 rad
+    pos = torch.tensor([[0.0, 0.0, 0.0, 1.0]])  # only head_yaw deviates, by 1 rad
     default = torch.zeros(1, 4)
     entity = _FakeEntity(_NeckData(pos, default), joint_ids=_NECK_IDS)
     env = _FakeEnv(entity)
 
-    # motif par défaut : head_yaw compté -> coût 1.0
+    # default pattern: head_yaw counted -> cost 1.0
     assert torch.allclose(
         mdp.neck_joint_pos_l2(env), torch.tensor([1.0]), atol=1e-6
     )
-    # motif du spin : head_yaw exclu -> coût 0.0 (tête libre en lacet)
+    # spin pattern: head_yaw excluded -> cost 0.0 (head free in yaw)
     assert torch.allclose(
         mdp.neck_joint_pos_l2(env, pattern=r"^(neck_pitch|head_pitch|head_roll)$"),
         torch.tensor([0.0]),
@@ -751,14 +753,14 @@ def test_neck_joint_pos_l2_pattern_can_exclude_head_yaw():
     )
 ```
 
-- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `uv run --with pytest pytest tests/test_spin.py -q`
 Expected: FAIL — `AttributeError: ... has no attribute 'leg_antisymmetry'`
 
-- [ ] **Step 3 : Ajouter le paramètre `pattern` à `neck_joint_pos_l2`**
+- [ ] **Step 3: Add the `pattern` parameter to `neck_joint_pos_l2`**
 
-Dans `src/mjlab_microduck/tasks/mdp.py`, remplacer la fonction existante (vers la ligne 1237) par :
+In `src/mjlab_microduck/tasks/mdp.py`, replace the existing function (around line 1237) with:
 
 ```python
 def neck_joint_pos_l2(
@@ -772,9 +774,9 @@ def neck_joint_pos_l2(
     SceneEntityCfg singleton is reused across robots with different joint layouts
     (e.g. walk robot vs rollers robot where passive wheels shift neck indices).
 
-    ``pattern`` sélectionne les joints comptés (défaut : toute la nuque + la tête).
-    La tâche spin passe un motif qui EXCLUT `head_yaw`, pour laisser la tête servir
-    de volant d'inertie au lancement de la rotation.
+    ``pattern`` selects which joints are counted (default: the whole neck + head).
+    The spin task passes a pattern that EXCLUDES `head_yaw`, so the head can act
+    as a flywheel when launching the rotation.
     """
     asset: Entity = env.scene[asset_cfg.name]
     joint_ids, _ = asset.find_joints(pattern)
@@ -782,9 +784,9 @@ def neck_joint_pos_l2(
     return torch.sum(torch.square(error), dim=1)
 ```
 
-- [ ] **Step 4 : Implémenter `leg_antisymmetry`**
+- [ ] **Step 4: Implement `leg_antisymmetry`**
 
-Ajouter à la suite de la Task 3 dans `src/mjlab_microduck/tasks/mdp.py` :
+Append after Task 3 in `src/mjlab_microduck/tasks/mdp.py`:
 
 ```python
 def leg_antisymmetry(
@@ -797,13 +799,13 @@ def leg_antisymmetry(
     hold_end: float = SPIN_HOLD_END,
     brake_end: float = SPIN_BRAKE_END,
 ) -> torch.Tensor:
-    """Amorce le CISEAU des jambes (une avant / une arrière) pendant le spin.
+    """Prime the leg SCISSOR (one forward / one back) during the spin.
 
-    Le robot a des conventions de signe MIROIR gauche/droite : une pose
-    symétrique satisfait q_G + q_D ≈ 0 (cf. `leg_symmetry_reward`), donc le
-    ciseau satisfait q_G ≈ q_D. On retourne `gate(φ) · (−mean|q_G − q_D|)` — à
-    utiliser avec un poids POSITIF, décroissant par curriculum : l'amorce
-    s'efface pour laisser la policy affiner son propre geste.
+    The robot has MIRRORED left/right sign conventions: a symmetric pose
+    satisfies q_L + q_R ≈ 0 (cf. `leg_symmetry_reward`), so the scissor
+    satisfies q_L ≈ q_R. We return `gate(φ) · (−mean|q_L − q_R|)` — use with a
+    POSITIVE weight, decayed by curriculum: the priming fades away so the policy
+    can refine its own gesture.
     """
     asset: Entity = env.scene[asset_cfg.name]
     left, right = [], []
@@ -821,35 +823,35 @@ def leg_antisymmetry(
     return gate * scissor
 ```
 
-- [ ] **Step 5 : Lancer les tests pour vérifier qu'ils passent**
+- [ ] **Step 5: Run the tests to verify they pass**
 
 Run: `uv run --with pytest pytest tests/test_spin.py -q`
 Expected: PASS (21 tests)
 
-- [ ] **Step 6 : Vérifier la non-régression des autres tests**
+- [ ] **Step 6: Check the rest of the suite for regressions**
 
-`neck_joint_pos_l2` est utilisée par les envs roller / slope / swizzle ; sa signature a changé (ajout d'un paramètre avec défaut, donc compatible).
+`neck_joint_pos_l2` is used by the roller / slope / swizzle envs; its signature changed (a parameter with a default was added, so it stays compatible).
 
 Run: `uv run --with pytest pytest tests/ -q`
-Expected: PASS — aucun test existant cassé
+Expected: PASS — no existing test broken
 
 - [ ] **Step 7 : Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/mdp.py tests/test_spin.py
-git commit -m "spin: amorce ciseau des jambes + head_yaw libre (pattern sur neck_joint_pos_l2)"
+git commit -m "spin: leg-scissor priming + free head_yaw (pattern on neck_joint_pos_l2)"
 ```
 
 ---
 
-### Task 5 : Env cfg et enregistrement de la tâche
+### Task 5: Env cfg and task registration
 
-Le fichier d'environnement complet et son enregistrement, avec les tests de configuration.
+The complete environment file and its registration, with the config tests.
 
 **Files:**
 - Create: `src/mjlab_microduck/tasks/microduck_spin_env_cfg.py`
 - Modify: `src/mjlab_microduck/tasks/__init__.py`
-- Test: `tests/test_spin_cfg.py` (créer)
+- Test: `tests/test_spin_cfg.py` (create)
 
 **Interfaces:**
 - Consumes: `spin_rate_track`, `spin_rate_l1`, `spin_stay_in_place`, `spin_wheel_differential`, `spin_grounded`, `leg_antisymmetry`, `neck_joint_pos_l2(pattern=...)`, `SPIN_PERIOD`, `SPIN_RATE_MAX`, `SPIN_ACCEL_END`, `SPIN_HOLD_END`, `SPIN_BRAKE_END` (Tasks 1-4)
@@ -858,9 +860,9 @@ Le fichier d'environnement complet et son enregistrement, avec les tests de conf
   - `MicroduckSpinRlCfg: RslRlOnPolicyRunnerCfg`
   - task id `Mjlab-Spin-Flat-MicroDuck`
 
-- [ ] **Step 1 : Écrire les tests qui échouent**
+- [ ] **Step 1: Write the failing tests**
 
-Créer `tests/test_spin_cfg.py` :
+Create `tests/test_spin_cfg.py`:
 
 ```python
 from mjlab_microduck.tasks import mdp as microduck_mdp
@@ -874,9 +876,9 @@ def test_cfg_uses_phase_command_with_runtime_default_period():
     cfg = make_microduck_spin_env_cfg()
     cmd = cfg.commands["twist"]
     assert isinstance(cmd, microduck_mdp.GroundPickPhaseCommandCfg)
-    # 4.0 s = le défaut de --ground-pick-period : rien à passer au runtime
+    # 4.0 s = the default of --ground-pick-period: nothing to pass at runtime
     assert cmd.period == 4.0
-    # chaque épisode démarre à phase 0 (debout), comme le bouton au déploiement
+    # every episode starts at phase 0 (standing), like the button at deployment
     assert cmd.randomize_phase is False
 
 
@@ -891,20 +893,20 @@ def test_cfg_has_the_spin_rewards():
         "leg_antisymmetry",
     ):
         assert name in cfg.rewards, name
-    # objectif principal avec un poids dominant
+    # main objective with a dominant weight
     assert cfg.rewards["spin_rate_track"].weight == 6.0
-    # sur-place est un COÛT
+    # staying in place is a COST
     assert cfg.rewards["spin_stay_in_place"].weight < 0.0
-    # cible positive = anti-horaire (le sens est porté par l'enveloppe)
+    # positive target = counter-clockwise (the direction is carried by the envelope)
     assert microduck_mdp.SPIN_RATE_MAX > 0.0
 
 
 def test_angular_momentum_reward_is_removed():
-    # Régression : angular_momentum_penalty pénalise la NORME 3D du moment
-    # angulaire, elle combattrait directement le spin. Elle doit être absente.
+    # Regression: angular_momentum_penalty penalizes the 3D NORM of angular
+    # momentum, so it would fight the spin head-on. It must be absent.
     cfg = make_microduck_spin_env_cfg()
     assert "angular_momentum" not in cfg.rewards
-    # body_ang_vel ne pénalise que x/y -> elle reste, elle mate le ballant
+    # body_ang_vel only penalizes x/y -> it stays, it damps the wobble
     assert "body_ang_vel" in cfg.rewards
 
 
@@ -916,14 +918,14 @@ def test_head_yaw_is_free_to_act_as_a_flywheel():
 
 def test_entry_velocity_allows_standstill_and_slow_roll():
     cfg = make_microduck_spin_env_cfg()
-    # jamais via un push en mode reset (régression NaN du crouch)
+    # never through a reset-mode push (the crouch's NaN regression)
     assert "entry_velocity" not in cfg.events
     lo, hi = cfg.events["reset_base"].params["velocity_range"]["x"]
     assert lo == 0.0 and hi > 0.0
 
 
 def test_symmetry_augmentation_is_disabled():
-    # la symétrie G/D transformerait un spin à gauche en spin à droite
+    # L/R symmetry would turn a left spin into a right spin
     assert MicroduckSpinRlCfg.algorithm.symmetry_cfg is None
 
 
@@ -937,9 +939,9 @@ def test_leg_antisymmetry_shaping_decays():
 
 
 def test_actor_observation_keeps_the_61d_slot_layout():
-    # condition pour que l'ONNX charge dans le slot du runtime. L'égalité exacte
-    # des dimensions avec le crouch est vérifiée en Task 6 Step 1 (il faut
-    # construire l'env pour compter les dims ; ici on vérifie la structure).
+    # condition for the ONNX to load in the runtime slot. Exact dimension
+    # equality with the crouch is checked in Task 6 Step 1 (that needs the env
+    # built in order to count the dims; here we only check the structure).
     cfg = make_microduck_spin_env_cfg()
     terms = cfg.observations["actor"].terms
     assert "base_lin_vel" not in terms
@@ -950,42 +952,42 @@ def test_actor_observation_keeps_the_61d_slot_layout():
     assert terms["body_command"].params["dim"] == 6
 ```
 
-- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `uv run --with pytest pytest tests/test_spin_cfg.py -q`
-Expected: FAIL avec `ModuleNotFoundError: No module named 'mjlab_microduck.tasks.microduck_spin_env_cfg'`
+Expected: FAIL with `ModuleNotFoundError: No module named 'mjlab_microduck.tasks.microduck_spin_env_cfg'`
 
-- [ ] **Step 3 : Créer le fichier d'environnement**
+- [ ] **Step 3: Create the environment file**
 
-Créer `src/mjlab_microduck/tasks/microduck_spin_env_cfg.py` :
+Create `src/mjlab_microduck/tasks/microduck_spin_env_cfg.py`:
 
 ```python
-"""Microduck SPIN task — rotation rapide sur place, sur rollers.
+"""Microduck SPIN task — fast spin in place, on rollers.
 
-Geste cyclique déclenché au bouton A via le slot --ground-pick du runtime :
-~2 tours anti-horaire à ~6 rad/s puis arrêt propre debout.
+Cyclic gesture triggered by button A through the runtime's --ground-pick slot:
+~2 counter-clockwise turns at ~6 rad/s, then a clean stop standing up.
 
-Hybride :
-  - physique / robot roller  ← microduck_velocity_rollers_env_cfg.py
-  - machinerie phase cyclique ← microduck_roller_crouch_env_cfg.py
-    (commande GroundPickPhaseCommand : [cos(2πφ), sin(2πφ), 0], période 4 s)
+Hybrid:
+  - physics / roller robot     ← microduck_velocity_rollers_env_cfg.py
+  - cyclic-phase machinery     ← microduck_roller_crouch_env_cfg.py
+    (GroundPickPhaseCommand: [cos(2πφ), sin(2πφ), 0], 4 s period)
 
-Différence de fond avec le crouch : la phase pilote une VITESSE DE LACET cible
-(objectif de résultat) et non une pose articulaire. Deux amorces décroissantes
-poussent vers le roulement différentiel — le seul mécanisme physique certain sur
-4 roues passives : patin gauche vers l'arrière, patin droit vers l'avant.
+The fundamental difference from the crouch: the phase drives a target YAW RATE
+(an outcome objective) and not a joint pose. Two decaying priming terms push
+toward differential rolling — the only certain physical mechanism on 4 passive
+wheels: left skate backward, right skate forward.
 
-Obs 61D unifié → interchangeable au runtime avec roller / ground_pick / crouch.
-Voir docs/superpowers/specs/2026-08-04-spin-env-design.md.
+Unified 61D obs → hot-swappable at runtime with roller / ground_pick / crouch.
+See docs/superpowers/specs/2026-08-04-spin-env-design.md.
 """
 
 import math
 from copy import deepcopy
 
-# La symétrie G/D transformerait un spin à gauche en spin à droite : interdit ici.
+# L/R symmetry would turn a left spin into a right spin: forbidden here.
 ENABLE_SYMMETRY = False
 
-# DR — repris du roller env
+# DR — taken from the roller env
 ENABLE_COM_RANDOMIZATION             = True
 ENABLE_HEAD_COM_RANDOMIZATION        = True
 ENABLE_MASS_INERTIA_RANDOMIZATION    = True
@@ -1006,8 +1008,8 @@ VELOCITY_PUSH_RANGE              = (-0.2, 0.2)
 IMU_ORIENTATION_RANDOMIZATION_ANGLE = 6.0
 ENCODER_BIAS_RANGE               = (-0.015, 0.015)
 
-# Le bouton peut être pressé à l'arrêt OU en roulement lent : la policy apprend
-# à tuer l'élan résiduel avant/pendant le lancement de la rotation.
+# The button can be pressed at a standstill OR while rolling slowly: the policy
+# learns to kill the residual momentum before/during the rotation launch.
 ENTRY_VELOCITY_X = (0.0, 0.3)
 
 from mjlab.envs import ManagerBasedRlEnvCfg
@@ -1033,7 +1035,7 @@ from mjlab_microduck.tasks import mdp as microduck_mdp
 from mjlab_microduck.tasks.microduck_velocity_env_cfg import HEAD_BODY_NAMES
 from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg, SYMMETRY_CFG
 
-# Enveloppe de phase : constantes canoniques définies dans mdp.py.
+# Phase envelope: canonical constants defined in mdp.py.
 SPIN_PERIOD = microduck_mdp.SPIN_PERIOD
 _ENVELOPE = {
     "rate_max": microduck_mdp.SPIN_RATE_MAX,
@@ -1041,13 +1043,13 @@ _ENVELOPE = {
     "hold_end": microduck_mdp.SPIN_HOLD_END,
     "brake_end": microduck_mdp.SPIN_BRAKE_END,
 }
-# Nuque/tête tenues près du neutre SAUF head_yaw, laissé libre : il peut servir
-# de volant d'inertie pour lancer la rotation.
+# Neck/head held near neutral EXCEPT head_yaw, left free: it can act as a
+# flywheel to launch the rotation.
 NECK_PATTERN_NO_YAW = r"^(neck_pitch|head_pitch|head_roll)$"
 
 
 def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
-    """Env spin sur rollers, piloté par la phase du slot ground-pick."""
+    """Spin-on-rollers env, driven by the ground-pick slot's phase."""
 
     feet_ground_cfg = ContactSensorCfg(
         name="feet_ground_contact",
@@ -1081,10 +1083,10 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
     joint_pos_action.scale = 1.0
 
     # === REWARDS ===
-    # ⚠️ angular_momentum n'est PAS gardée : elle pénalise la norme 3D du moment
-    # angulaire, donc elle combattrait directement le spin. body_ang_vel, elle,
-    # ne pénalise que x/y (« Don't penalize z-angular velocity » dans mjlab) →
-    # gardée, elle mate le ballant roulis/tangage sans gêner la rotation.
+    # ⚠️ angular_momentum is NOT kept: it penalizes the 3D norm of angular
+    # momentum, so it would fight the spin head-on. body_ang_vel, on the other
+    # hand, only penalizes x/y ("Don't penalize z-angular velocity" in mjlab) →
+    # kept, it damps roll/pitch wobble without hindering the rotation.
     keep = {"upright", "body_ang_vel", "action_rate_l2"}
     for name in list(cfg.rewards.keys()):
         if name not in keep:
@@ -1096,25 +1098,25 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
     cfg.rewards["body_ang_vel"].weight = -0.05
     cfg.rewards["action_rate_l2"].weight = -1.0
 
-    # Objectif principal : suivre la vitesse de lacet cible ω*(φ) (trapèze).
+    # Main objective: track the target yaw rate ω*(φ) (trapezoidal).
     cfg.rewards["spin_rate_track"] = RewardTermCfg(
         func=microduck_mdp.spin_rate_track,
         weight=6.0,
         params={"command_name": "twist", "std": 1.5, **_ENVELOPE},
     )
-    # Bootstrap L1 : gradient constant quand la gaussienne sature loin de la cible.
+    # L1 bootstrap: constant gradient when the gaussian saturates far from the target.
     cfg.rewards["spin_rate_l1"] = RewardTermCfg(
         func=microduck_mdp.spin_rate_l1,
         weight=0.5,
         params={"command_name": "twist", **_ENVELOPE},
     )
-    # Tourner SUR PLACE, et tuer l'élan d'entrée.
+    # Spin IN PLACE, and kill the entry momentum.
     cfg.rewards["spin_stay_in_place"] = RewardTermCfg(
         func=microduck_mdp.spin_stay_in_place,
         weight=-1.0,
         params={},
     )
-    # Amorce 1 : tourner EN ROULEMENT (patins en sens opposés), pas en patinage.
+    # Priming 1: spin BY ROLLING (skates in opposite directions), not by skidding.
     cfg.rewards["spin_wheel_differential"] = RewardTermCfg(
         func=microduck_mdp.spin_wheel_differential,
         weight=1.0,
@@ -1124,7 +1126,7 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             **_ENVELOPE,
         },
     )
-    # Amorce 2 : ciseau des jambes (décroît par curriculum, voir plus bas).
+    # Priming 2: leg scissor (decayed by curriculum, see below).
     cfg.rewards["leg_antisymmetry"] = RewardTermCfg(
         func=microduck_mdp.leg_antisymmetry,
         weight=1.0,
@@ -1134,7 +1136,7 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             **_ENVELOPE,
         },
     )
-    # Les deux lames au sol pendant le spin (pas de vrille en l'air).
+    # Both blades on the ground during the spin (no mid-air twist).
     cfg.rewards["spin_grounded"] = RewardTermCfg(
         func=microduck_mdp.spin_grounded,
         weight=0.5,
@@ -1144,7 +1146,7 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             **_ENVELOPE,
         },
     )
-    # Stabilité / sim2real
+    # Stability / sim2real
     cfg.rewards["feet_flat"] = RewardTermCfg(
         func=microduck_mdp.feet_flat_penalty,
         weight=-2.0,
@@ -1193,10 +1195,10 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
         )
 
     cfg.events["reset_base"].params["pose_range"]["z"] = (0.1335, 0.1435)
-    # Élan d'entrée : injecté via reset_root_state_uniform (état par défaut PROPRE
-    # + range), et NON via push_by_setting_velocity en mode reset, qui additionne à
-    # une vitesse racine potentiellement divergente et fait exploser le free-joint
-    # de la base -> NaN. Régression connue du roller_crouch.
+    # Entry momentum: injected through reset_root_state_uniform (CLEAN default
+    # state + range), and NOT through push_by_setting_velocity in reset mode,
+    # which adds to a potentially divergent root velocity and blows up the base
+    # free joint -> NaN. Known regression from roller_crouch.
     cfg.events["reset_base"].params["velocity_range"] = {"x": ENTRY_VELOCITY_X}
 
     if ENABLE_WHEEL_FRICTION_RANDOMIZATION:
@@ -1322,13 +1324,13 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             func=microduck_mdp.zero_command_padding, params={"dim": 6},
         )
 
-    # === COMMAND: phase (comme ground_pick / roller_crouch) ===
+    # === COMMAND: phase (like ground_pick / roller_crouch) ===
     command: UniformVelocityCommandCfg = cfg.commands["twist"]
     command.rel_standing_envs = 0.0
     command.rel_heading_envs = 0.0
-    # period=4.0 = défaut de --ground-pick-period (rien à passer au runtime) ;
-    # randomize_phase=False -> chaque épisode démarre debout à phase 0, comme le
-    # bouton au déploiement. Épisode 20 s = 5 cycles complets du geste.
+    # period=4.0 = the default of --ground-pick-period (nothing to pass at
+    # runtime); randomize_phase=False -> every episode starts standing at phase 0,
+    # like the button at deployment. A 20 s episode = 5 full cycles of the gesture.
     cfg.commands["twist"] = microduck_mdp.GroundPickPhaseCommandCfg(
         **{
             **vars(command),
@@ -1355,8 +1357,8 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             ],
         },
     )
-    # L'amorce ciseau s'efface : elle lance le bon mécanisme puis laisse la policy
-    # affiner son propre geste (fréquence de pompage libre).
+    # The scissor priming fades out: it launches the right mechanism, then lets
+    # the policy refine its own gesture (free pumping frequency).
     cfg.curriculum["leg_antisym_weight"] = CurriculumTermCfg(
         func=microduck_mdp.reward_weight,
         params={
@@ -1436,9 +1438,9 @@ MicroduckSpinRlCfg = RslRlOnPolicyRunnerCfg(
 )
 ```
 
-- [ ] **Step 4 : Enregistrer la tâche**
+- [ ] **Step 4: Register the task**
 
-Dans `src/mjlab_microduck/tasks/__init__.py`, ajouter l'import après le bloc `microduck_roller_slope_env_cfg` (vers la ligne 66) :
+In `src/mjlab_microduck/tasks/__init__.py`, add the import after the `microduck_roller_slope_env_cfg` block (around line 66):
 
 ```python
 from .microduck_spin_env_cfg import (
@@ -1447,7 +1449,7 @@ from .microduck_spin_env_cfg import (
 )
 ```
 
-Puis l'enregistrement à la fin du fichier, après le bloc `Mjlab-RollerSlope-Flat-MicroDuck` :
+Then the registration at the end of the file, after the `Mjlab-RollerSlope-Flat-MicroDuck` block:
 
 ```python
 register_mjlab_task(
@@ -1460,60 +1462,60 @@ register_mjlab_task(
 print("✓ Spin task registered: Mjlab-Spin-Flat-MicroDuck")
 ```
 
-- [ ] **Step 5 : Lancer les tests de config**
+- [ ] **Step 5: Run the config tests**
 
 Run: `uv run --with pytest pytest tests/test_spin_cfg.py -q`
 Expected: PASS (8 tests)
 
-- [ ] **Step 6 : Vérifier que la tâche est bien enregistrée**
+- [ ] **Step 6: Verify the task is actually registered**
 
 Run: `uv run python -c "import mjlab_microduck.tasks"`
-Expected: la sortie contient `✓ Spin task registered: Mjlab-Spin-Flat-MicroDuck`, sans exception
+Expected: the output contains `✓ Spin task registered: Mjlab-Spin-Flat-MicroDuck`, with no exception
 
-- [ ] **Step 7 : Vérifier la non-régression de toute la suite**
+- [ ] **Step 7: Check the whole suite for regressions**
 
 Run: `uv run --with pytest pytest tests/ -q`
 Expected: PASS
 
-- [ ] **Step 8 : Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
 git add src/mjlab_microduck/tasks/microduck_spin_env_cfg.py src/mjlab_microduck/tasks/__init__.py tests/test_spin_cfg.py
-git commit -m "spin: env cfg Mjlab-Spin-Flat-MicroDuck + enregistrement"
+git commit -m "spin: env cfg Mjlab-Spin-Flat-MicroDuck + registration"
 ```
 
 ---
 
-### Task 6 : Vérification en simulation (smoke run)
+### Task 6: Verification in simulation (smoke run)
 
-Les tests unitaires ne prouvent pas que l'env tourne réellement : les 61D de l'obs, les capteurs de contact, les résolutions de joints et l'absence de NaN ne se voient qu'en lançant le simulateur. Cette tâche est la porte de sortie du plan.
+The unit tests do not prove the env actually runs: the 61D obs, the contact sensors, the joint resolutions and the absence of NaN only show up once the simulator is launched. This task is the plan's exit gate.
 
 **Files:**
-- Modify: `docs/superpowers/specs/2026-08-04-spin-env-design.md` (noter la mesure de demi-voie et le résultat du smoke run)
+- Modify: `docs/superpowers/specs/2026-08-04-spin-env-design.md` (record the half-track measurement and the smoke-run result)
 
 **Interfaces:**
-- Consumes: la tâche enregistrée `Mjlab-Spin-Flat-MicroDuck` (Task 5)
-- Produces: rien de code — une vérification et une note
+- Consumes: the registered task `Mjlab-Spin-Flat-MicroDuck` (Task 5)
+- Produces: no code — a verification and a note
 
-- [ ] **Step 1 : Vérifier la dimension réelle de l'obs actor**
+- [ ] **Step 1: Check the actual actor-obs dimension**
 
 Run:
 ```bash
 uv run python -c "
-import mjlab_microduck.tasks  # enregistre les tâches
+import mjlab_microduck.tasks  # registers the tasks
 from mjlab_microduck.tasks.microduck_spin_env_cfg import make_microduck_spin_env_cfg
 from mjlab_microduck.tasks.microduck_roller_crouch_env_cfg import make_microduck_roller_crouch_env_cfg
 spin = make_microduck_spin_env_cfg()
 crouch = make_microduck_roller_crouch_env_cfg()
 print('spin  actor terms:', list(spin.observations['actor'].terms.keys()))
 print('crouch actor terms:', list(crouch.observations['actor'].terms.keys()))
-assert list(spin.observations['actor'].terms.keys()) == list(crouch.observations['actor'].terms.keys()), 'layout obs != crouch -> ONNX ne chargera pas dans le slot'
-print('OK: layout obs actor identique au crouch')
+assert list(spin.observations['actor'].terms.keys()) == list(crouch.observations['actor'].terms.keys()), 'obs layout != crouch -> the ONNX will not load in the slot'
+print('OK: actor obs layout identical to the crouch')
 "
 ```
-Expected: `OK: layout obs actor identique au crouch`. Si les listes diffèrent, corriger le bloc OBSERVATIONS de l'env cfg avant de continuer — c'est la condition pour que l'ONNX charge dans le slot du runtime.
+Expected: `OK: actor obs layout identical to the crouch`. If the lists differ, fix the env cfg's OBSERVATIONS block before going further — that is the condition for the ONNX to load in the runtime slot.
 
-- [ ] **Step 2 : Lancer un entraînement très court avec garde NaN**
+- [ ] **Step 2: Run a very short training with the NaN guard**
 
 Run:
 ```bash
@@ -1522,43 +1524,43 @@ uv run train Mjlab-Spin-Flat-MicroDuck \
   --agent.max_iterations 5 \
   --enable-nan-guard
 ```
-Expected: 5 itérations sans exception, sans NaN, et les logs `Episode_Reward/` listent bien `spin_rate_track`, `spin_rate_l1`, `spin_stay_in_place`, `spin_wheel_differential`, `spin_grounded`, `leg_antisymmetry`.
+Expected: 5 iterations with no exception, no NaN, and the `Episode_Reward/` logs do list `spin_rate_track`, `spin_rate_l1`, `spin_stay_in_place`, `spin_wheel_differential`, `spin_grounded`, `leg_antisymmetry`.
 
-Si des NaN apparaissent : les dumps sont dans `/tmp/mjlab/nan_dumps/`. Le suspect n°1 est la vitesse d'entrée — vérifier qu'elle passe bien par `reset_base.velocity_range` et pas par un push en `mode="reset"`.
+If NaNs show up: the dumps are in `/tmp/mjlab/nan_dumps/`. Suspect #1 is the entry velocity — check that it really goes through `reset_base.velocity_range` and not through a push in `mode="reset"`.
 
-- [ ] **Step 3 : Lancer un entraînement de calibrage (500 itérations)**
+- [ ] **Step 3: Run a calibration training (500 iterations)**
 
 Run:
 ```bash
 uv run train Mjlab-Spin-Flat-MicroDuck --env.scene.num-envs 4096 --agent.max_iterations 500
 ```
-Expected: `Episode_Reward/spin_rate_track` **monte** sur les 500 itérations. C'est le signal que l'objectif est apprenable. Noter la valeur atteinte.
+Expected: `Episode_Reward/spin_rate_track` **rises** over the 500 iterations. That is the signal that the objective is learnable. Note the value reached.
 
-Si la courbe reste plate, appliquer le « Plan B » du spec dans l'ordre : (1) curriculum de vitesse 3 → 6 rad/s, (2) monter `spin_wheel_differential` et retarder la décroissance de `leg_antisymmetry`, (3) élargir `std` de 1.5 à 2.5.
+If the curve stays flat, apply the spec's "Plan B" in order: (1) a rate curriculum 3 → 6 rad/s, (2) raise `spin_wheel_differential` and delay the decay of `leg_antisymmetry`, (3) widen `std` from 1.5 to 2.5.
 
-- [ ] **Step 4 : Regarder le geste**
+- [ ] **Step 4: Watch the gesture**
 
 Run: `uv run scripts/play_latest.py`
-Expected: le robot tente une rotation anti-horaire sur place. À 500 itérations le geste sera brut ; ce qu'on vérifie c'est qu'il tourne **dans le bon sens**, qu'il ne part pas en translation, et qu'il ne finit pas systématiquement par tomber.
+Expected: the robot attempts a counter-clockwise rotation in place. At 500 iterations the gesture will be crude; what we check is that it turns **in the right direction**, that it does not drift away in translation, and that it does not systematically end up falling.
 
-- [ ] **Step 5 : Noter les mesures dans le spec**
+- [ ] **Step 5: Record the measurements in the spec**
 
-Ajouter une section `## Résultats de la vérification initiale` à la fin de `docs/superpowers/specs/2026-08-04-spin-env-design.md`, contenant : la demi-voie mesurée (Task 3 Step 5), la valeur retenue pour `omega_scale`, le résultat du smoke run 5 itérations, et la valeur de `Episode_Reward/spin_rate_track` à 500 itérations.
+Add a `## Initial verification results` section at the end of `docs/superpowers/specs/2026-08-04-spin-env-design.md`, containing: the measured half-track (Task 3 Step 5), the value chosen for `omega_scale`, the result of the 5-iteration smoke run, and the value of `Episode_Reward/spin_rate_track` at 500 iterations.
 
-- [ ] **Step 6 : Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add docs/superpowers/specs/2026-08-04-spin-env-design.md
-git commit -m "spin: notes de verification initiale (demi-voie, smoke run, 500 it.)"
+git commit -m "spin: initial verification notes (half-track, smoke run, 500 it.)"
 ```
 
 ---
 
-## Notes pour l'implémenteur
+## Notes for the implementer
 
-- **Ordre obligatoire** : Task 1 → 2 → 3 → 4 → 5 → 6. Les tâches 2 à 4 dépendent du faux env créé dans la Task 2 ; la Task 5 consomme toutes les fonctions des tâches 1 à 4.
-- **Le piège n°1 de cette tâche** est la reward `angular_momentum` : si elle reste dans l'env, elle pénalise la norme 3D du moment angulaire et le spin ne décollera jamais. Le test `test_angular_momentum_reward_is_removed` la garde.
-- **Le piège n°2** est la convention de signe miroir gauche/droite du robot : le ciseau se mesure par `|q_G − q_D|`, pas par `|q_G + q_D|`. Comparer avec `leg_symmetry_reward` (ligne ~3769 de `mdp.py`) en cas de doute.
-- **Le piège n°3** est la parité d'obs 61D : toute divergence par rapport au layout du crouch rend l'ONNX inutilisable dans le slot du runtime. La Task 6 Step 1 la vérifie explicitement.
-- Ne pas activer la symétrie PPO, quelle que soit la tentation d'accélérer l'apprentissage.
-- **Hors périmètre de ce plan** : l'entraînement complet (8000 itérations), l'export ONNX et le déploiement dans le slot du runtime. Les commandes sont dans le spec ; le plan s'arrête quand l'env est vérifié apprenable (Task 6).
+- **Mandatory order**: Task 1 → 2 → 3 → 4 → 5 → 6. Tasks 2 to 4 depend on the fake env created in Task 2; Task 5 consumes all the functions from Tasks 1 to 4.
+- **Trap #1 of this task** is the `angular_momentum` reward: if it stays in the env, it penalizes the 3D norm of angular momentum and the spin will never take off. The `test_angular_momentum_reward_is_removed` test guards against it.
+- **Trap #2** is the robot's mirrored left/right sign convention: the scissor is measured by `|q_L − q_R|`, not by `|q_L + q_R|`. Compare with `leg_symmetry_reward` (line ~3769 of `mdp.py`) if in doubt.
+- **Trap #3** is 61D obs parity: any divergence from the crouch's layout makes the ONNX unusable in the runtime slot. Task 6 Step 1 checks it explicitly.
+- Do not enable PPO symmetry, however tempting it is to speed up learning.
+- **Out of scope for this plan**: the full training (8000 iterations), the ONNX export and the deployment into the runtime slot. The commands are in the spec; the plan stops once the env is verified learnable (Task 6).

--- a/docs/superpowers/specs/2026-07-17-roller-crouch-glide-design.md
+++ b/docs/superpowers/specs/2026-07-17-roller-crouch-glide-design.md
@@ -1,121 +1,121 @@
-# Design — Roller Crouch-Glide (« s'accroupir en glissant » au bouton)
+# Design — Roller Crouch-Glide ("crouch while gliding", on a button press)
 
-**Date :** 2026-07-17
-**Statut :** conception validée, prêt pour le plan d'implémentation
+**Date:** 2026-07-17
+**Status:** design approved, ready for the implementation plan
 
-## Contexte
+## Context
 
-Le robot microduck sait patiner (policy roller, tâche `Mjlab-Velocity-Flat-MicroDuck-Rollers`).
-On veut un nouveau geste : sur un appui bouton, il **s'accroupit et continue de glisser
-sur son élan** (comme un patineur en position basse), maintient ~1 s, puis **se relève**
-tout seul et reprend le patinage.
+The microduck robot can skate (the roller policy, task `Mjlab-Velocity-Flat-MicroDuck-Rollers`).
+We want a new gesture: on a button press, it **crouches and keeps gliding on its
+momentum** (like a skater in a low stance), holds for ~1 s, then **stands back up**
+by itself and resumes skating.
 
-Contrainte forte de l'utilisatrice : **ne pas modifier le runtime Rust**
-(`apirrone/microduck_runtime`, installé en binaire). Le geste doit donc réutiliser un
-mécanisme déjà présent dans le runtime.
+Hard constraint from the user: **do not modify the Rust runtime**
+(`apirrone/microduck_runtime`, installed as a binary). The gesture must therefore reuse a
+mechanism already present in the runtime.
 
-**Découverte clé :** le runtime a déjà un slot « comportement one-shot déclenché au
-bouton » : `--ground-pick`. Il est déclenché par le **bouton A** (front montant),
-joue une policy ONNX pilotée par une **phase** pendant une durée fixe, puis revient
-automatiquement à la policy principale. Surtout, il utilise **exactement le même
-layout d'observation 61D** que la policy roller — les deux sont interchangeables au
-runtime. C'est le véhicule idéal, sans une ligne de Rust.
+**Key discovery:** the runtime already has a "one-shot button-triggered behavior"
+slot: `--ground-pick`. It is triggered by **button A** (rising edge), plays a
+phase-driven ONNX policy for a fixed duration, then automatically returns to the
+main policy. Crucially, it uses **exactly the same 61D observation layout** as the
+roller policy — the two are hot-swappable at runtime. It is the ideal vehicle,
+without a line of Rust.
 
-Compromis accepté : le geste est **one-shot** (durée fixe, pas de « bascule maintenue »).
-La durée de l'accroupi est fixée par la période du slot.
+Accepted trade-off: the gesture is **one-shot** (fixed duration, no "hold to keep it").
+The crouch duration is set by the slot's period.
 
-## Approche retenue (approche B)
+## Chosen approach (approach B)
 
-Créer une **nouvelle tâche mjlab** entraînée sur le robot rollers, qui joue
-descente → glisse accroupi → remontée, piloté par la phase du slot ground-pick.
-L'exporter en ONNX et la charger via `--ground-pick`. Aucune modif Rust.
+Create a **new mjlab task** trained on the roller robot, which plays
+descent → crouched glide → rise, driven by the ground-pick slot's phase.
+Export it to ONNX and load it via `--ground-pick`. No Rust changes.
 
-### Fichiers concernés
+### Files involved
 
-| Fichier | Action |
+| File | Action |
 |---|---|
-| `src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py` | **Nouveau.** L'env, hybride roller + ground-pick. |
-| `src/mjlab_microduck/tasks/mdp.py` | **Ajout** de la reward `crouch_glide_height_by_phase`. |
-| `src/mjlab_microduck/tasks/__init__.py` | **Ajout** : enregistrer `Mjlab-RollerCrouch-Flat-MicroDuck`. |
+| `src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py` | **New.** The env, a roller + ground-pick hybrid. |
+| `src/mjlab_microduck/tasks/mdp.py` | **Add** the `crouch_glide_height_by_phase` reward. |
+| `src/mjlab_microduck/tasks/__init__.py` | **Add**: register `Mjlab-RollerCrouch-Flat-MicroDuck`. |
 
-### Réutilisation (ne rien réinventer)
+### Reuse (do not reinvent anything)
 
-- **Physique / robot roller** ← `microduck_velocity_rollers_env_cfg.py` :
-  `MICRODUCK_WALK_ROLLERS_ROBOT_CFG` (14 joints actifs + 4 roues passives),
-  capteur de contact sur les `roller_blade`, DR friction des roulements
-  (`randomize_wheel_friction` + curriculum), obs 14-dim (roues exclues via
+- **Roller physics / robot** ← `microduck_velocity_rollers_env_cfg.py`:
+  `MICRODUCK_WALK_ROLLERS_ROBOT_CFG` (14 active joints + 4 passive wheels),
+  contact sensor on the `roller_blade`s, bearing-friction DR
+  (`randomize_wheel_friction` + curriculum), 14-dim obs (wheels excluded via
   `SceneEntityCfg("robot", joint_names=(r"^(?!passive_).*",))`), `action.scale=1.0`,
   `kp_fw=200`.
-- **Machinerie phase / one-shot** ← `microduck_ground_pick_env_cfg.py` :
-  commande `microduck_mdp.GroundPickPhaseCommand` **réutilisée telle quelle**
-  (produit le `[cos(2πφ), sin(2πφ), 0]` que le runtime enverra dans le slot twist),
-  padding head/body à zéro (`zero_command_padding`), terminaison `robot_state_is_nan`,
+- **Phase / one-shot machinery** ← `microduck_ground_pick_env_cfg.py`:
+  the `microduck_mdp.GroundPickPhaseCommand` command **reused as-is**
+  (it produces the `[cos(2πφ), sin(2πφ), 0]` the runtime will send into the twist slot),
+  zero head/body padding (`zero_command_padding`), the `robot_state_is_nan` termination,
   `reset_action_history`.
-- **DR sim2real** ← repris du roller env sans changement (IMU misalignment obs-level,
-  encoder bias, masse/inertie, friction BAM, armature, pushes doux ±0.2).
+- **sim2real DR** ← taken from the roller env unchanged (obs-level IMU misalignment,
+  encoder bias, mass/inertia, BAM friction, armature, gentle ±0.2 pushes).
 
-## Le cœur : cible de hauteur « en trapèze » pilotée par la phase
+## The core: a trapezoidal, phase-driven height target
 
-Seule vraie nouveauté. Au lieu de descendre la bouche (ground-pick), on pilote la
-**hauteur du tronc** (`com_height` du `trunk_base`) selon la phase, avec un palier bas :
+The only genuine novelty. Instead of lowering the mouth (ground-pick), we drive the
+**trunk height** (`com_height` of `trunk_base`) along the phase, with a low plateau:
 
 ```
-hauteur
- haute ┐                    ┌──   debout (rend la main à la policy roller)
+height
+  high ┐                    ┌──   standing (hands control back to the roller policy)
        │ \                 /
-  basse│  \_______________/       accroupi + glisse (palier 1 s)
+   low │  \_______________/       crouched + gliding (1 s plateau)
        └───────────────────────► phase
        0   0.375      0.625   1
 ```
 
-- φ ∈ [0, 0.375] : descente vers la hauteur accroupie
-- φ ∈ [0.375, 0.625] : **maintien accroupi** (= 1 s sur une période de 4 s) → glisse
-- φ ∈ [0.625, 1.0] : remontée vers la pose roller debout
+- φ ∈ [0, 0.375]: descent toward the crouched height
+- φ ∈ [0.375, 0.625]: **crouch hold** (= 1 s over a 4 s period) → glide
+- φ ∈ [0.625, 1.0]: rise back to the standing roller pose
 
-**Nouvelle reward `crouch_glide_height_by_phase(env, command_name, height_low,
-height_high, hold_lo=0.375, hold_hi=0.625, std=...)`** dans `mdp.py` :
-lit la phase depuis la commande, calcule la hauteur-cible (interpolée haut→bas→haut,
-plate sur le palier), récompense `exp(-((h_mesurée - h_cible)/std)²)`.
-S'inspirer des fonctions `com_height_target` (mdp.py:694) et des
-`interpolated/multistage height target` déjà présentes.
+**New reward `crouch_glide_height_by_phase(env, command_name, height_low,
+height_high, hold_lo=0.375, hold_hi=0.625, std=...)`** in `mdp.py`:
+it reads the phase from the command, computes the target height (interpolated
+high→low→high, flat over the plateau), and rewards `exp(-((h_measured - h_target)/std)²)`.
+Take inspiration from `com_height_target` (mdp.py:694) and the
+`interpolated/multistage height target` functions already present.
 
-Valeurs de départ : `height_high ≈ 0.11` m (hauteur roller debout, cf. bande
-`com_height_target` roller 0.0935–0.1235), `height_low ≈ 0.075` m (accroupi ;
-à affiner en play). La phase est reconstruite depuis `atan2(sin, cos)` de la commande.
+Starting values: `height_high ≈ 0.11` m (standing roller height, cf. the roller
+`com_height_target` band 0.0935–0.1235), `height_low ≈ 0.075` m (crouched;
+to be refined at play time). The phase is reconstructed from `atan2(sin, cos)` of the command.
 
-## Récompenses
+## Rewards
 
-| Reward | Rôle | Origine |
+| Reward | Role | Origin |
 |---|---|---|
-| `crouch_glide_height_by_phase` | Cible principale (haut→bas→haut) | **nouveau** |
-| `wheel_speed` (poids réduit ~2–3) | Garder l'élan, ne pas freiner pendant l'accroupi | roller env (`wheel_speed_reward`) |
-| `upright` (≈2), `body_ang_vel` (−0.05), `angular_momentum` (−0.02) | Équilibre / stabilité | roller env |
-| `return_pose` (fin de phase) | Converger vers la pose roller debout pour rendre la main proprement | adapté de `ground_pick_return_pose` |
-| `feet_flat` (−2) | Lames à plat → glisse stable | roller env |
-| `action_rate_l2`, `neck_action_rate_l2`, `joint_torques_l2`, `self_collisions` | Lissage / transfert sim2real | les deux envs |
+| `crouch_glide_height_by_phase` | Main target (high→low→high) | **new** |
+| `wheel_speed` (reduced weight ~2–3) | Keep the momentum, do not brake during the crouch | roller env (`wheel_speed_reward`) |
+| `upright` (≈2), `body_ang_vel` (−0.05), `angular_momentum` (−0.02) | Balance / stability | roller env |
+| `return_pose` (end of phase) | Converge to the standing roller pose for a clean handover | adapted from `ground_pick_return_pose` |
+| `feet_flat` (−2) | Blades flat → stable glide | roller env |
+| `action_rate_l2`, `neck_action_rate_l2`, `joint_torques_l2`, `self_collisions` | Smoothing / sim2real transfer | both envs |
 
-**Explicitement PAS inclus :** `braking` (on ne veut pas s'arrêter), `mouth_ground_proximity`
-/ `mouth_perpendicular_to_ground` (on ne touche pas le sol), `skating_air_time` /
-`single_support` / `glide` (pas de stride pendant le trick — on glisse passivement).
+**Explicitly NOT included:** `braking` (we do not want to stop), `mouth_ground_proximity`
+/ `mouth_perpendicular_to_ground` (we do not touch the ground), `skating_air_time` /
+`single_support` / `glide` (no stride during the trick — we glide passively).
 
-## Entraînement
+## Training
 
-- `MicroduckRollerCrouchRlCfg` = copie de `MicroduckRollersRlCfg`
+- `MicroduckRollerCrouchRlCfg` = a copy of `MicroduckRollersRlCfg`
   (MLP 512/256/128, ELU, obs_normalization, PPO, `experiment_name="roller_crouch"`).
-- Enregistrer dans `tasks/__init__.py` :
+- Register in `tasks/__init__.py`:
   `register_mjlab_task(task_id="Mjlab-RollerCrouch-Flat-MicroDuck", ...)`.
-- Lancer :
+- Launch:
   ```bash
   uv run train Mjlab-RollerCrouch-Flat-MicroDuck \
     --env.scene.num-envs 4096 --agent.max_iterations 8000
   ```
-- Épisodes démarrés avec une **vitesse d'entrée réaliste** (le robot arrive en roulant),
-  sinon il n'aura pas d'élan à conserver pendant l'accroupi. À câbler via un event de
-  reset (vitesse initiale non nulle) ou un push au début d'épisode.
+- Episodes started with a **realistic entry velocity** (the robot arrives already rolling),
+  otherwise it will have no momentum to preserve during the crouch. To be wired through a
+  reset event (non-zero initial velocity) or a push at the start of the episode.
 
-## Export + déploiement (flags runtime exacts)
+## Export + deployment (exact runtime flags)
 
-Export ONNX (le normaliseur est baké par `export.py`), puis :
+ONNX export (the normalizer is baked in by `export.py`), then:
 
 ```bash
 microduck_runtime --variant pre-alpha --new-cmd-obs --roller \
@@ -128,31 +128,31 @@ microduck_runtime --variant pre-alpha --new-cmd-obs --roller \
   --ground-pick-action-scale 0.8
 ```
 
-Bouton **A** → crouch-glide, puis retour auto à la policy roller.
+Button **A** → crouch-glide, then automatic return to the roller policy.
 
-**Pièges de parité entraînement/déploiement (importants pour le sim2real) :**
-- `--ground-pick-kp-ratio 1.0` : le défaut est **0.6** (baisse kp à 120 pendant le trick).
-  On entraîne à kp=200 → il faut forcer **1.0** pour que ça corresponde.
-- `--ground-pick-action-scale` doit matcher l'`action_scale` d'entraînement (0.8 ci-dessus).
-- `--ground-pick-period 5.0` doit matcher la période/longueur de mouvement entraînée
-  (défaut 4.0, on le garde).
+**Training/deployment parity pitfalls (important for sim2real):**
+- `--ground-pick-kp-ratio 1.0`: the default is **0.6** (it lowers kp to 120 during the trick).
+  We train at kp=200 → we must force **1.0** to match.
+- `--ground-pick-action-scale` must match the training `action_scale` (0.8 above).
+- `--ground-pick-period 5.0` must match the trained period/motion length
+  (the default is 4.0; we keep ours).
 
-## Risques et vérification
+## Risks and verification
 
-- **One-shot, durée fixe :** l'accroupi dure `ground-pick-period` puis remonte tout seul.
-  Pas de maintien libre — limite acceptée de l'approche B.
-- **Élan pendant le trick :** la phase remplace la commande de vitesse → **pas de poussée
-  active** pendant l'accroupi. Si l'élan d'entrée est trop faible, il ralentit. D'où
-  l'entraînement avec vitesse d'entrée réaliste.
-- **Vérification :**
-  1. En sim (`play`) : il descend, garde les roues qui tournent pendant le palier,
-     se relève sans tomber, et la pose finale rejoint proprement la pose roller debout.
-  2. Sur le vrai robot : lancer à petite vitesse, appuyer sur A, observer.
-  3. Confirmer que la policy roller reprend la main proprement après le retour.
+- **One-shot, fixed duration:** the crouch lasts `ground-pick-period` then rises by itself.
+  No free hold — an accepted limitation of approach B.
+- **Momentum during the trick:** the phase replaces the velocity command → **no active push**
+  during the crouch. If the entry momentum is too low, it slows down. Hence
+  training with a realistic entry velocity.
+- **Verification:**
+  1. In sim (`play`): it goes down, keeps the wheels turning during the plateau,
+     stands back up without falling, and the final pose cleanly rejoins the standing roller pose.
+  2. On the real robot: launch at low speed, press A, observe.
+  3. Confirm that the roller policy cleanly takes back control after the return.
 
-## Questions ouvertes / à confirmer pendant l'implémentation
+## Open questions / to confirm during implementation
 
-- Valeur exacte de `height_low` (accroupi) — à régler en play.
-- Meilleure façon d'injecter la vitesse d'entrée à l'épisode (event reset vs push initial).
-- Poids relatif `wheel_speed` vs `crouch_glide_height_by_phase` (garder l'élan sans
-  empêcher de s'accroupir).
+- The exact value of `height_low` (crouched) — to be tuned at play time.
+- The best way to inject the entry velocity at episode start (reset event vs initial push).
+- The relative weight of `wheel_speed` vs `crouch_glide_height_by_phase` (keep the momentum
+  without preventing the crouch).

--- a/docs/superpowers/specs/2026-07-22-roller-slope-design.md
+++ b/docs/superpowers/specs/2026-07-22-roller-slope-design.md
@@ -1,145 +1,143 @@
-# Mode pente — `roller_slope` (descente passive équilibrée)
+# Slope mode — `roller_slope` (balanced passive descent)
 
-Date : 2026-07-22
-Statut : design validé, prêt pour le plan d'implémentation.
+Date: 2026-07-22
+Status: design approved, ready for the implementation plan.
 
-## Objectif
+## Objective
 
-Entraîner une politique dédiée où **microduck (sur rollers) démarre sur du plat
-avec une petite impulsion vers l'avant, roule jusqu'à une rampe descendante, et
-se laisse glisser jusqu'en bas en restant debout et équilibré**. Aucun pilotage
-pendant la descente : le seul objectif de la politique est de **ne pas tomber**.
+Train a dedicated policy where **the microduck (on rollers) starts on the flat
+with a small forward impulse, rolls to a downhill ramp, and lets itself glide all
+the way down while staying upright and balanced**. No steering during the
+descent: the policy's only objective is to **not fall**.
 
-La politique doit gérer des rampes de raideur croissante (**~2° → ~20°**) grâce à
-un curriculum de difficulté.
+The policy must handle ramps of increasing steepness (**~2° → ~20°**) via a
+difficulty curriculum.
 
-## Décisions cadrées (brainstorming)
+## Settled decisions (brainstorming)
 
-| Sujet | Décision |
+| Topic | Decision |
 |---|---|
-| Comportement | Descente passive équilibrée (la gravité fait avancer, pas de pédalage imposé) |
-| Pilotage | Aucun — équilibre pur, commande `twist` forcée à zéro |
-| Approche | **A** — tâche dédiée, isolée (comme `roller_crouch`) |
-| Forme du terrain | **Rampe simple** : plat de départ + rampe descendante (pas de pyramide) |
-| Scénario épisode | Spawn sur le plat → vitesse d'impulsion vers l'avant → glisse sur la rampe |
-| Raideur | Curriculum **0/2° → 20°** |
-| Déploiement | Flag `--slope <onnx>` + touche **`Y`** dans `infer_policy.py` (Y est libre) |
+| Behavior | Balanced passive descent (gravity provides the motion, no imposed pedalling) |
+| Steering | None — pure balance, `twist` command forced to zero |
+| Approach | **A** — dedicated, isolated task (like `roller_crouch`) |
+| Terrain shape | **Simple ramp**: starting flat + downhill ramp (not a pyramid) |
+| Episode scenario | Spawn on the flat → forward impulse velocity → glide down the ramp |
+| Steepness | Curriculum **0/2° → 20°** |
+| Deployment | `--slope <onnx>` flag + the **`Y`** key in `infer_policy.py` (Y is free) |
 
 ## Architecture
 
-### 1. Nouvelle tâche
+### 1. New task
 
-Fichier : `src/mjlab_microduck/tasks/microduck_roller_slope_env_cfg.py`, cloné de
+File: `src/mjlab_microduck/tasks/microduck_roller_slope_env_cfg.py`, cloned from
 `microduck_velocity_rollers_env_cfg.py`.
 
-- Même robot rollers (`MICRODUCK_WALK_ROLLERS_ROBOT_CFG`), même physique, même
-  domain randomization / bruit / délais.
-- **Même observation 61D** (twist + head/body en zéro-padding) → la politique
-  charge par le chemin `--new-cmd-obs` du runtime et reste interchangeable avec
-  les autres politiques rollers.
-- Enregistrement dans `src/mjlab_microduck/tasks/__init__.py` via
-  `register_mjlab_task`, avec une config PPO `MicroduckRollerSlopeRlCfg`
+- Same roller robot (`MICRODUCK_WALK_ROLLERS_ROBOT_CFG`), same physics, same
+  domain randomization / noise / delays.
+- **Same 61D observation** (twist + zero-padded head/body) → the policy loads
+  through the runtime's `--new-cmd-obs` path and stays hot-swappable with
+  the other roller policies.
+- Registered in `src/mjlab_microduck/tasks/__init__.py` via
+  `register_mjlab_task`, with a PPO config `MicroduckRollerSlopeRlCfg`
   (`experiment_name`/`run_name` = `roller_slope`).
 
-### 2. Terrain « plat + rampe » (custom)
+### 2. "Flat + ramp" terrain (custom)
 
-Les terrains inclinés fournis par mjlab sont des pyramides ; on écrit donc un
-`SubTerrainCfg` dédié (p. ex. `FlatRampTerrainCfg`) dont la méthode
-`function(difficulty, spec, rng)` construit :
+The sloped terrains shipped with mjlab are pyramids; we therefore write a
+dedicated `SubTerrainCfg` (e.g. `FlatRampTerrainCfg`) whose
+`function(difficulty, spec, rng)` method builds:
 
-- une **zone plate de départ** (longueur ~1–2 m) où le robot spawne ;
-- une **rampe descendante** à la suite, dont l'angle est
-  **interpolé par `difficulty`** sur `[~2°, ~20°]`.
+- a **starting flat area** (~1–2 m long) where the robot spawns;
+- a **downhill ramp** after it, whose angle is
+  **interpolated by `difficulty`** over `[~2°, ~20°]`.
 
-Le terrain est monté via `TerrainEntityCfg(terrain_type="generator", ...)` avec un
-`TerrainGeneratorCfg` qui génère plusieurs niveaux de difficulté (donc plusieurs
-angles de rampe). L'origine de chaque environnement doit tomber **sur la zone
-plate**, la rampe devant lui.
+The terrain is mounted through `TerrainEntityCfg(terrain_type="generator", ...)` with a
+`TerrainGeneratorCfg` that generates several difficulty levels (hence several
+ramp angles). Each environment's origin must land **on the flat area**, with the
+ramp in front of it.
 
-> Risque d'implémentation à traiter dans le plan : positionnement de l'origine de
-> spawn sur le plat (pas au centre de la tuile), et orientation de la rampe pour
-> que « devant » = « vers le bas ».
+> Implementation risk to address in the plan: placing the spawn origin on the
+> flat (not at the tile center), and orienting the ramp so that "forward" =
+> "downhill".
 
-### 3. Commande = aucune
+### 3. Command = none
 
-Slot `twist` neutralisé : `rel_standing_envs = 1.0`, ranges de vitesse à 0,
-`rel_heading_envs = 0.0`. Head/body restent en zéro-padding. La politique ne
-reçoit aucune consigne de déplacement.
+The `twist` slot is neutralized: `rel_standing_envs = 1.0`, velocity ranges at 0,
+`rel_heading_envs = 0.0`. Head/body stay zero-padded. The policy receives no
+movement instruction at all.
 
-### 4. Reset & vitesse d'impulsion
+### 4. Reset & impulse velocity
 
-- `reset_base` : spawn au repos sur le plat, hauteur `z` nominale rollers
-  (~`0.1335–0.1435`, comme le roller env).
-- **Vitesse d'entrée** injectée via le `velocity_range` de
-  `reset_root_state_uniform` (état propre + range), **pas** via
-  `push_by_setting_velocity` (qui s'additionne à l'état courant et peut faire
-  diverger le free-joint → NaN — leçon déjà apprise sur `roller_crouch`) :
-  `x ≈ (0.2, 0.5) m/s` vers l'avant.
-- Pushs aléatoires légers conservés pendant l'épisode (robustesse), comme le
+- `reset_base`: spawn at rest on the flat, at the nominal roller `z` height
+  (~`0.1335–0.1435`, like the roller env).
+- **Entry velocity** injected through the `velocity_range` of
+  `reset_root_state_uniform` (clean state + range), **not** through
+  `push_by_setting_velocity` (which adds to the current state and can make the
+  free joint diverge → NaN — a lesson already learned on `roller_crouch`):
+  `x ≈ (0.2, 0.5) m/s` forward.
+- Light random pushes kept during the episode (robustness), like the
   roller env.
 
-### 5. Récompenses
+### 5. Rewards
 
-Cœur « rester droit + posture naturelle », anti-optimum-paresseux (éviter qu'il
-s'écrase au sol pour maximiser la stabilité) :
+Core "stay upright + natural posture", anti-lazy-optimum (preventing it from
+flattening itself onto the ground to maximize stability):
 
-- `upright` (tronc vertical) — **principale**
-- `alive` (bonus de survie par pas)
-- **pose debout nominale** : récompense vers la pose HOME (mécanique
-  d'interpolation de pose reprise de `roller_crouch`, mais cible fixe = debout),
-  pour garder une stance rollers normale plutôt qu'un accroupi défensif
-- `feet_flat` (rollers à plat au sol)
-- `body_ang_vel`, `angular_momentum` (pas de tremblement / vrille)
+- `upright` (vertical trunk) — **primary**
+- `alive` (per-step survival bonus)
+- **nominal standing pose**: reward toward the HOME pose (pose-interpolation
+  machinery taken from `roller_crouch`, but with a fixed target = standing),
+  to keep a normal roller stance rather than a defensive crouch
+- `feet_flat` (rollers flat on the ground)
+- `body_ang_vel`, `angular_momentum` (no shaking / twisting)
 - `action_rate_l2`, `neck_action_rate_l2`, `joint_torques_l2`,
-  `self_collisions` (douceur + sim2real)
+  `self_collisions` (smoothness + sim2real)
 
-> Pas de récompense de vitesse/frein : la descente est passive. On ne récompense
-> pas « aller vite », seulement « rester droit en descendant ».
+> No speed/braking reward: the descent is passive. We do not reward "going
+> fast", only "staying upright while going down".
 
-### 6. Terminaisons
+### 6. Terminations
 
-- **Chute** : `bad_orientation` (tronc trop incliné).
-- **Bas atteint** : `out_of_terrain_bounds` (le robot est arrivé en bas de la
-  rampe → reset).
+- **Fall**: `bad_orientation` (trunk tilted too far).
+- **Bottom reached**: `out_of_terrain_bounds` (the robot has reached the bottom
+  of the ramp → reset).
 - `nan_state`, time-out.
 
-### 7. Curriculum de difficulté (raideur)
+### 7. Difficulty (steepness) curriculum
 
-Progression **doux → raide** : commencer sur des rampes quasi plates, augmenter
-l'angle vers 20° au fur et à mesure des réussites.
+Progression **gentle → steep**: start on nearly flat ramps and increase the
+angle toward 20° as successes accumulate.
 
-> Risque d'implémentation : le curriculum standard `terrain_levels_vel` promeut
-> selon la distance parcourue par rapport à la vitesse commandée. Ici la commande
-> est nulle, donc **il faut un critère de promotion custom** : promouvoir si le
-> robot a survécu / atteint le bas sans tomber, rétrograder s'il chute tôt.
+> Implementation risk: the standard `terrain_levels_vel` curriculum promotes
+> based on distance travelled relative to the commanded velocity. Here the
+> command is zero, so **a custom promotion criterion is needed**: promote if the
+> robot survived / reached the bottom without falling, demote if it falls early.
 
-### 8. Déploiement — bouton `Y`
+### 8. Deployment — the `Y` button
 
-Dans `scripts/infer_policy.py` :
+In `scripts/infer_policy.py`:
 
-- nouveau flag `--slope <onnx>` chargeant la politique pente comme session
-  supplémentaire (même schéma que `--walking` / `--standing` / `--ground-pick`) ;
-- `GLFW_KEY_Y = 89` (aujourd'hui **libre** — la tête est sur `H`) qui **bascule**
-  la session active vers/depuis la politique pente ;
-- ligne d'aide clavier ajoutée.
+- a new `--slope <onnx>` flag loading the slope policy as an additional session
+  (same scheme as `--walking` / `--standing` / `--ground-pick`);
+- `GLFW_KEY_Y = 89` (currently **free** — the head is on `H`) which **toggles**
+  the active session to/from the slope policy;
+- a keyboard help line added.
 
-Aucun contrôle existant n'est cassé (contrairement à un partage de la touche `H`
-du contrôle de la tête).
+No existing control is broken (unlike sharing the head control's `H` key).
 
-## Ce qui n'est PAS dans le périmètre (YAGNI)
+## What is NOT in scope (YAGNI)
 
-- Pas de pilotage gauche/droite ni de freinage en descente.
-- Pas de montée de pente ni de traversée.
-- Pas de pyramide ni de terrains multi-directions.
-- Pas de fine-tuning depuis les poids roller existants (entraînement from
-  scratch).
+- No left/right steering and no braking on the descent.
+- No uphill climbing and no traversal.
+- No pyramid and no multi-direction terrains.
+- No fine-tuning from the existing roller weights (training from scratch).
 
-## Livrables
+## Deliverables
 
 1. `microduck_roller_slope_env_cfg.py` (env + `FlatRampTerrainCfg` + PPO cfg).
-2. Enregistrement de la tâche dans `tasks/__init__.py`.
-3. Récompenses/curriculum custom nécessaires dans `tasks/mdp.py` (pose-debout,
-   promotion de niveau).
-4. Branchement `--slope` + touche `Y` dans `scripts/infer_policy.py`.
-5. Tests unitaires pour les fonctions pures (angle de rampe par difficulté,
-   éventuel critère de promotion).
+2. Task registration in `tasks/__init__.py`.
+3. Any custom rewards/curriculum needed in `tasks/mdp.py` (standing pose, level
+   promotion).
+4. `--slope` wiring + the `Y` key in `scripts/infer_policy.py`.
+5. Unit tests for the pure functions (ramp angle by difficulty, and the
+   promotion criterion if any).

--- a/docs/superpowers/specs/2026-07-24-ground-pick-pose-following-design.md
+++ b/docs/superpowers/specs/2026-07-24-ground-pick-pose-following-design.md
@@ -1,42 +1,42 @@
-# Ground-pick par suivi de pose interpolée par la phase
+# Ground-pick by phase-interpolated pose following
 
-**Date** : 2026-07-24
-**Branche** : `new_pre_alpha_ground_pick`
-**Fichier cible** : `src/mjlab_microduck/tasks/microduck_ground_pick_env_cfg.py` (réécriture en place)
-**Task id** : `Mjlab-GroundPick-Flat-MicroDuck` (inchangé)
+**Date**: 2026-07-24
+**Branch**: `new_pre_alpha_ground_pick`
+**Target file**: `src/mjlab_microduck/tasks/microduck_ground_pick_env_cfg.py` (rewritten in place)
+**Task id**: `Mjlab-GroundPick-Flat-MicroDuck` (unchanged)
 
-## 1. Objectif
+## 1. Objective
 
-Remplacer l'objectif *espace-tâche* du ground_pick actuel (récompense la bouche
-qui descend au sol, puis récompense séparément le retour debout) par un objectif
-**directif de suivi de pose** : on définit deux poses articulaires cibles — STAND
-et DOWN — et on récompense le suivi de la **pose interpolée par la phase**
+Replace the current ground_pick's *task-space* objective (reward the mouth going
+down to the ground, then separately reward the return to standing) with a
+**directive pose-following objective**: we define two target joint poses — STAND
+and DOWN — and reward tracking of the **phase-interpolated pose**
 (STAND→DOWN→STAND).
 
-Motivation (reprise de l'approche roller_crouch, validée) : l'objectif par pose
-interpolée est **symétrique par construction** — le « se relever » (cible → STAND)
-est récompensé exactement comme le « se baisser » (cible → DOWN), ce qui règle le
-problème d'optimum paresseux où la policy descend mais remonte mal. Le signal est
-**dense à chaque phase** (cible qui bouge en continu), contrairement à une cible
-fixe pondérée par `sin` qui ne donne aucun signal aux transitions.
+Motivation (taken from the roller_crouch approach, which is validated): the
+interpolated-pose objective is **symmetric by construction** — "standing back up"
+(target → STAND) is rewarded exactly like "going down" (target → DOWN), which
+fixes the lazy-optimum problem where the policy goes down but comes back up
+poorly. The signal is **dense at every phase** (a continuously moving target),
+unlike a fixed target weighted by `sin`, which gives no signal at the transitions.
 
-Le geste reste déclenché au **bouton A** via le slot `--ground-pick` du runtime
-(one-shot, retour auto à la policy principale). Obs 61D unifié inchangé →
-policy interchangeable dans le slot.
+The gesture stays triggered by **button A** through the runtime's `--ground-pick`
+slot (one-shot, automatic return to the main policy). The unified 61D obs is
+unchanged → the policy stays hot-swappable in the slot.
 
-## 2. Poses cibles
+## 2. Target poses
 
-Résolution des joints **PAR NOM** (`asset.find_joints([name])`) — robuste, cohérent
-avec l'approche roller. 14 joints (mouth exclu).
+Joints resolved **BY NAME** (`asset.find_joints([name])`) — robust, and consistent
+with the roller approach. 14 joints (mouth excluded).
 
-- **STAND_POSE** = HOME (`default_joint_pos` du modèle). Source du blend ; ne pas
-  la redéfinir en dur — utiliser le défaut du modèle comme source (blend=0).
-  Au déploiement, la policy principale reprend depuis HOME → retour propre.
+- **STAND_POSE** = HOME (the model's `default_joint_pos`). The blend source; do not
+  redefine it by hand — use the model default as the source (blend=0).
+  At deployment, the main policy resumes from HOME → clean return.
 
-- **DOWN_POSE** = valeurs initiales issues du **keyframe FOLD** de `scene_walk.xml`
-  (pli avant profond, tête baissée → bouche vers le sol). Dict par nom en tête de
-  fichier, **commenté comme remplaçable par une lecture `read_pose.py`** du vrai
-  robot posé bouche-au-sol. Valeurs de départ :
+- **DOWN_POSE** = initial values taken from the **FOLD keyframe** of `scene_walk.xml`
+  (deep forward fold, head down → mouth toward the ground). A by-name dict at the top of
+  the file, **commented as replaceable with a `read_pose.py` reading** of the real
+  robot placed mouth-to-ground. Starting values:
 
   ```python
   DOWN_POSE = {
@@ -48,114 +48,113 @@ avec l'approche roller. 14 joints (mouth exclu).
   }
   ```
 
-## 3. Profil de phase (4 segments)
+## 3. Phase profile (4 segments)
 
-Commande `GroundPickPhaseCommand` : `[cos(2πφ), sin(2πφ), 0]`, période **4.0 s**
-(défaut du slot runtime → pas de flag période à changer au déploiement).
+`GroundPickPhaseCommand` command: `[cos(2πφ), sin(2πφ), 0]`, period **4.0 s**
+(the runtime slot's default → no period flag to change at deployment).
 
 ```
-DESCENT_END=0.15  HOLD_END=0.50  RISE_END=0.65   (période 4 s)
-[0, 0.15)     descente  STAND->DOWN   ~0.6 s   blend 0->1
-[0.15, 0.50)  bas       DOWN          ~1.4 s   blend 1
-[0.50, 0.65)  remontée  DOWN->STAND   ~0.6 s   blend 1->0
-[0.65, 1.0)   haut      STAND (repos) ~1.4 s   blend 0
+DESCENT_END=0.15  HOLD_END=0.50  RISE_END=0.65   (4 s period)
+[0, 0.15)     descent  STAND->DOWN   ~0.6 s   blend 0->1
+[0.15, 0.50)  low      DOWN          ~1.4 s   blend 1
+[0.50, 0.65)  rise     DOWN->STAND   ~0.6 s   blend 1->0
+[0.65, 1.0)   high     STAND (rest)  ~1.4 s   blend 0
 ```
 
-`blend ∈ [0,1]` : 0 = STAND (HOME), 1 = DOWN. Cible = `stand + blend·(down - stand)`.
-Bornes tunables (constantes en tête de fichier).
+`blend ∈ [0,1]`: 0 = STAND (HOME), 1 = DOWN. Target = `stand + blend·(down - stand)`.
+Tunable bounds (constants at the top of the file).
 
-**`randomize_phase=False`** : chaque épisode démarre à φ=0 (= debout), comme le
-déclenchement bouton A au déploiement. Les épisodes se réinitialisant à des
-instants échelonnés, les envs se décorrèlent naturellement en phase (pas besoin de
-randomiser). Nécessite d'ajouter un flag `randomize_phase` à
-`GroundPickPhaseCommandCfg` (défaut `True` → autres tâches sit/stand inchangées),
-honoré dans `reset()`.
+**`randomize_phase=False`**: every episode starts at φ=0 (= standing), like the
+button-A trigger at deployment. Since episodes reset at staggered times, the envs
+naturally decorrelate in phase (no need to randomize). This requires adding a
+`randomize_phase` flag to `GroundPickPhaseCommandCfg` (default `True` → the other
+sit/stand tasks are unchanged), honored in `reset()`.
 
-## 4. Nouvelles fonctions mdp (portées de roller, adaptées, par nom)
+## 4. New mdp functions (ported from roller, adapted, by name)
 
-Dans `src/mjlab_microduck/tasks/mdp.py`. Noms distincts du `phase_pose_match`
-existant (qui est la variante cible-fixe-pondérée-sin) pour éviter la confusion.
+In `src/mjlab_microduck/tasks/mdp.py`. Names deliberately distinct from the existing
+`phase_pose_match` (which is the fixed-target, sin-weighted variant) to avoid confusion.
 
-- **`phase_pose_blend(phase, descent_end, hold_end, rise_end) -> Tensor`** — pur,
-  blend 4 segments 0..1 (testable en isolation).
+- **`phase_pose_blend(phase, descent_end, hold_end, rise_end) -> Tensor`** — pure,
+  4-segment blend 0..1 (testable in isolation).
 - **`_phase_pose_error(env, asset_cfg, command_name, target_pose, descent_end,
-  hold_end, rise_end, source_pose=None) -> (cur, target)`** — résout les joints par
-  nom ; `source_pose` = HOME (`default_joint_pos`) si `None` ; calcule
-  `phase = atan2(sin,cos)/2π % 1`, `blend`, puis `target = source + blend·(target_pose - source)`.
+  hold_end, rise_end, source_pose=None) -> (cur, target)`** — resolves joints by
+  name; `source_pose` = HOME (`default_joint_pos`) if `None`; computes
+  `phase = atan2(sin,cos)/2π % 1`, `blend`, then `target = source + blend·(target_pose - source)`.
 - **`phase_pose_track(env, command_name, target_pose, source_pose=None, std=0.3,
-  descent_end, hold_end, rise_end, asset_cfg) -> Tensor`** — gaussienne
+  descent_end, hold_end, rise_end, asset_cfg) -> Tensor`** — gaussian
   `exp(-((cur-target)/std)²).mean(-1)`.
-- **`phase_pose_track_l1(env, ...même args sans std...) -> Tensor`** — bootstrap
-  `-(cur-target).abs().mean(-1)` (gradient constant quand la gaussienne sature).
+- **`phase_pose_track_l1(env, ...same args without std...) -> Tensor`** — bootstrap
+  `-(cur-target).abs().mean(-1)` (constant gradient when the gaussian saturates).
 
-`target_pose` = `DOWN_POSE` (dict par nom). `source_pose=None` → HOME.
+`target_pose` = `DOWN_POSE` (by-name dict). `source_pose=None` → HOME.
 
 ## 5. Rewards
 
-Réécriture minimale par rapport à l'actuel — on remplace la mécanique de retour de
-pose, on garde la stabilité/régul/sim2real.
+A minimal rewrite relative to the current one — we replace the pose-return
+machinery and keep the stability/regularization/sim2real stack.
 
-| Reward | Poids | Statut | Rôle |
+| Reward | Weight | Status | Role |
 |---|---|---|---|
-| `phase_pose_track` (std 0.3) | **6.0** | **NOUVEAU** | suivi pose interpolée STAND↔DOWN |
-| `phase_pose_track_l1` | **2.0** | **NOUVEAU** | bootstrap L1 |
-| `mouth_ground_proximity` (std 0.10) | **1.0** | retune (était 2.0) | filet : garantit la bouche au sol si DOWN imparfaite ; gaté approche (+sin) |
-| `upright` | 0.2 | gardé | tronc ~vertical (faible, le robot penche) |
-| `feet_grounded` | 3.0 | gardé | 2 pieds au sol pendant tout le geste |
-| `self_collisions` | -1.0 | gardé | |
-| `head_impact_penalty` (seuil 2 N) | -0.5 | gardé | pas de slam tête (DOWN amène la tête bas) |
-| `action_rate_l2` | -0.8→-2.0 (curric) | gardé | lissage |
-| `neck_action_rate_l2` | -1.0 | gardé | |
-| `joint_torques_l2` | -5e-3 | gardé | |
-| `body_ang_vel` | -0.05 | gardé | |
-| `angular_momentum` | -0.02 | gardé | |
-| `soft_landing` | -1e-5 | gardé | |
+| `phase_pose_track` (std 0.3) | **6.0** | **NEW** | tracks the interpolated STAND↔DOWN pose |
+| `phase_pose_track_l1` | **2.0** | **NEW** | L1 bootstrap |
+| `mouth_ground_proximity` (std 0.10) | **1.0** | retuned (was 2.0) | safety net: guarantees the mouth reaches the ground if DOWN is imperfect; gated on the approach (+sin) |
+| `upright` | 0.2 | kept | trunk ~vertical (low weight, the robot leans) |
+| `feet_grounded` | 3.0 | kept | both feet on the ground throughout the gesture |
+| `self_collisions` | -1.0 | kept | |
+| `head_impact_penalty` (threshold 2 N) | -0.5 | kept | no head slam (DOWN brings the head low) |
+| `action_rate_l2` | -0.8→-2.0 (curric) | kept | smoothing |
+| `neck_action_rate_l2` | -1.0 | kept | |
+| `joint_torques_l2` | -5e-3 | kept | |
+| `body_ang_vel` | -0.05 | kept | |
+| `angular_momentum` | -0.02 | kept | |
+| `soft_landing` | -1e-5 | kept | |
 
-**Retirées** : `mouth_perpendicular_to_ground`, `ground_pick_return_pose_legs`,
-`ground_pick_return_pose_neck` (remplacées par le suivi de pose).
+**Removed**: `mouth_perpendicular_to_ground`, `ground_pick_return_pose_legs`,
+`ground_pick_return_pose_neck` (replaced by pose following).
 
-Tout le reste **inchangé** : bloc DR (CoM/head-CoM/mass-inertia/friction/armature/
-IMU-misalign/encoder-bias/pushes), obs 61D + padding head/body zéro, terminaisons
-(`nan_state`), curricula (`action_rate_weight`, `com_range`, `head_com_range`),
-RlCfg (`experiment_name="ground_pick"`).
+Everything else is **unchanged**: the DR block (CoM/head-CoM/mass-inertia/friction/armature/
+IMU-misalign/encoder-bias/pushes), the 61D obs + zero head/body padding, the terminations
+(`nan_state`), the curricula (`action_rate_weight`, `com_range`, `head_com_range`),
+and the RlCfg (`experiment_name="ground_pick"`).
 
-## 6. Déploiement (parité sim2real)
+## 6. Deployment (sim2real parity)
 
 ```bash
 microduck_runtime ... \
   --ground-pick ground_pick.onnx \
-  --ground-pick-period 4.0 \       # = période env (défaut, rien à changer)
-  --ground-pick-kp-ratio 1.0 \     # entraîné kp 200 → forcer 1.0 (défaut 0.6 baisse à 120)
-  --ground-pick-action-scale 1.0   # = action.scale env
+  --ground-pick-period 4.0 \       # = env period (the default, nothing to change)
+  --ground-pick-kp-ratio 1.0 \     # trained at kp 200 → force 1.0 (the 0.6 default lowers it to 120)
+  --ground-pick-action-scale 1.0   # = env action.scale
 ```
 
 ## 7. Tests
 
-`tests/` (lancer `uv run --with pytest pytest tests/ -q`) :
+In `tests/` (run `uv run --with pytest pytest tests/ -q`):
 
-- **Fonctions pures** : `phase_pose_blend` aux points clés
-  (φ=0→0, φ=0.075→0.5, φ=0.3→1, φ=0.575→0.5, φ=0.8→0, monotone par segment) ;
-  `phase_pose_track`/`_l1` : valeur max (cur==target) et signe.
-- **Construction de l'env** : `make_microduck_ground_pick_env_cfg()` construit ;
-  commande = `GroundPickPhaseCommand` avec `randomize_phase=False`, `period=4.0` ;
-  rewards `phase_pose_track`/`phase_pose_track_l1` présents ;
-  `mouth_perpendicular_to_ground`/`ground_pick_return_pose_*` absents ;
-  `mouth_ground_proximity` présent poids 1.0.
+- **Pure functions**: `phase_pose_blend` at the key points
+  (φ=0→0, φ=0.075→0.5, φ=0.3→1, φ=0.575→0.5, φ=0.8→0, monotone per segment);
+  `phase_pose_track`/`_l1`: maximum value (cur==target) and sign.
+- **Env construction**: `make_microduck_ground_pick_env_cfg()` builds;
+  the command is a `GroundPickPhaseCommand` with `randomize_phase=False`, `period=4.0`;
+  the `phase_pose_track`/`phase_pose_track_l1` rewards are present;
+  `mouth_perpendicular_to_ground`/`ground_pick_return_pose_*` are absent;
+  `mouth_ground_proximity` is present with weight 1.0.
 
-## 8. Entraînement / play / export
+## 8. Training / play / export
 
 ```bash
 uv run train Mjlab-GroundPick-Flat-MicroDuck --env.scene.num-envs 4096 --agent.max_iterations 20000
 uv run scripts/play_latest.py     # md-play
-uv run scripts/export_latest.py   # normaliseur baké dans l'ONNX
+uv run scripts/export_latest.py   # normalizer baked into the ONNX
 ```
-Surveiller `Episode_Reward/phase_pose_track` (doit monter).
+Watch `Episode_Reward/phase_pose_track` (it must rise).
 
-## 9. Hors scope / notes
+## 9. Out of scope / notes
 
-- **Doublon `pose_target_match`** (mdp.py 1577 et 1914) : latent, non traité ici.
-- **Ajustement DOWN_POSE** : si la bouche ne touche pas assez le sol avec les
-  valeurs FOLD, ajuster le dict (idéalement lecture `read_pose.py` du vrai robot
-  posé bouche-au-sol) plutôt que de gonfler `mouth_ground_proximity`.
-- **Transition au déploiement** : STAND=HOME = neutre de la policy principale →
-  pas d'à-coup au retour (contrairement au souci noté sur roller où STAND≠HOME).
+- **Duplicate `pose_target_match`** (mdp.py 1577 and 1914): latent, not addressed here.
+- **Tuning DOWN_POSE**: if the mouth does not reach the ground closely enough with the
+  FOLD values, adjust the dict (ideally a `read_pose.py` reading of the real robot
+  placed mouth-to-ground) rather than inflating `mouth_ground_proximity`.
+- **Transition at deployment**: STAND=HOME = the main policy's neutral →
+  no jolt on return (unlike the issue noted on roller, where STAND≠HOME).

--- a/docs/superpowers/specs/2026-07-24-shoot-pose-following-design.md
+++ b/docs/superpowers/specs/2026-07-24-shoot-pose-following-design.md
@@ -1,202 +1,202 @@
-# Spec — Tâche RL « shoot dans une balle » par suivi de poses
+# Spec — "Kick a ball" RL task by pose following
 
-**Date** : 2026-07-24
-**Branche** : `new_pre_alpha_ground_pick`
-**Task id** : `Mjlab-Shoot-Flat-MicroDuck`
+**Date**: 2026-07-24
+**Branch**: `new_pre_alpha_ground_pick`
+**Task id**: `Mjlab-Shoot-Flat-MicroDuck`
 
-## Objectif
+## Objective
 
-Apprendre un geste de **shoot one-shot** (frappe dans une balle) par **suivi d'une
-trajectoire de poses articulaires à 4 keyframes** interpolée par la phase :
+Learn a **one-shot kick gesture** (striking a ball) by **following a 4-keyframe
+joint-pose trajectory** interpolated along the phase:
 
 ```
-STAND → PIED_ARRIÈRE (armement) → PIED_AVANT (frappe) → STAND (repos)
+STAND → FOOT_BACK (wind-up) → FOOT_FORWARD (strike) → STAND (rest)
 ```
 
-- **Jambe droite** frappe, **jambe gauche** en appui.
-- **Aucune balle simulée** : on apprend le *geste* par suivi de poses (comme
-  `ground_pick` / crouch). Si une vraie balle est devant le robot au déploiement,
-  elle se fait frapper.
-- Obs **61D unifiée** identique aux autres policies microduck → l'ONNX exporté se
-  déploie tel quel dans un **slot bouton** du runtime (one-shot : joue le geste
-  puis rend la main à la policy principale).
+- The **right leg** kicks, the **left leg** provides support.
+- **No simulated ball**: we learn the *gesture* through pose following (like
+  `ground_pick` / crouch). If a real ball is in front of the robot at deployment,
+  it gets kicked.
+- **Unified 61D obs**, identical to the other microduck policies → the exported
+  ONNX deploys as-is into a runtime **button slot** (one-shot: it plays the
+  gesture then hands control back to the main policy).
 
-Même moule que la tâche `ground_pick` de cette branche (phase encodée `[cos, sin, 0]`
-dans le slot twist, suivi de pose par phase, obs 61D, DR sim2real héritée de velocity).
+Same mold as this branch's `ground_pick` task (phase encoded as `[cos, sin, 0]`
+in the twist slot, per-phase pose following, 61D obs, sim2real DR inherited from velocity).
 
-## Non-objectifs (YAGNI)
+## Non-objectives (YAGNI)
 
-- Pas de balle physique, pas de reward de contact/vitesse de balle.
-- Pas de côté configurable (droite uniquement ; gauche = symétrisable plus tard si besoin).
-- Pas de marche / récupération de chute : tous les termes de locomotion sont retirés.
+- No physical ball, no contact/ball-velocity reward.
+- No configurable side (right only; left = mirrorable later if needed).
+- No walking / fall recovery: all locomotion terms are removed.
 
 ## Architecture
 
-### Fichier & enregistrement
+### File & registration
 - `src/mjlab_microduck/tasks/microduck_shoot_env_cfg.py`
   - `make_microduck_shoot_env_cfg(play: bool = False, rough: bool = False) -> ManagerBasedRlEnvCfg`
   - `MicroduckShootRlCfg` (RslRlOnPolicyRunnerCfg, `experiment_name="shoot"`)
-- Enregistrement dans `src/mjlab_microduck/tasks/__init__.py` :
-  `Mjlab-Shoot-Flat-MicroDuck` (variante `-Rough-` optionnelle).
-- Base : hérite de l'env velocity (via `make_velocity_env_cfg` comme ground_pick),
-  puis strip agressif de tout ce qui est locomotion.
-- Robot : `MICRODUCK_WALK_ROBOT_CFG` (marche standard, 14 joints, pas de rollers).
+- Registration in `src/mjlab_microduck/tasks/__init__.py`:
+  `Mjlab-Shoot-Flat-MicroDuck` (optional `-Rough-` variant).
+- Base: inherits from the velocity env (via `make_velocity_env_cfg` like ground_pick),
+  then aggressively strips everything locomotion-related.
+- Robot: `MICRODUCK_WALK_ROBOT_CFG` (standard walker, 14 joints, no rollers).
 - `action.scale = 1.0`.
 
-### Poses (placeholders → lues sur le vrai robot via `read_pose.py`)
-Dicts `{nom_joint: rad}`, **14 joints** (mouth exclu). Sommet du fichier env.
-- `STAND_POSE` : station neutre (~HOME du sim).
-- `KICK_BACK_POSE` : hanche droite en **extension arrière** + genou droit fléchi
-  (armement) ; jambe gauche + cou ≈ HOME.
-- `KICK_FWD_POSE` : hanche droite **fléchie avant** + genou droit tendu (frappe) ;
-  jambe gauche + cou ≈ HOME.
+### Poses (placeholders → read off the real robot via `read_pose.py`)
+`{joint_name: rad}` dicts, **14 joints** (mouth excluded). At the top of the env file.
+- `STAND_POSE`: neutral stance (~the sim's HOME).
+- `KICK_BACK_POSE`: right hip in **backward extension** + right knee flexed
+  (wind-up); left leg + neck ≈ HOME.
+- `KICK_FWD_POSE`: right hip **flexed forward** + right knee extended (strike);
+  left leg + neck ≈ HOME.
 
-Placeholders plausibles au départ (ajustables), à remplacer par les lectures réelles.
+Plausible placeholders to begin with (adjustable), to be replaced by real readings.
 
-### Commande & phase
-- Réutilise `GroundPickPhaseCommand` : `command = [cos(2π·φ), sin(2π·φ), 0]` dans le
-  slot twist.
-- **Période** : `SHOOT_PERIOD ≈ 2.5 s` (configurable via `cfg.period`).
-- **Nouveau flag `randomize_phase`** sur `GroundPickPhaseCommandCfg` /
-  `GroundPickPhaseCommand` :
-  - Défaut `True` (non-cassant : `ground_pick` garde le comportement actuel).
-  - Shoot le met à `False` → `reset()` remet φ=0 au lieu de `rand()`.
-  - Raison : chaque épisode démarre au STAND (état du robot = `default_joint_pos`)
-    avec φ=0 = cible STAND → cohérence état/cible au reset (sinon la policy est
-    sommée d'être instantanément en pose « frappe » depuis une station immobile).
-  - **Invariant de cohérence** : `STAND_POSE` DOIT égaler la pose articulaire de
-    reset du sim (`HOME_FRAME` / `default_joint_pos`, non nulle : hip_pitch ±0.4579,
-    ankle ±0.4530, hip_roll ±0.0873, neck/head_pitch 0.3491). Vérifié par
-    `test_stand_pose_matches_home_standing_pose`. Les placeholders initialement à
-    zéro cassaient cet invariant (corrigé après revue finale).
+### Command & phase
+- Reuses `GroundPickPhaseCommand`: `command = [cos(2π·φ), sin(2π·φ), 0]` in the
+  twist slot.
+- **Period**: `SHOOT_PERIOD ≈ 2.5 s` (configurable via `cfg.period`).
+- **New `randomize_phase` flag** on `GroundPickPhaseCommandCfg` /
+  `GroundPickPhaseCommand`:
+  - Default `True` (non-breaking: `ground_pick` keeps its current behavior).
+  - Shoot sets it to `False` → `reset()` sets φ=0 instead of `rand()`.
+  - Reason: every episode starts at STAND (robot state = `default_joint_pos`)
+    with φ=0 = the STAND target → state/target consistency at reset (otherwise the
+    policy is required to be instantly in the "strike" pose from a standstill).
+  - **Consistency invariant**: `STAND_POSE` MUST equal the sim's reset joint pose
+    (`HOME_FRAME` / `default_joint_pos`, which is non-zero: hip_pitch ±0.4579,
+    ankle ±0.4530, hip_roll ±0.0873, neck/head_pitch 0.3491). Verified by
+    `test_stand_pose_matches_home_standing_pose`. The placeholders initially set to
+    zero broke this invariant (fixed after the final review).
 
-### Reset (hauteur debout, pas d'élan)
-- `reset_base.pose_range.z = (0.12, 0.13)` — **hauteur debout absolue** (le `pos`
-  racine par défaut de `InitialStateCfg` est (0,0,0), donc z de reset = 0.12–0.13 m,
-  pas un offset additif ; valeur identique à l'env velocity qui marche). Pas de chute.
-- **Pas d'injection de vitesse d'entrée** (shoot debout, contrairement au crouch-glide).
+### Reset (standing height, no run-up)
+- `reset_base.pose_range.z = (0.12, 0.13)` — an **absolute standing height** (the
+  default root `pos` of `InitialStateCfg` is (0,0,0), so the reset z is 0.12–0.13 m,
+  not an additive offset; the same value as the velocity env, which works). No fall.
+- **No entry-velocity injection** (kicking from standing, unlike crouch-glide).
 
-### Rewards hérités non listés
-La table ci-dessus n'est pas exhaustive : l'env hérite de velocity quelques
-régularisateurs génériques de faible poids non spécifiques au shoot —
-`angular_momentum` (-0.02), `dof_pos_limits` — conservés (stabilité, négligeables).
-⚠️ `soft_landing` (reward de marche) est **retiré** : il lit le capteur 2-pieds
-`feet_ground_contact` supprimé au profit du capteur pied gauche → KeyError au 1er step
-sinon, et il est inerte pour un shoot debout.
+### Inherited rewards not listed
+The table above is not exhaustive: the env inherits from velocity a few generic
+low-weight regularizers not specific to the kick —
+`angular_momentum` (-0.02), `dof_pos_limits` — kept (stability, negligible).
+⚠️ `soft_landing` (a walking reward) is **removed**: it reads the two-foot
+`feet_ground_contact` sensor, dropped in favor of the left-foot sensor → KeyError on the
+first step otherwise, and it is inert for a standing kick.
 
-### Gotcha renommage capteur (⚠️)
-Renommer le capteur pied (`feet_ground_contact` → `left_foot_ground_contact`) casse
-tout ce que l'héritage velocity/ground_pick référence par ce nom. À traiter :
-- **obs critic** `foot_air_time`/`foot_contact`/`foot_contact_forces` → repointés vers
-  le capteur pied gauche (le critic garde l'info d'appui ; sinon KeyError à la
-  construction de l'env).
-- **reward** `soft_landing` → retiré (voir ci-dessus ; sinon KeyError au 1er step).
-Toujours valider par une construction live + **au moins un `step()`** (le reward
-manager ne tourne qu'au step), pas seulement le build de cfg ni les tests unitaires.
+### Sensor-renaming gotcha (⚠️)
+Renaming the foot sensor (`feet_ground_contact` → `left_foot_ground_contact`) breaks
+everything the velocity/ground_pick inheritance references by that name. To handle:
+- **critic obs** `foot_air_time`/`foot_contact`/`foot_contact_forces` → repointed at
+  the left-foot sensor (the critic keeps the support information; otherwise KeyError at
+  env construction).
+- **reward** `soft_landing` → removed (see above; otherwise KeyError on the first step).
+Always validate with a live construction + **at least one `step()`** (the reward
+manager only runs at step time), not just the cfg build or the unit tests.
 
-### ⚠️ Transfert de poids appris (révision post-1er entraînement)
-Constat : les poses BACK/FWD relevées **robot tenu à la main (appui bipède)** gardent le
-CoM **centré entre les deux pieds** (~4-5 cm à l'intérieur du pied gauche) à toutes les
-phases. Avec `upright` imposé, dès que le pied droit se lève le robot bascule → aucune
-policy ne peut tenir (géométrique, pas du tuning). Vérifié en sim (CoM vs sites pieds).
+### ⚠️ Learned weight transfer (revision after the first training run)
+Finding: the BACK/FWD poses recorded with the **robot held by hand (double support)** keep the
+CoM **centered between both feet** (~4-5 cm inside the left foot) at every phase.
+With `upright` imposed, as soon as the right foot lifts the robot tips over → no
+policy can hold it (geometric, not a tuning issue). Verified in sim (CoM vs foot sites).
 
-Fix retenu (RL apprend l'équilibre) :
-- `mdp.com_over_support_foot` : reward gaussien (std 4 cm) tirant la projection du CoM
-  (`root_com_pos_w`) vers le pied d'appui, **gaté** par `mdp.kick_engagement` (0 au repos
-  STAND, 1 pendant la frappe). Poids 3.0.
-- **suivi de pose scindé** (param `joint_names` sur `kick_pose_track`/`_l1`) :
-  GESTE = jambe droite + cou/tête (std 0.35, serré) ; APPUI = jambe gauche (std 0.9,
-  poids 1.0, **lâche**) → la policy peut adducter/décaler le bassin pour transférer le
-  poids sans que le suivi fige le bassin centré.
-La table « Équilibre / appui » ci-dessus est donc étendue : `support_leg_pose` (1.0),
-`com_over_support` (3.0) s'ajoutent, et `kick_pose_track`/`kick_pose_l1` ne portent plus
-que sur les 9 joints du geste (droite+cou).
+Chosen fix (let RL learn the balance):
+- `mdp.com_over_support_foot`: a gaussian reward (std 4 cm) pulling the CoM projection
+  (`root_com_pos_w`) toward the support foot, **gated** by `mdp.kick_engagement` (0 at STAND
+  rest, 1 during the strike). Weight 3.0.
+- **split pose following** (a `joint_names` param on `kick_pose_track`/`_l1`):
+  GESTURE = right leg + neck/head (std 0.35, tight); SUPPORT = left leg (std 0.9,
+  weight 1.0, **loose**) → the policy can adduct/shift the pelvis to transfer the
+  weight without the pose tracking freezing the pelvis centered.
+The "Balance / support" table above is therefore extended: `support_leg_pose` (1.0)
+and `com_over_support` (3.0) are added, and `kick_pose_track`/`kick_pose_l1` now cover
+only the 9 gesture joints (right + neck).
 
-### Objectif : suivi de la pose interpolée par la phase
-Nouvelle fonction **pure** dans `mdp.py` :
+### Objective: following the phase-interpolated pose
+A new **pure** function in `mdp.py`:
 ```python
 kick_pose_target(phase, stand, back, forward, windup_end, kick_end, return_end) -> Tensor
 ```
-Interpole entre les vecteurs de pose selon 4 segments (période normalisée [0,1)) :
+Interpolates between the pose vectors across 4 segments (normalized period [0,1)):
 ```
-[0, windup_end)        STAND   → BACK      (armement,     défaut 0.35)
-[windup_end, kick_end) BACK    → FORWARD   (frappe sèche, défaut 0.10 = "snap")
-[kick_end, return_end) FORWARD → STAND     (retour,       défaut 0.30)
-[return_end, 1.0)      STAND              (repos)
+[0, windup_end)        STAND   → BACK      (wind-up,      default 0.35)
+[windup_end, kick_end) BACK    → FORWARD   (sharp strike, default 0.10 = "snap")
+[kick_end, return_end) FORWARD → STAND     (return,       default 0.30)
+[return_end, 1.0)      STAND              (rest)
 ```
-Le « snap » vient du segment frappe court : la cible articulaire bouge vite → swing
-rapide du pied. Les 3 bornes de timing sont paramétrables.
+The "snap" comes from the short strike segment: the joint target moves fast → a fast
+foot swing. All 3 timing bounds are parameterizable.
 
-Résolution des joints **par nom** (`asset.find_joints([name])`) — robuste à l'ordre.
+Joints resolved **by name** (`asset.find_joints([name])`) — robust to ordering.
 
-Rewards de suivi (toujours actifs, symétriques comme crouch) :
-| Reward | Poids | Rôle |
+Tracking rewards (always active, symmetric like crouch):
+| Reward | Weight | Role |
 |---|---|---|
-| `kick_pose_tracking` | 6.0 | suivi gaussien `exp(-((q-cible)/std)²).mean`, std=0.4 |
-| `kick_pose_l1` | 2.0 | bootstrap L1 (gradient constant tôt) |
+| `kick_pose_tracking` | 6.0 | gaussian tracking `exp(-((q-target)/std)²).mean`, std=0.4 |
+| `kick_pose_l1` | 2.0 | L1 bootstrap (constant gradient early on) |
 
-### Équilibre / appui (jambe unique = risque de bascule)
-| Reward | Poids | Rôle |
+### Balance / support (single leg = tipping risk)
+| Reward | Weight | Role |
 |---|---|---|
-| `upright` | 2.0 | tronc vertical |
-| `support_foot_grounded` (pied gauche) | 6.0 | garder le pied d'appui planté (capteur mono-pied → `found∈{0,1}` → reward∈{0,0.5} après `/2`, donc poids 6.0 ≈ contribution max 3.0) |
-| `feet_flat` (gauche) | -1.0 | lame gauche à plat |
+| `upright` | 2.0 | vertical trunk |
+| `support_foot_grounded` (left foot) | 6.0 | keep the support foot planted (single-foot sensor → `found∈{0,1}` → reward∈{0,0.5} after `/2`, hence weight 6.0 ≈ max contribution 3.0) |
+| `feet_flat` (left) | -1.0 | left blade flat |
 | `self_collisions` | -1.0 | |
 | `body_ang_vel` | -0.05 | |
 
-`support_foot_grounded` : réutiliser le mécanisme `feet_grounded_reward` du
-ground_pick mais restreint au **pied gauche** (capteur de contact sur
+`support_foot_grounded`: reuse the ground_pick `feet_grounded_reward` mechanism but
+restricted to the **left foot** (contact sensor on
 `left_foot_collision`).
 
-### Régularisation (allégée vs ground_pick — laisser passer le snap)
-| Reward | Poids | Rôle |
+### Regularization (lighter than ground_pick — let the snap through)
+| Reward | Weight | Role |
 |---|---|---|
-| `action_rate_l2` | -0.5 | léger : un poids lourd tuerait la frappe rapide |
-| `neck_action_rate_l2` | -0.5 | tête stable |
+| `action_rate_l2` | -0.5 | light: a heavy weight would kill the fast strike |
+| `neck_action_rate_l2` | -0.5 | stable head |
 | `joint_torques_l2` | -1e-3 | |
 
-**Retirés** (termes de marche) : `track_linear_velocity`, `track_angular_velocity`,
+**Removed** (walking terms): `track_linear_velocity`, `track_angular_velocity`,
 `air_time`, `foot_clearance`, `foot_swing_height`, `foot_slip`, `pose`.
 
-### Observations / déploiement (parité)
-- Obs **61D identique** à ground_pick/roller : `[gyro(3), projected_gravity(3),
-  joint_pos(14), joint_vel(14), last_action(14), command(13)]` avec les slots
-  head(4)+body(6) **zero-paddés** (`zero_command_padding`).
-- Même DR sim2real héritée de velocity (CoM, mass/inertia, friction BAM, armature,
-  IMU misalignment obs-level, encoder-bias, pushes ±0.3), termine par NaN guard.
-- Export ONNX (normaliseur baké) via le script d'export existant.
-- Déploiement dans un slot phase du runtime, p.ex. :
+### Observations / deployment (parity)
+- **61D obs identical** to ground_pick/roller: `[gyro(3), projected_gravity(3),
+  joint_pos(14), joint_vel(14), last_action(14), command(13)]` with the
+  head(4)+body(6) slots **zero-padded** (`zero_command_padding`).
+- The same sim2real DR inherited from velocity (CoM, mass/inertia, BAM friction, armature,
+  obs-level IMU misalignment, encoder bias, ±0.3 pushes), ending with the NaN guard.
+- ONNX export (normalizer baked in) via the existing export script.
+- Deployed into a runtime phase slot, e.g.:
   ```
   --ground-pick shoot.onnx --ground-pick-period 2.5 \
   --ground-pick-kp-ratio 1.0 --ground-pick-action-scale <match>
   ```
-  Bouton → shoot → retour auto à la policy principale.
+  Button → kick → automatic return to the main policy.
 
 ## Tests
 
-- `tests/test_shoot.py` — fonctions pures :
-  - `kick_pose_target` aux keypoints : STAND à φ=0, BACK à `windup_end`,
-    FORWARD à `kick_end`, STAND dans le segment repos ; interpolation à mi-segment ;
-    bornes (chaque composante entre min/max des poses).
-  - Valeurs des rewards `kick_pose_tracking` / `kick_pose_l1` sur cas simples.
-- `tests/test_shoot_cfg.py` — l'env se construit avec la bonne commande
-  (`GroundPickPhaseCommand`, `randomize_phase=False`, période) et les rewards
-  attendus présents / termes de marche absents.
-- Lancer : `uv run --with pytest pytest tests/ -q`.
+- `tests/test_shoot.py` — pure functions:
+  - `kick_pose_target` at the keypoints: STAND at φ=0, BACK at `windup_end`,
+    FORWARD at `kick_end`, STAND in the rest segment; mid-segment interpolation;
+    bounds (each component between the min/max of the poses).
+  - Values of the `kick_pose_tracking` / `kick_pose_l1` rewards on simple cases.
+- `tests/test_shoot_cfg.py` — the env builds with the right command
+  (`GroundPickPhaseCommand`, `randomize_phase=False`, period) and the expected
+  rewards present / walking terms absent.
+- Run: `uv run --with pytest pytest tests/ -q`.
 
-## Entraînement
+## Training
 
 ```bash
 uv run train Mjlab-Shoot-Flat-MicroDuck --env.scene.num-envs 4096 --agent.max_iterations <N>
 ```
-Surveiller `Episode_Reward/kick_pose_tracking` (doit monter). Play : script play_latest.
+Watch `Episode_Reward/kick_pose_tracking` (it must rise). Play: the play_latest script.
 
-## Points ouverts / à régler à l'entraînement
-- **Timings** (windup/kick/return) et **période** : défauts snap raisonnables,
-  à ajuster selon la vitesse de pied obtenue et la stabilité.
-- **Poids `action_rate`** : tension snap vs lissage sim2real ; démarrer léger (-0.5).
-- **Enrichissement optionnel (non retenu pour v1)** : petit reward de « vitesse du
-  pied droit vers l'avant » gaté sur le segment frappe, pour pousser la puissance
-  sans balle simulée. À ajouter seulement si le suivi de pose seul manque de punch.
-- **Transitions au déploiement** : si `STAND_POSE` ≠ neutre de la policy principale,
-  léger à-coup au déclenchement/retour (comme noté pour crouch).
+## Open points / to settle during training
+- **Timings** (windup/kick/return) and **period**: reasonable snap defaults,
+  to be adjusted according to the foot speed achieved and the stability.
+- **`action_rate` weight**: snap vs sim2real smoothing tension; start light (-0.5).
+- **Optional enrichment (not retained for v1)**: a small "right foot forward velocity"
+  reward gated on the strike segment, to push for power without a simulated ball.
+  To be added only if pose following alone lacks punch.
+- **Transitions at deployment**: if `STAND_POSE` ≠ the main policy's neutral,
+  a slight jolt on trigger/return (as noted for crouch).

--- a/docs/superpowers/specs/2026-08-04-roller-standup-design.md
+++ b/docs/superpowers/specs/2026-08-04-roller-standup-design.md
@@ -1,86 +1,86 @@
-# Design — `roller_standup` : se relever sur rollers
+# Design — `roller_standup`: standing up on rollers
 
-**But** : une policy dédiée qui remet le microduck **debout sur ses rollers** après une chute
-(à plat ventre ou à plat dos), et qui sait ensuite **tenir** la station sur roues.
+**Goal**: a dedicated policy that puts the microduck back **upright on its rollers** after a fall
+(face down or face up), and that can then **hold** the stance on wheels.
 
-Portage de la recette `standup` (canard marcheur) vers le modèle rollers. Aucune modification
-des envs existants.
+A port of the `standup` recipe (walking duck) to the roller model. No changes to the
+existing envs.
 
 ---
 
-## Décisions actées
+## Settled decisions
 
-| Décision | Choix | Alternatives écartées |
+| Decision | Choice | Rejected alternatives |
 |---|---|---|
-| Forme | **Policy dédiée** épisodique | Greffer le relevé sur l'env roller (recette `velstand`) → risque réel de casser la foulée acquise |
-| Poses de départ | **ventre + dos + debout** | `assis` (n'existe que pour le hand-off depuis la policy `sit`, pas d'équivalent roller) ; côtés (couverture max mais convergence bien plus dure) ; sans `debout` (la policy se relèverait puis retomberait) |
-| Roues libres | **curriculum de friction de roulement inversé** | Vraie friction d'entrée (bootstrap trop dur) ; imposer une technique de patineur par récompenses (historique du repo : les récompenses de style trop directives créent des optima parasites — le swizzle, l'optimum paresseux du crouch) |
-| Pose cible | **HOME + hauteur mesurée** | `STAND_POSE` du roller-crouch (signalée comme issue ouverte : ≠ du neutre roller → à-coup au retour) ; pose lue sur le vrai robot (bloque le dev) |
-| Commande | **twist neutralisé** (≈ 0) | Commande de phase / slot bouton (voir « Déploiement ») ; tête pilotable |
+| Form | **Dedicated** episodic policy | Grafting the standup onto the roller env (the `velstand` recipe) → a real risk of breaking the learned gait |
+| Start poses | **face down + face up + standing** | `sitting` (only exists for the hand-off from the `sit` policy, no roller equivalent); side-lying (maximum coverage but much harder convergence); without `standing` (the policy would stand up then fall back) |
+| Free wheels | **reversed rolling-friction curriculum** | Real entry friction (bootstrap too hard); imposing a skater technique through rewards (repo history: overly directive style rewards create parasitic optima — the swizzle, the crouch's lazy optimum) |
+| Target pose | **HOME + measured height** | The roller-crouch's `STAND_POSE` (flagged as an open issue: ≠ the roller neutral → jolt on return); a pose read off the real robot (blocks development) |
+| Command | **neutralized twist** (≈ 0) | A phase command / button slot (see "Deployment"); steerable head |
 
 ---
 
 ## Architecture
 
-**Nouveau fichier** : `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`
+**New file**: `src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py`
 - `make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg`
 - `MicroduckRollerStandUpRlCfg` (`experiment_name="roller_standup"`)
-- Task id : `Mjlab-RollerStandUp-Flat-MicroDuck` (flat uniquement, pas de variante rough)
+- Task id: `Mjlab-RollerStandUp-Flat-MicroDuck` (flat only, no rough variant)
 
-**Dérivation** : `cfg = make_microduck_velocity_rollers_env_cfg()`.
+**Derivation**: `cfg = make_microduck_velocity_rollers_env_cfg()`.
 
-C'est le pattern de `roller_slope` (246 lignes) et non celui de `roller_crouch` (479 lignes, qui
-repart de `make_velocity_env_cfg()` et recopie tous les blocs de DR). On hérite ainsi sans risque
-de dérive :
+This is `roller_slope`'s pattern (246 lines), not `roller_crouch`'s (479 lines, which starts
+over from `make_velocity_env_cfg()` and copies every DR block). We thus inherit without any risk
+of drift:
 
-- le robot `MICRODUCK_WALK_ROLLERS_ROBOT_CFG` (14 joints actifs + 4 roues passives, BAM m6, kp_fw 200) ;
-- les capteurs `feet_ground_contact` (mode subtree sur `ankle_{l,r}_v1`) et `self_collision` ;
-- toute la DR : CoM tronc + tête, masse/inertie (pseudo_inertia), friction BAM, armature,
-  biais d'encodeur, désalignement IMU au niveau obs, friction des roulements ;
-- **l'observation unifiée 61D** `[gyro(3), projected_gravity(3), joint_pos(14), joint_vel(14),
-  last_action(14), command(13)]` — condition dure pour l'interchangeabilité au runtime ;
-- la termination `nan_state` (garde élargi : joints + free-joint + roues).
+- the `MICRODUCK_WALK_ROLLERS_ROBOT_CFG` robot (14 active joints + 4 passive wheels, BAM m6, kp_fw 200);
+- the `feet_ground_contact` (subtree mode on `ankle_{l,r}_v1`) and `self_collision` sensors;
+- the whole DR stack: trunk + head CoM, mass/inertia (pseudo_inertia), BAM friction, armature,
+  encoder bias, obs-level IMU misalignment, bearing friction;
+- **the unified 61D observation** `[gyro(3), projected_gravity(3), joint_pos(14), joint_vel(14),
+  last_action(14), command(13)]` — a hard requirement for runtime hot-swappability;
+- the `nan_state` termination (widened guard: joints + free joint + wheels).
 
-Le modèle rollers **permet physiquement** de s'allonger : `robot_allcollisions_rollers.xml` porte des
-géoms de collision sur le tronc (`np_f970`), les hanches, les jambes, les coques de tête et la mâchoire,
-en plus des 4 pneus. Vérifié.
+The roller model **physically allows** lying down: `robot_allcollisions_rollers.xml` carries
+collision geoms on the trunk (`np_f970`), the hips, the legs, the head shells and the jaw,
+in addition to the 4 tires. Verified.
 
 ---
 
-## Constantes mesurées
+## Measured constants
 
-Mesurées par cinématique exacte (minimum des sommets de maillage des géoms collidantes, pose
-`STAND` du keyframe, tronc ramené au contact) sur `scene_rollers.xml` vs `scene.xml` :
+Measured by exact kinematics (minimum over the mesh vertices of the colliding geoms, the keyframe's
+`STAND` pose, trunk lowered to contact) on `scene_rollers.xml` vs `scene.xml`:
 
-| pose | modèle pieds | modèle rollers |
+| pose | feet model | roller model |
 |---|---|---|
-| debout (`STAND` = HOME) | 0.1172 | **0.1407** |
-| à plat ventre (repos) | 0.0752 | 0.0752 |
-| à plat dos (repos) | 0.0476 | 0.0475 |
+| standing (`STAND` = HOME) | 0.1172 | **0.1407** |
+| face down (rest) | 0.0752 | 0.0752 |
+| face up (rest) | 0.0476 | 0.0475 |
 
-Contrôle de cohérence : le `standup` utilise `STAND_Z = 0.115` mesuré **sous charge** contre 0.1172
-en cinématique → ~2 mm d'affaissement. On applique la même correction, et le résultat tombe pile dans
-le `reset_base z = 0.1335–0.1435` déjà utilisé par l'env roller.
+Consistency cross-check: `standup` uses `STAND_Z = 0.115` measured **under load** against 0.1172
+kinematically → ~2 mm of sag. We apply the same correction, and the result falls exactly inside
+the `reset_base z = 0.1335–0.1435` range already used by the roller env.
 
 ```python
-ROLLER_STAND_Z   = 0.138   # tronc debout sur roues, sous charge (+23 mm vs pieds)
-ROLLER_PRONE_Z   = 0.075   # hauteur de repos à plat ventre
+ROLLER_STAND_Z   = 0.138   # trunk standing on wheels, under load (+23 mm vs feet)
+ROLLER_PRONE_Z   = 0.075   # face-down rest height
 EPISODE_LENGTH_S = 6.0
 ```
 
-Les hauteurs de repos au sol sont **identiques** aux deux modèles (c'est la coque du tronc qui touche,
-pas les pieds). Cela ne veut pas dire que la plage `prone_z` du `standup` se réutilise telle quelle :
-voir la note sous « Reset » — `prone_z_min` diverge (0.076 ici, pas 0.05) car une seule plage sert
-deux poses (ventre, dos) dont les hauteurs de contact au reset ne sont pas les mêmes.
+The ground rest heights are **identical** on both models (it is the trunk shell that touches,
+not the feet). That does not mean `standup`'s `prone_z` range can be reused as-is:
+see the note under "Reset" — `prone_z_min` diverges (0.076 here, not 0.05) because a single range serves
+two poses (face down, face up) whose contact heights at reset are not the same.
 
-La grandeur mesurée est bien celle que lisent les récompenses : `height_target_gaussian` et
-`height_l1_penalty` utilisent `root_link_pos_w[:, 2]`, qui vaut exactement `xpos[trunk_base].z`
-(le free-joint est sur `trunk_base`) — vérifié numériquement.
+The measured quantity is indeed the one the rewards read: `height_target_gaussian` and
+`height_l1_penalty` use `root_link_pos_w[:, 2]`, which equals exactly `xpos[trunk_base].z`
+(the free joint sits on `trunk_base`) — verified numerically.
 
-## Indices de joints
+## Joint indices
 
-Les roues passives sont **intercalées** dans l'ordre des joints. Ordre réel vérifié dans MuJoCo
-(`m.jnt_qposadr`, modèle rollers, 18 joints après le free-joint) :
+The passive wheels are **interleaved** in the joint ordering. Actual ordering verified in MuJoCo
+(`m.jnt_qposadr`, roller model, 18 joints after the free joint):
 
 ```
 0-4   left_hip_yaw, left_hip_roll, left_hip_pitch, left_knee, left_ankle
@@ -91,89 +91,89 @@ Les roues passives sont **intercalées** dans l'ordre des joints. Ordre réel v�
 ```
 
 ```python
-_LEG_JOINTS   = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]   # standup : [0-4, 9-13]
-_NECK_JOINTS  = [7, 8, 9, 10]                          # standup : [5-8]
+_LEG_JOINTS   = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]   # standup: [0-4, 9-13]
+_NECK_JOINTS  = [7, 8, 9, 10]                          # standup: [5-8]
 _WHEEL_JOINTS = [5, 6, 16, 17]
 ```
 
-Seul `_LEG_JOINTS` est réellement consommé (par les récompenses de pose). `_NECK_JOINTS` et
-`_WHEEL_JOINTS` sont déclarés pour la documentation et pour le test d'indices : le cou est résolu
-**par nom** (`neck_joint_pos_l2` appelle `find_joints(r".*(neck|head).*")` à chaque pas, précisément
-pour être robuste au décalage dû aux roues) et les roues par la regex `^passive_.*`.
+Only `_LEG_JOINTS` is actually consumed (by the pose rewards). `_NECK_JOINTS` and
+`_WHEEL_JOINTS` are declared for documentation and for the index test: the neck is resolved
+**by name** (`neck_joint_pos_l2` calls `find_joints(r".*(neck|head).*")` every step, precisely
+to be robust to the offset caused by the wheels) and the wheels by the `^passive_.*` regex.
 
-Le doc de passation signale explicitement cette fragilité. Elle est verrouillée par un test qui
-construit l'env et vérifie les noms de joints à ces indices (voir « Tests »).
+The handover doc flags this fragility explicitly. It is locked in by a test that
+builds the env and checks the joint names at those indices (see "Tests").
 
 ---
 
-## Récompenses
+## Rewards
 
-### Retirées de l'héritage roller
+### Removed from the roller inheritance
 
-| Retiré | Pourquoi |
+| Removed | Why |
 |---|---|
-| `wheel_speed`, `braking`, `skating_air_time`, `glide`, `single_support`, `gait_symmetry`, `forward_lean`, `heading_hold` | récompenses de foulée : aucun sens quand on est par terre |
-| `feet_flat` | pendant la montée les lames ne sont pas à plat → cette pénalité combattrait le geste |
-| `hip_roll_neutral` | se relever demande d'écarter les jambes |
-| `pose`, `com_height_target` | remplacés par les cibles pose/hauteur ci-dessous |
-| `upright` (gaussienne de base) | remplacée par `upright_linear` + `upright_sharp` |
+| `wheel_speed`, `braking`, `skating_air_time`, `glide`, `single_support`, `gait_symmetry`, `forward_lean`, `heading_hold` | stride rewards: meaningless while lying on the ground |
+| `feet_flat` | during the rise the blades are not flat → this penalty would fight the gesture |
+| `hip_roll_neutral` | standing up requires spreading the legs |
+| `pose`, `com_height_target` | replaced by the pose/height targets below |
+| `upright` (base gaussian) | replaced by `upright_linear` + `upright_sharp` |
 
-### Gardées de l'héritage roller
+### Kept from the roller inheritance
 
-| Reward | Poids | Rôle |
+| Reward | Weight | Role |
 |---|---|---|
-| `action_over_limit` | −0.5 | protection sim2real (sur-commande au-delà des butées), indépendante de la tâche |
+| `action_over_limit` | −0.5 | sim2real protection (over-commanding past the limits), task-independent |
 | `self_collisions` | −1.0 | |
-| `body_ang_vel` | **−0.05** | volontairement **léger** : le `standup` documente qu'à −0.15 il gelait le relevé (bloqueur de mouvement) |
+| `body_ang_vel` | **−0.05** | deliberately **light**: `standup` documents that at −0.15 it froze the rise (motion blocker) |
 | `angular_momentum` | −0.02 | |
-| `action_rate_l2` | curriculum −0.4 → −0.8 → −1.0 | l'env roller le met à plat à −1.0 ; on reprend la rampe du `standup` (douce au début → aide le bootstrap du grand mouvement de retournement) |
-| `neck_action_rate_l2` | −0.5 | tête stable |
-| `neck_joint_pos_l2` | −0.5 | garder la tête droite (le choix de `roller_slope`) — **remplace** la commande `head_pose` du `standup` |
+| `action_rate_l2` | curriculum −0.4 → −0.8 → −1.0 | the roller env pins it flat at −1.0; we reuse `standup`'s ramp (gentle at first → helps bootstrap the large roll-over motion) |
+| `neck_action_rate_l2` | −0.5 | stable head |
+| `neck_joint_pos_l2` | −0.5 | keep the head upright (`roller_slope`'s choice) — **replaces** `standup`'s `head_pose` command |
 | `joint_torques_l2` | −1e-3 | |
 
-### Ajoutée
+### Added
 
-| Reward | Poids | Rôle |
+| Reward | Weight | Role |
 |---|---|---|
-| `joint_torque_rate_l2` | −2e-3 | anti-jitter : le `standup` l'a identifié comme le seul amortisseur qui ne bloque pas le retournement (il pénalise la *variation* de couple, pas son amplitude ni la rotation du tronc) |
+| `joint_torque_rate_l2` | −2e-3 | anti-jitter: `standup` identified it as the only damper that does not block the roll-over (it penalizes the torque *rate*, not its magnitude nor trunk rotation) |
 
-### Récompenses de relevé (transplant du `standup`, remappé)
+### Standup rewards (transplanted from `standup`, remapped)
 
-Les dix termes sont copiés **avec leurs poids déjà réglés** par les itérations documentées dans
-`microduck_standup_env_cfg.py`. Seuls changent les indices de joints et les deux hauteurs.
-Toutes les fonctions mdp existent déjà — **rien à écrire dans `mdp.py`**.
+The ten terms are copied **with their already-tuned weights** from the iterations documented in
+`microduck_standup_env_cfg.py`. Only the joint indices and the two heights change.
+All the mdp functions already exist — **nothing to write in `mdp.py`**.
 
-| Reward | Fonction mdp | Poids | Paramètres roller | Rôle |
+| Reward | mdp function | Weight | Roller parameters | Role |
 |---|---|---|---|---|
-| `pose_stand_legs` | `pose_target_match` | +8.0 | `std=0.5`, `joint_indices=_LEG_JOINTS`, `target_overrides=None` (HOME) | pose articulaire cible |
-| `pose_stand_l1` | `pose_l1_penalty` | +5.0 | `joint_indices=_LEG_JOINTS`, `target_overrides=None` | bootstrap L1 : gradient constant même loin de HOME |
-| `height_stand` | `height_target_gaussian` | +4.0 | `std=0.04`, `target_height=0.138` | gaussienne large → tire depuis le sol |
-| `height_stand_sharp` | `height_target_gaussian` | +4.0 | `std=0.015`, `target_height=0.138` | gaussienne étroite → force les derniers cm |
-| `height_stand_l1` | `height_l1_penalty` | +30.0 | `target_height=0.138` | rend « rester par terre » net négatif (sinon optimum paresseux) |
-| `com_upward_velocity` | `com_upward_velocity` | +3.0 | `max_height=0.148` | paye le *mouvement* de montée (+10 mm de marge au-dessus de la cible, comme 0.125 vs 0.115 chez `standup`) |
-| `gentle_rise` | `trunk_vertical_accel_penalty` | −0.02 | | pénalise `\|a_z\|` → montée lisse à vitesse constante |
-| `upright_linear` | `body_upright_linear` | +6.0 | | `cos(tilt)` : fort gradient quand couché |
-| `upright_sharp` | `upright_gaussian_at_height` | +6.0 | `std=0.3`, `height_low=0.075`, `height_high=0.138` | gaussienne serrée gatée en hauteur → tue le penché-arrière |
-| `standing_composite` | `standing_composite_score` | +15.0 | `height_std=0.04`, `upright_std=0.40`, `pose_std=0.40`, `target_height=0.138`, `joint_indices=_LEG_JOINTS` | score multiplicatif hauteur × droit × pose |
+| `pose_stand_legs` | `pose_target_match` | +8.0 | `std=0.5`, `joint_indices=_LEG_JOINTS`, `target_overrides=None` (HOME) | target joint pose |
+| `pose_stand_l1` | `pose_l1_penalty` | +5.0 | `joint_indices=_LEG_JOINTS`, `target_overrides=None` | L1 bootstrap: constant gradient even far from HOME |
+| `height_stand` | `height_target_gaussian` | +4.0 | `std=0.04`, `target_height=0.138` | wide gaussian → pulls up from the ground |
+| `height_stand_sharp` | `height_target_gaussian` | +4.0 | `std=0.015`, `target_height=0.138` | narrow gaussian → forces the last few cm |
+| `height_stand_l1` | `height_l1_penalty` | +30.0 | `target_height=0.138` | makes "stay on the ground" net negative (otherwise a lazy optimum) |
+| `com_upward_velocity` | `com_upward_velocity` | +3.0 | `max_height=0.148` | pays for the *motion* of rising (+10 mm of margin above the target, like 0.125 vs 0.115 in `standup`) |
+| `gentle_rise` | `trunk_vertical_accel_penalty` | −0.02 | | penalizes `\|a_z\|` → smooth, constant-speed rise |
+| `upright_linear` | `body_upright_linear` | +6.0 | | `cos(tilt)`: strong gradient while lying down |
+| `upright_sharp` | `upright_gaussian_at_height` | +6.0 | `std=0.3`, `height_low=0.075`, `height_high=0.138` | tight height-gated gaussian → kills the backward lean |
+| `standing_composite` | `standing_composite_score` | +15.0 | `height_std=0.04`, `upright_std=0.40`, `pose_std=0.40`, `target_height=0.138`, `joint_indices=_LEG_JOINTS` | multiplicative score height × uprightness × pose |
 
-Tous les termes prennent `asset_cfg=SceneEntityCfg("robot", body_names=("trunk_base",))` là où le
-`standup` le fait.
+Every term takes `asset_cfg=SceneEntityCfg("robot", body_names=("trunk_base",))` wherever
+`standup` does.
 
-**Pas de pénalités d'impact** (tronc/tête) pour cette v1 : le `standup` n'en a pas, seul `velstand`
-en a. On garde le jeu minimal.
+**No impact penalties** (trunk/head) for this v1: `standup` has none, only `velstand`
+does. We keep the minimal set.
 
 ---
 
-## Observation et commande
+## Observation and command
 
-**Observation** : héritée intacte de l'env roller (61D). Aucune modification — c'est la raison de
-dériver de cet env.
+**Observation**: inherited untouched from the roller env (61D). No modification — that is the reason
+for deriving from that env.
 
-On ajoute `nan_policy = "sanitize"` sur les groupes actor et critic, comme `roller_slope` : un contact
-rare fait diverger le free-joint en NaN, l'obs est assainie (→ 0) pour ne pas tuer l'entraînement,
-et l'env fautif se reset au pas suivant.
+We add `nan_policy = "sanitize"` on the actor and critic groups, like `roller_slope`: a rare
+contact makes the free joint diverge to NaN, the obs is sanitized (→ 0) so training is not killed,
+and the offending env resets on the next step.
 
-**Commande** : le slot `twist` est neutralisé, exactement comme le `standup` :
+**Command**: the `twist` slot is neutralized, exactly like `standup`:
 
 ```python
 command = cfg.commands["twist"]
@@ -189,184 +189,183 @@ command.ranges.ang_vel_z = (-0.05, 0.05)
 cfg.commands["twist"] = microduck_mdp.VelocityCommandCommandOnlyCfg(**vars(command))
 ```
 
-Les slots `head_pose` (4) et `body_pose` (6) restent **zero-paddés** — convention de la famille
-roller (`roller`, `roller_crouch`, `roller_slope`). C'est un écart assumé vis-à-vis du `standup` de
-la marche, qui pilote la tête via une vraie commande `head_pose` 4D (voir « Risques »).
+The `head_pose` (4) and `body_pose` (6) slots stay **zero-padded** — the roller family's
+convention (`roller`, `roller_crouch`, `roller_slope`). This is a deliberate departure from the
+walker's `standup`, which steers the head through a real 4D `head_pose` command (see "Risks").
 
-Justification du twist neutralisé : dans `scripts/infer_policy.py`, la policy `standup` de la marche
-est chargée en `--standing` à côté de `--walking`, et la bascule est **automatique sur la magnitude
-de la commande de vitesse** (`infer_policy.py:262`, seuil 0.05) ; quand `standing` est active, le
-slot twist est laissé à zéro (`infer_policy.py:239`). Les slots à phase (`ground_pick`, `fold`)
-servent aux tricks one-shot déclenchés au bouton, pas à un relevé.
+Rationale for the neutralized twist: in `scripts/infer_policy.py`, the walker's `standup` policy
+is loaded as `--standing` alongside `--walking`, and the switch is **automatic on the velocity
+command's magnitude** (`infer_policy.py:262`, threshold 0.05); when `standing` is active, the
+twist slot is left at zero (`infer_policy.py:239`). The phase slots (`ground_pick`, `fold`)
+serve one-shot button-triggered tricks, not a standup.
 
 ---
 
 ## Reset
 
-Ajout de l'événement `set_ground_state` (mode `reset`), inséré **après** `reset_base` et
-`reset_robot_joints` de l'héritage (l'ordre des événements suit l'ordre d'insertion dans le dict) :
+We add the `set_ground_state` event (mode `reset`), inserted **after** the inherited `reset_base`
+and `reset_robot_joints` (event order follows insertion order in the dict):
 
 ```python
 cfg.events["set_ground_state"] = EventTermCfg(
     func=microduck_mdp.set_random_ground_state,
     mode="reset",
     params={
-        "face_down_prob":  0.50,   # ventre — piloté par le curriculum ci-dessous
-        "face_up_prob":    0.00,   # dos — introduit tard (le plus dur)
-        "sitting_prob":    0.00,   # pas de bucket assis → aucun override de joint à remapper
+        "face_down_prob":  0.50,   # face down — driven by the curriculum below
+        "face_up_prob":    0.00,   # face up — introduced late (the hardest)
+        "sitting_prob":    0.00,   # no sitting bucket → no joint overrides to remap
         "standing_prob":   0.50,
-        "prone_z_min":     0.076,  # cf. note ci-dessous — pas un simple héritage du standup
+        "prone_z_min":     0.076,  # cf. the note below — not a simple inheritance from standup
         "prone_z_max":     0.09,
-        "standing_z_min":  0.134,  # roller (contre 0.11–0.12 pour les pieds)
+        "standing_z_min":  0.134,  # roller (vs 0.11–0.12 for the feet model)
         "standing_z_max":  0.144,
-        "sitting_tilt_max": math.radians(10),  # ± bruit de pitch/roll ; s'applique AUSSI au bucket debout
+        "sitting_tilt_max": math.radians(10),  # ± pitch/roll noise; ALSO applies to the standing bucket
     },
 )
 ```
 
-Note : dans `set_random_ground_state`, le bucket `standing` réutilise le quaternion du bucket
-`sitting` — donc `sitting_tilt_max` bruite aussi les départs debout, ce qui est voulu.
+Note: in `set_random_ground_state`, the `standing` bucket reuses the `sitting` bucket's quaternion —
+so `sitting_tilt_max` also adds noise to standing starts, which is intended.
 
-**Sur `prone_z_min` = 0.076 (et pas 0.05, valeur reprise à tort du `standup`)** : les poses ventre et
-dos partagent une seule plage de z, mais leurs hauteurs de contact mesurées diffèrent — ventre
-0.0752, dos 0.0475 — donc une plage unique ne peut pas être idéale pour les deux. Le commentaire du
-`standup` justifie son plancher `0.05` par un repos mesuré à ~0.044 **après stabilisation sous
-gravité** ; or ce qui compte à l'instant du reset, c'est la hauteur de contact en pose HOME, pas la
-hauteur de repos une fois retombé. À 0.05, le ventre spawn avec la coque du tronc **enfoncée de
-25 mm dans le sol**, un pushout que la policy paie ensuite via `gentle_rise` /
-`joint_torque_rate_l2`. `prone_z_min = 0.076` élimine cette interpénétration, au prix d'un dos qui
-démarre 28–42 mm au-dessus de son repos — un artefact bien plus doux qu'un pushout de contact.
+**On `prone_z_min` = 0.076 (and not 0.05, a value wrongly carried over from `standup`)**: the face-down
+and face-up poses share a single z range, but their measured contact heights differ — face down
+0.0752, face up 0.0475 — so a single range cannot be ideal for both. `standup`'s comment justifies
+its `0.05` floor with a rest height measured at ~0.044 **after settling under gravity**; but what
+matters at reset time is the contact height in the HOME pose, not the rest height after settling.
+At 0.05, a face-down start spawns with the trunk shell **sunk 25 mm into the ground**, a pushout the
+policy then pays for through `gentle_rise` / `joint_torque_rate_l2`. `prone_z_min = 0.076` eliminates
+that interpenetration, at the cost of a face-up start 28–42 mm above its rest height — a far gentler
+artifact than a contact pushout.
 
-**Aucune modification de `mdp.py`** : `reset_robot_joints` de la base utilise
-`joint_names=(".*",)` avec `velocity_range=(0.0, 0.0)` et `default_joint_vel` (HOME_FRAME
-`joint_vel={".*": 0.0}`) → les 4 roues passives sont déjà remises à zéro à chaque reset. Vérifié.
+**No modification to `mdp.py`**: the base's `reset_robot_joints` uses
+`joint_names=(".*",)` with `velocity_range=(0.0, 0.0)` and `default_joint_vel` (HOME_FRAME
+`joint_vel={".*": 0.0}`) → the 4 passive wheels are already zeroed on every reset. Verified.
 
-**Curriculum `ground_state_mix`** (`event_param_curriculum`), même logique easy → hard que le
-`standup` : le dos est introduit tard et reçoit le plus d'entraînement à la fin.
+**Curriculum `ground_state_mix`** (`event_param_curriculum`), the same easy → hard logic as
+`standup`: face up is introduced late and gets the most training at the end.
 
-| iter | debout | ventre | dos |
+| iter | standing | face down | face up |
 |---|---|---|---|
 | 0 | 0.50 | 0.50 | 0.00 |
 | 600 | 0.35 | 0.45 | 0.20 |
 | 1500 | 0.25 | 0.40 | 0.35 |
 | 2500 | 0.20 | 0.40 | 0.40 |
 
-(Steps en unités de `common_step_counter` = `iter × 24`.)
+(Steps in units of `common_step_counter` = `iter × 24`.)
 
-**Poussées** : `push_robot` est hérité de l'env roller (±0.2 m/s, intervalle 3–6 s). On ajoute le
-curriculum montant du `standup` pour ne pas parasiter le bootstrap : 0 → ±0.08 (iter 500) → ±0.2
+**Pushes**: `push_robot` is inherited from the roller env (±0.2 m/s, 3–6 s interval). We add
+`standup`'s rising curriculum so as not to disturb the bootstrap: 0 → ±0.08 (iter 500) → ±0.2
 (iter 1000).
 
-**Terminations** : suppression de `fell_over` (le robot **démarre** tombé — la termination sur
-inclinaison n'a pas de sens ici). `nan_state` est hérité et conservé.
+**Terminations**: `fell_over` removed (the robot **starts** fallen — a tilt termination
+makes no sense here). `nan_state` is inherited and kept.
 
-**Terrain** : `plane`. Pas de variante rough pour cette v1 — cohérent avec l'env roller, qui n'a pas
-de paramètre `rough`.
+**Terrain**: `plane`. No rough variant for this v1 — consistent with the roller env, which has no
+`rough` parameter.
 
 ---
 
-## Curriculum de friction de roulement, inversé
+## Reversed rolling-friction curriculum
 
-C'est la seule pièce réellement nouvelle du design, et le cœur de la question posée par la tâche :
-**les roues roulent, il n'y a aucune adhérence longitudinale pour pousser sur le sol.**
+This is the only genuinely new piece of the design, and the heart of the question the task poses:
+**the wheels roll, there is no longitudinal traction to push against the ground.**
 
-Le mécanisme existe déjà et est hérité (`randomize_wheel_friction` via `dr.dof_frictionloss` sur
-`^passive_.*` + `wheel_friction_curriculum`). Dans l'env roller il **monte** 0 → 0.0015. Ici on le
-fait **descendre** :
+The mechanism already exists and is inherited (`randomize_wheel_friction` via `dr.dof_frictionloss` on
+`^passive_.*` + `wheel_friction_curriculum`). In the roller env it ramps **up** 0 → 0.0015. Here we ramp it
+**down**:
 
-| iter | frictionloss | effet |
+| iter | frictionloss | effect |
 |---|---|---|
-| 0 | 0.05 | roues quasi bloquées → il se relève comme s'il avait des pieds |
+| 0 | 0.05 | near-locked wheels → it rises as if it had feet |
 | 1000 | 0.02 | |
 | 2000 | 0.008 | |
 | 3000 | 0.003 | |
-| 4000 | 0.0015 | la vraie valeur du roulement (celle de l'env roller) |
+| 4000 | 0.0015 | the real rolling value (the roller env's) |
 
-`wheel_friction_curriculum` applique simplement le dernier palier franchi
-(`if env.common_step_counter > stage["step"]`) — il fonctionne aussi bien en descente qu'en montée.
-**Zéro code à écrire.**
+`wheel_friction_curriculum` simply applies the last stage crossed
+(`if env.common_step_counter > stage["step"]`) — it works just as well going down as going up.
+**Zero code to write.**
 
-**Ce que ce curriculum nous dit** : si `Episode_Reward/standing_composite` s'écroule quand la
-friction baisse, on a la réponse nette que le geste « pieds adhérents » ne transfère pas aux roues
-libres, et il faudra guider une technique de patineur (appui genou intermédiaire, un patin à la
-fois). C'est un résultat exploitable, pas un échec.
+**What this curriculum tells us**: if `Episode_Reward/standing_composite` collapses when the
+friction drops, we have a clear answer that the "sticky feet" gesture does not transfer to free
+wheels, and we will have to guide a skater technique (intermediate knee support, one skate at a
+time). That is an actionable result, not a failure.
 
 ---
 
-## Réseau et PPO
+## Network and PPO
 
-Identiques au `standup` : actor et critic `(512, 256, 128)` elu, `obs_normalization=True`
-(normaliseur baké dans l'ONNX par `export.py`), PPO `lr=1e-3` schedule adaptive, `desired_kl=0.01`,
+Identical to `standup`: actor and critic `(512, 256, 128)` elu, `obs_normalization=True`
+(the normalizer is baked into the ONNX by `export.py`), PPO `lr=1e-3` adaptive schedule, `desired_kl=0.01`,
 `entropy_coef=0.01`, `gamma=0.99`, `lam=0.95`, `num_steps_per_env=24`, `save_interval=250`,
-`max_iterations=15_000`. **Symétrie OFF** (`SYMMETRY_CFG` est câblé pour l'ancien layout 51D et casse
-sur le 61D — même situation que tous les envs v1.5+).
+`max_iterations=15_000`. **Symmetry OFF** (`SYMMETRY_CFG` is wired for the old 51D layout and breaks
+on the 61D one — the same situation as every v1.5+ env).
 
 ---
 
 ## Tests
 
-`tests/test_roller_standup_cfg.py` :
+`tests/test_roller_standup_cfg.py`:
 
-1. l'env se construit (`play=False` et `play=True`) ;
-2. **les noms de joints aux indices `_LEG_JOINTS` / `_NECK_JOINTS` / `_WHEEL_JOINTS` sont les bons**
-   (le verrou contre la fragilité des roues intercalées) ;
-3. les récompenses de relevé attendues sont présentes, les récompenses de patinage absentes
-   (`wheel_speed`, `glide`, `single_support`, `feet_flat`, …) ;
-4. `fell_over` absent, `nan_state` présent ;
-5. le curriculum `wheel_friction` est bien **décroissant** et finit à 0.0015 ;
-6. le curriculum `ground_state_mix` : les probabilités du dernier palier somment à 1 et
-   `face_up_prob` croît de façon monotone ;
-7. **parité d'obs** : les noms et dimensions des termes actor/critic sont identiques à ceux de
-   `make_microduck_velocity_rollers_env_cfg()` (sinon l'ONNX ne se charge pas dans un slot).
+1. the env builds (`play=False` and `play=True`);
+2. **the joint names at the `_LEG_JOINTS` / `_NECK_JOINTS` / `_WHEEL_JOINTS` indices are correct**
+   (the lock-in against the interleaved-wheel fragility);
+3. the expected standup rewards are present, the skating rewards absent
+   (`wheel_speed`, `glide`, `single_support`, `feet_flat`, …);
+4. `fell_over` absent, `nan_state` present;
+5. the `wheel_friction` curriculum is indeed **decreasing** and ends at 0.0015;
+6. the `ground_state_mix` curriculum: the last stage's probabilities sum to 1 and
+   `face_up_prob` grows monotonically;
+7. **obs parity**: the names and dimensions of the actor/critic terms are identical to those of
+   `make_microduck_velocity_rollers_env_cfg()` (otherwise the ONNX will not load in a slot).
 
-Lancer : `uv run --with pytest pytest tests/ -q`.
+Run: `uv run --with pytest pytest tests/ -q`.
 
 ---
 
-## Entraînement et déploiement
+## Training and deployment
 
 ```bash
 uv run train Mjlab-RollerStandUp-Flat-MicroDuck --env.scene.num-envs 4096 --agent.max_iterations 15000
 ```
 
-Surveiller `Episode_Reward/standing_composite` (doit monter), et surtout son comportement **aux
-paliers de friction de roulement** (iters 1000/2000/3000/4000).
+Watch `Episode_Reward/standing_composite` (it must rise), and above all its behavior **at the
+rolling-friction stages** (iters 1000/2000/3000/4000).
 
-Play : `uv run scripts/play_latest.py`. Export : `uv run scripts/export_latest.py`.
+Play: `uv run scripts/play_latest.py`. Export: `uv run scripts/export_latest.py`.
 
-Déploiement visé : la policy en `--standing` face à la policy roller en `--walking`, avec la bascule
-automatique sur la magnitude de la commande. **Réserve** : `infer_policy.py` est le script de
-sim/clavier local ; le runtime robot est le binaire Rust `microduck_runtime`, absent de ce repo — il
-n'est pas vérifié ici qu'il expose un équivalent `--standing` avec la même bascule. Le doc de
-passation ne liste que `--model`, `--ground-pick`, `--fold-policy`. À confirmer. Cela ne change rien
-à l'entraînement : si le runtime n'a pas ce slot, la policy reste utilisable dans un slot bouton (la
-commande y serait une phase au lieu de zéro — ce serait alors le seul point à revoir).
+Intended deployment: the policy in `--standing` alongside the roller policy in `--walking`, with the
+automatic switch on command magnitude. **Caveat**: `infer_policy.py` is the local
+sim/keyboard script; the robot runtime is the Rust binary `microduck_runtime`, absent from this repo — it
+has not been verified here that it exposes a `--standing` equivalent with the same switching. The
+handover doc only lists `--model`, `--ground-pick`, `--fold-policy`. To be confirmed. This changes nothing
+about training: if the runtime lacks that slot, the policy remains usable in a button slot (the
+command there would be a phase instead of zero — that would then be the only point to revisit).
 
 ---
 
-## Risques et points de vigilance
+## Risks and points to watch
 
-1. **Le relevé sur roues libres est peut-être infaisable sans technique dédiée.** C'est le risque
-   principal. Le curriculum de friction est conçu pour trancher cette question de façon lisible
-   plutôt que pour la contourner.
-2. **Le bucket « dos » est le plus dur.** Le `standup` documente qu'il gelait en « ne rien faire »
-   sur cette pose, et que la cause était les *bloqueurs de mouvement* (`body_ang_vel` élevé,
-   `action_rate` trop fort). Les valeurs reprises ici sont celles de la version « se relève de
-   partout » — ne pas les durcir sans raison.
-3. **Tête zero-paddée vs commande `head_pose`.** Si la policy est déployée en `--standing` et que
-   quelqu'un actionne les touches de tête, `infer_policy` écrit `cmd[3:7] = head_offset` et la policy
-   voit du hors-distribution. Choix assumé pour rester dans la convention roller ; à revoir si le
-   pilotage de tête pendant le relevé s'avère nécessaire.
-4. **Frictionloss 0.05 est loin du réel.** Les paliers 0 → 2000 iters produisent une policy qui ne
-   transfère pas ; seuls les checkpoints d'après le dernier palier (iter 4000+) sont candidats au
-   déploiement.
+1. **Standing up on free wheels may be infeasible without a dedicated technique.** That is the main
+   risk. The friction curriculum is designed to settle this question legibly rather than to work
+   around it.
+2. **The "face up" bucket is the hardest.** `standup` documents that it froze into "do nothing"
+   on that pose, and that the cause was the *motion blockers* (high `body_ang_vel`,
+   too strong an `action_rate`). The values reused here are those of the "gets up from
+   anywhere" version — do not harden them without a reason.
+3. **Zero-padded head vs a `head_pose` command.** If the policy is deployed as `--standing` and
+   someone presses the head keys, `infer_policy` writes `cmd[3:7] = head_offset` and the policy
+   sees out-of-distribution input. A deliberate choice to stay within the roller convention; to be revisited if
+   steering the head during the standup turns out to be necessary.
+4. **Frictionloss 0.05 is far from reality.** The stages from iter 0 → 2000 produce a policy that does
+   not transfer; only checkpoints from after the last stage (iter 4000+) are deployment candidates.
 
-## Hors périmètre
+## Out of scope
 
-- Intégrer le relevé dans la policy de roulage (recette `velstand`) — décision reportée après
-  validation de la faisabilité.
-- Buckets de départ sur le côté.
-- Variante rough / terrain accidenté.
-- Pénalités d'impact tronc/tête.
-- Toute modification des envs `roller`, `roller_crouch`, `roller_slope`, `standup`, `velstand`, ou
-  de `mdp.py`.
+- Integrating the standup into the rolling policy (the `velstand` recipe) — decision deferred until
+  feasibility is validated.
+- Side-lying start buckets.
+- A rough / uneven-terrain variant.
+- Trunk/head impact penalties.
+- Any modification to the `roller`, `roller_crouch`, `roller_slope`, `standup`, `velstand` envs, or
+  to `mdp.py`.

--- a/docs/superpowers/specs/2026-08-04-spin-env-design.md
+++ b/docs/superpowers/specs/2026-08-04-spin-env-design.md
@@ -1,276 +1,276 @@
-# Spec — Env « Spin » (rotation rapide sur place, sur rollers)
+# Spec — "Spin" env (fast spin in place, on rollers)
 
-Date : 2026-08-04. Branche : `new_pre_alpha_rollers`.
+Date: 2026-08-04. Branch: `new_pre_alpha_rollers`.
 
-> **Amendement (après le premier run)** : le premier run de calibrage (500 it.)
-> a montré que le robot tombe systématiquement vers 1,16 s, bien avant le
-> freinage. En réponse, la cible a été réduite de moitié — `SPIN_RATE_MAX`
-> 6.0 → **3.0 rad/s**, soit **1 tour par cycle au lieu de 2** — et
-> `spin_stay_in_place` renforcé à **−3.0**, **sans curriculum** de vitesse.
-> Voir « Résultats de la vérification initiale » pour les preuves et la
-> configuration actuellement en vigueur.
+> **Amendment (after the first run)**: the first calibration run (500 it.)
+> showed that the robot falls systematically around 1.16 s, well before the
+> braking segment. In response, the target was halved — `SPIN_RATE_MAX`
+> 6.0 → **3.0 rad/s**, i.e. **1 turn per cycle instead of 2** — and
+> `spin_stay_in_place` strengthened to **−3.0**, **without a curriculum** on speed.
+> See "Initial verification results" for the evidence and the configuration
+> currently in force.
 
-## But
+## Goal
 
-Une nouvelle tâche RL qui apprend au microduck sur rollers à faire un **spin** :
-~2 tours anti-horaire sur place à ~6 rad/s (360°/s) *(cible initiale ; ramenée
-à 3 rad/s, voir l'amendement)*, puis arrêt propre debout.
-Geste **cyclique piloté par une phase**, déployé dans un **slot bouton one-shot**
-du runtime, comme la tâche `roller_crouch` existante.
+A new RL task that teaches the microduck on rollers to perform a **spin**:
+~2 counter-clockwise turns in place at ~6 rad/s (360°/s) *(the initial target; reduced
+to 3 rad/s, see the amendment)*, then a clean stop standing up.
+A **cyclic, phase-driven gesture**, deployed in a **one-shot button slot**
+of the runtime, like the existing `roller_crouch` task.
 
-## Décisions cadrées
+## Settled decisions
 
-| Question | Décision |
+| Question | Decision |
 |---|---|
-| Support | Sur rollers (`MICRODUCK_WALK_ROLLERS_ROBOT_CFG`, 4 roues passives) |
-| Pilotage | Slot bouton one-shot, commande = phase `[cos(2πφ), sin(2πφ), 0]` |
-| Cible | ~6 rad/s, 2 tours, puis freinage jusqu'à l'arrêt (cible initiale ; ramenée à 3 rad/s, voir l'amendement) |
-| État d'entrée | À l'arrêt **ou** en roulement lent (0 → 0.3 m/s) |
-| Sens | Gauche uniquement (lacet positif, anti-horaire) |
-| Approche | Objectif « résultat » (suivi de ω_z) + amorce antisymétrique décroissante |
+| Support | On rollers (`MICRODUCK_WALK_ROLLERS_ROBOT_CFG`, 4 passive wheels) |
+| Steering | One-shot button slot, command = phase `[cos(2πφ), sin(2πφ), 0]` |
+| Target | ~6 rad/s, 2 turns, then braking to a stop (the initial target; reduced to 3 rad/s, see the amendment) |
+| Entry state | At a standstill **or** rolling slowly (0 → 0.3 m/s) |
+| Direction | Left only (positive yaw, counter-clockwise) |
+| Approach | "Outcome" objective (tracking ω_z) + a decaying antisymmetric priming term |
 
-**Contrainte runtime** : le slot n'envoie que `[cos, sin, 0]` — aucun canal libre
-pour le sens de rotation. La policy tourne donc **toujours à gauche**. Une policy
-miroir pourrait plus tard aller dans un autre slot (bouton B, `--fold-policy`).
+**Runtime constraint**: the slot only sends `[cos, sin, 0]` — no free channel
+for the rotation direction. The policy therefore **always spins left**. A mirrored
+policy could later go into another slot (button B, `--fold-policy`).
 
-## Mécanique physique visée
+## Target physical mechanism
 
-Sur 4 roues passives, la rotation sur place « propre » se fait en **roulement
-différentiel** : le patin gauche part vers l'arrière, le droit vers l'avant (les
-roues **roulent**, elles ne patinent pas). C'est un *swizzle antisymétrique* : les
-jambes font l'inverse l'une de l'autre, au lieu du miroir du swizzle classique.
+On 4 passive wheels, a "clean" spin in place is achieved through **differential
+rolling**: the left skate goes backward, the right one forward (the wheels **roll**,
+they do not skid). This is an *antisymmetric swizzle*: the legs do the opposite of
+each other, instead of the classic swizzle's mirror.
 
-Vérification des signes pour une rotation anti-horaire (repère : x avant, y gauche,
-z haut ; ω_z > 0) : un point à gauche (+y) a pour vitesse `ω ẑ × y ŷ = −ω y x̂`,
-donc **vers l'arrière**. Les 4 roues tournent positif en marche avant (vérifié par
-`test_wheel_direction.py`), donc pour un spin anti-horaire :
-`ω_roues_gauche < 0`, `ω_roues_droite > 0`, soit **`ω_D − ω_G > 0`**.
+Sign check for a counter-clockwise rotation (frame: x forward, y left,
+z up; ω_z > 0): a point on the left (+y) has velocity `ω ẑ × y ŷ = −ω y x̂`,
+i.e. **backward**. All 4 wheels spin positive when moving forward (verified by
+`test_wheel_direction.py`), so for a counter-clockwise spin:
+`ω_left_wheels < 0`, `ω_right_wheels > 0`, i.e. **`ω_R − ω_L > 0`**.
 
-## Approche retenue (C) et pourquoi
+## Chosen approach (C) and why
 
-Trois approches ont été considérées :
+Three approaches were considered:
 
-- **A — objectif « résultat » pur** : on récompense la vitesse de lacet et on laisse
-  PPO trouver le geste. Risque documenté dans ce repo : optimum paresseux /
-  patinage-sautillement au lieu du roulement propre.
-- **B — objectif « directif » par poses** : deux poses de ciseau interpolées par la
-  phase, comme `roller_crouch`. Marche vite *si* les poses sont bonnes ; or pour le
-  crouch elles étaient **lues sur le vrai robot**, alors qu'ici le geste est inconnu.
-  Il faudrait le composer à la main : cher et risqué (des poses sans couple utile
-  ne produisent rien).
-- **C — A + amorce antisymétrique décroissante** ← **retenue**. Structure de A, plus
-  deux termes de *shaping* faibles qui injectent la seule connaissance physique
-  certaine (le roulement différentiel), et dont le poids décroît par curriculum pour
-  laisser la policy affiner son propre geste. La **fréquence de pompage reste libre**.
+- **A — pure "outcome" objective**: reward the yaw rate and let PPO find the gesture.
+  Risk documented in this repo: a lazy optimum /
+  skid-hopping instead of clean rolling.
+- **B — "directive" objective through poses**: two scissor poses interpolated along the
+  phase, like `roller_crouch`. Works quickly *if* the poses are good; but for the
+  crouch they were **read off the real robot**, whereas here the gesture is unknown.
+  It would have to be composed by hand: expensive and risky (poses with no useful
+  torque produce nothing).
+- **C — A + a decaying antisymmetric priming term** ← **chosen**. A's structure, plus
+  two weak *shaping* terms that inject the only certain physical knowledge (differential
+  rolling), and whose weight decays by curriculum so the policy can refine its own
+  gesture. The **pumping frequency stays free**.
 
 ## Architecture
 
-**Fichier** : `src/mjlab_microduck/tasks/microduck_spin_env_cfg.py`
+**File**: `src/mjlab_microduck/tasks/microduck_spin_env_cfg.py`
 - factory `make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg`
-- config PPO `MicroduckSpinRlCfg`
-- task id `Mjlab-Spin-Flat-MicroDuck`, enregistré dans `tasks/__init__.py`
+- PPO config `MicroduckSpinRlCfg`
+- task id `Mjlab-Spin-Flat-MicroDuck`, registered in `tasks/__init__.py`
 
-Clone la structure de `microduck_roller_crouch_env_cfg.py` : robot rollers, obs 61D
-unifié, DR complète, `action.scale = 1.0`, terrain plat.
+Clones the structure of `microduck_roller_crouch_env_cfg.py`: roller robot, unified 61D
+obs, full DR, `action.scale = 1.0`, flat terrain.
 
-**`ENABLE_SYMMETRY = False`** — obligatoire : l'augmentation de symétrie gauche/droite
-transformerait un spin à gauche en spin à droite et détruirait l'apprentissage.
+**`ENABLE_SYMMETRY = False`** — mandatory: left/right symmetry augmentation
+would turn a left spin into a right spin and destroy learning.
 
-**Commande** : `GroundPickPhaseCommandCfg(period=4.0, randomize_phase=False)`.
-`period=4.0` est le défaut de `--ground-pick-period` → rien à passer au runtime.
-`randomize_phase=False` → chaque épisode démarre à φ=0 (debout), comme au déploiement.
+**Command**: `GroundPickPhaseCommandCfg(period=4.0, randomize_phase=False)`.
+`period=4.0` is the default of `--ground-pick-period` → nothing to pass at runtime.
+`randomize_phase=False` → every episode starts at φ=0 (standing), like at deployment.
 
-## Enveloppe de phase
+## Phase envelope
 
-La phase pilote une **vitesse de lacet cible** ω\*(φ), en trapèze sur 4 segments
-(période 4 s, `SPIN_RATE_MAX = 6.0` rad/s — cible initiale ; ramenée à 3 rad/s,
-voir l'amendement ; les segments et la période n'ont pas changé) :
+The phase drives a **target yaw rate** ω\*(φ), trapezoidal over 4 segments
+(4 s period, `SPIN_RATE_MAX = 6.0` rad/s — the initial target; reduced to 3 rad/s,
+see the amendment; the segments and the period are unchanged):
 
 ```
-ACCEL_END = 0.125   [0,     0.125)  0.5 s  ω* : 0 → 6 rad/s   (lancement, rampe linéaire)
-HOLD_END  = 0.525   [0.125, 0.525)  1.6 s  ω* = 6 rad/s        (régime)
-BRAKE_END = 0.650   [0.525, 0.650)  0.5 s  ω* : 6 → 0          (freinage, rampe linéaire)
-            1.0     [0.650, 1.0)    1.4 s  ω* = 0              (repos debout)
+ACCEL_END = 0.125   [0,     0.125)  0.5 s  ω*: 0 → 6 rad/s   (launch, linear ramp)
+HOLD_END  = 0.525   [0.125, 0.525)  1.6 s  ω* = 6 rad/s       (steady state)
+BRAKE_END = 0.650   [0.525, 0.650)  0.5 s  ω*: 6 → 0          (braking, linear ramp)
+            1.0     [0.650, 1.0)    1.4 s  ω* = 0             (standing rest)
 ```
 
-*(Les valeurs ω\* = 6 rad/s ci-dessus correspondent à `SPIN_RATE_MAX` = 6.0, la
-cible initiale ; voir l'amendement pour la valeur en vigueur.)*
+*(The ω\* = 6 rad/s values above correspond to `SPIN_RATE_MAX` = 6.0, the
+initial target; see the amendment for the value in force.)*
 
-Intégrale sur un cycle : `0.5·3 + 1.6·6 + 0.5·3 = 12.6 rad ≈ 2.0 tours`. ✅
-*(à `SPIN_RATE_MAX = 6.0`, cible initiale.)* Forme générale : l'intégrale vaut
-`2.1 × SPIN_RATE_MAX` quel que soit `rate_max` (0.25 + 1.6 + 0.25 = 2.1). Avec la
-cible en vigueur (3.0 rad/s) : `2.1 × 3.0 = 6.3 rad ≈ 1 tour` par cycle — voir
-l'amendement.
+Integral over one cycle: `0.5·3 + 1.6·6 + 0.5·3 = 12.6 rad ≈ 2.0 turns`. ✅
+*(at `SPIN_RATE_MAX = 6.0`, the initial target.)* General form: the integral equals
+`2.1 × SPIN_RATE_MAX` whatever `rate_max` is (0.25 + 1.6 + 0.25 = 2.1). With the
+target in force (3.0 rad/s): `2.1 × 3.0 = 6.3 rad ≈ 1 turn` per cycle — see
+the amendment.
 
-Épisode = 20 s = **5 cycles** : le robot répète lancement → régime → freinage → repos
-cinq fois par épisode. Plus de données par épisode, et le segment « repos » entraîne
-aussi la sortie propre du trick. **Note (post-run)** : ceci reste vrai
-géométriquement (20 s / 4 s), mais aucun épisode du run de calibrage n'a survécu
-au-delà de ~1,16 s, soit une fraction du premier cycle seulement — voir
-« Résultats de la vérification initiale ».
+Episode = 20 s = **5 cycles**: the robot repeats launch → steady state → braking → rest
+five times per episode. More data per episode, and the "rest" segment also trains
+the clean exit from the trick. **Note (post-run)**: this remains true
+geometrically (20 s / 4 s), but no episode of the calibration run survived
+beyond ~1.16 s, i.e. only a fraction of the first cycle — see
+"Initial verification results".
 
-**Fonction pure** `spin_rate_by_phase(phase, rate_max, accel_end, hold_end, brake_end)`
-dans `mdp.py`, à côté de `crouch_pose_blend`. Testable sans simulateur.
+**Pure function** `spin_rate_by_phase(phase, rate_max, accel_end, hold_end, brake_end)`
+in `mdp.py`, next to `crouch_pose_blend`. Testable without a simulator.
 
-**Porte de shaping** : `gate(φ) = spin_rate_by_phase(φ) / rate_max ∈ [0, 1]`. Vaut 0
-sur le segment repos → aucune amorce ne pousse au ciseau à ce moment-là, donc le robot
-revient en station neutre. C'est ce qui donne une sortie de trick propre vers la policy
-roller.
+**Shaping gate**: `gate(φ) = spin_rate_by_phase(φ) / rate_max ∈ [0, 1]`. It is 0
+over the rest segment → no priming term pushes toward the scissor at that moment, so the robot
+returns to a neutral stance. That is what gives a clean trick exit back to the roller
+policy.
 
 ## Rewards
 
-### Pièges vérifiés dans mjlab (à traiter explicitement)
+### Pitfalls verified in mjlab (to be handled explicitly)
 
-- `body_ang_vel` (`body_angular_velocity_penalty`) ne pénalise que **x/y**
-  (`ang_vel_xy`, commentaire « Don't penalize z-angular velocity ») → **gardée**
-  (poids −0.05) : elle réprime le ballant roulis/tangage sans gêner le spin.
-- `angular_momentum` (`angular_momentum_penalty`) pénalise la **norme 3D** du moment
-  angulaire → elle combattrait directement le spin. **Supprimée.**
+- `body_ang_vel` (`body_angular_velocity_penalty`) only penalizes **x/y**
+  (`ang_vel_xy`, comment "Don't penalize z-angular velocity") → **kept**
+  (weight −0.05): it suppresses roll/pitch wobble without hindering the spin.
+- `angular_momentum` (`angular_momentum_penalty`) penalizes the **3D norm** of angular
+  momentum → it would fight the spin head-on. **Removed.**
 
-### Nouvelles rewards (à écrire dans `mdp.py`)
+### New rewards (to be written in `mdp.py`)
 
-| Reward | Poids | Définition |
+| Reward | Weight | Definition |
 |---|---|---|
-| `spin_rate_track` | 6.0 | `exp(−((ω_z − ω*(φ))/std)²)`, `std = 1.5` rad/s. ω_z = lacet du tronc en repère corps (ce que voit l'IMU). Objectif principal. |
-| `spin_rate_l1` | 0.5 | `−|ω_z − ω*(φ)|` : bootstrap à gradient constant quand la gaussienne sature loin de la cible (même astuce que `crouch_glide_pose_l1`) |
-| `spin_stay_in_place` | −3.0 (initialement −1.0, voir l'amendement) | `‖v_xy‖²` du tronc → « sur place », et tue l'élan d'entrée. Pas d'état de référence, donc robuste aux 5 cycles par épisode |
-| `spin_wheel_differential` | 1.0 | `gate(φ) · tanh(clamp(ω_D − ω_G, min=0) / omega_scale)` avec `ω_G = (LF+LR)/2`, `ω_D = (RF+RR)/2` : récompense les patins qui roulent en sens opposés cohérents avec l'anti-horaire → tourner **en roulement**, pas en patinage. Roues résolues par nom (`passive_LF_?wheel`, …). `omega_scale = 17.0` rad/s en vigueur (voir le paragraphe de calibrage ci-dessous) |
-| `leg_antisymmetry` | 1.0 → 0.25 | `gate(φ) · (−mean|q_G − q_D|)` sur `hip_pitch` et `knee`. ⚠️ convention miroir : une pose *symétrique* donne `q_G + q_D ≈ 0`, donc le **ciseau** c'est `q_G ≈ q_D`. Décroît par curriculum |
-| `spin_grounded` | 0.5 | `gate(φ) · 1[n_contact ≥ 2]` : les deux lames au sol, empêche « je saute et je vrille en l'air ». La `grounded_reward` du swizzle n'est pas réutilisable telle quelle (elle se pondère par `cmd_x`, qui vaut ici `cos(2πφ)`) |
+| `spin_rate_track` | 6.0 | `exp(−((ω_z − ω*(φ))/std)²)`, `std = 1.5` rad/s. ω_z = trunk yaw in the body frame (what the IMU sees). Main objective. |
+| `spin_rate_l1` | 0.5 | `−|ω_z − ω*(φ)|`: constant-gradient bootstrap when the gaussian saturates far from the target (the same trick as `crouch_glide_pose_l1`) |
+| `spin_stay_in_place` | −3.0 (initially −1.0, see the amendment) | trunk `‖v_xy‖²` → "in place", and kills the entry momentum. No reference state, hence robust across the 5 cycles per episode |
+| `spin_wheel_differential` | 1.0 | `gate(φ) · tanh(clamp(ω_R − ω_L, min=0) / omega_scale)` with `ω_L = (LF+LR)/2`, `ω_R = (RF+RR)/2`: rewards skates rolling in opposite directions consistent with counter-clockwise → spinning **by rolling**, not by skidding. Wheels resolved by name (`passive_LF_?wheel`, …). `omega_scale = 17.0` rad/s in force (see the calibration paragraph below) |
+| `leg_antisymmetry` | 1.0 → 0.25 | `gate(φ) · (−mean|q_L − q_R|)` on `hip_pitch` and `knee`. ⚠️ mirror convention: a *symmetric* pose gives `q_L + q_R ≈ 0`, so the **scissor** is `q_L ≈ q_R`. Decays by curriculum |
+| `spin_grounded` | 0.5 | `gate(φ) · 1[n_contact ≥ 2]`: both blades on the ground, prevents "jump and twist in mid-air". The swizzle's `grounded_reward` is not reusable as-is (it weights itself by `cmd_x`, which here equals `cos(2πφ)`) |
 
-**Calibrage de `omega_scale`** (échelle de saturation du tanh) : au régime visé,
-chaque patin avance à `v = ω_z · demi_voie`, donc chaque roue tourne à
-`v / r` avec `r = 0.0175` m, et le différentiel vaut `2 · ω_z · demi_voie / r`.
-Les racines de jambe sont à `y = ±0.0175` m dans le modèle rollers, mais les patins
-sont plus écartés (offset de cheville) : la demi-voie réelle est à **mesurer sur les
-sites `left_foot` / `right_foot` dans le sim** au premier run. Avec une demi-voie
-estimée à ~0.03 m et `ω_z = 6` rad/s, le différentiel attendu était ~20 rad/s — d'où
-le défaut initial `omega_scale = 20.0`. **Mesure faite (Task 3) : demi-voie réelle
-= 0.0499 m, différentiel attendu = 34.2 rad/s, soit 71 % au-dessus de l'estimation
-— au-delà du seuil de 30 % fixé par le plan.** `SPIN_WHEEL_OMEGA_SCALE` a donc été
-corrigé à **34.0** (valeur intermédiaire, en vigueur tant que la cible était à
-6 rad/s ; recalibrée depuis à **17.0**, voir le paragraphe « Mise à jour »
-juste en dessous). Voir la section « Résultats de la vérification initiale »
-ci-dessous pour le détail de la mesure de demi-voie.
+**Calibrating `omega_scale`** (the tanh saturation scale): at the target steady state,
+each skate advances at `v = ω_z · half_track`, so each wheel spins at
+`v / r` with `r = 0.0175` m, and the differential equals `2 · ω_z · half_track / r`.
+The leg roots are at `y = ±0.0175` m in the roller model, but the skates
+are further apart (ankle offset): the real half-track has to be **measured on the
+`left_foot` / `right_foot` sites in sim** on the first run. With a half-track
+estimated at ~0.03 m and `ω_z = 6` rad/s, the expected differential was ~20 rad/s — hence
+the initial default `omega_scale = 20.0`. **Measurement done (Task 3): real half-track
+= 0.0499 m, expected differential = 34.2 rad/s, i.e. 71% above the estimate
+— beyond the 30% threshold set by the plan.** `SPIN_WHEEL_OMEGA_SCALE` was therefore
+corrected to **34.0** (an intermediate value, in force while the target was at
+6 rad/s; since recalibrated to **17.0**, see the "Update" paragraph
+just below). See the "Initial verification results" section
+below for the details of the half-track measurement.
 
-**Mise à jour (fix wave post-review)** : `SPIN_RATE_MAX` a été réduit de 6.0 à
-**3.0 rad/s** (décision humaine, sans curriculum — voir plus bas). Conséquence
-mécanique directe sur `omega_scale`, pas un choix indépendant : le différentiel
-attendu au régime redevient `2 · 3.0 · 0.0499 / 0.0175` = **17.1 rad/s**. Laisser
-`omega_scale = 34.0` plafonnerait le terme à `tanh(17.1/34) = 0.47` de son propre
-maximum, ce qui affaiblirait exactement le shaping que l'on cherche à renforcer.
-`SPIN_WHEEL_OMEGA_SCALE` est donc recorrigé à **17.0**, avec la même demi-voie
-mesurée (0.0499 m) conservée comme référence.
+**Update (post-review fix wave)**: `SPIN_RATE_MAX` was reduced from 6.0 to
+**3.0 rad/s** (a human decision, without a curriculum — see below). A direct mechanical
+consequence for `omega_scale`, not an independent choice: the expected differential
+at steady state becomes `2 · 3.0 · 0.0499 / 0.0175` = **17.1 rad/s**. Leaving
+`omega_scale = 34.0` would cap the term at `tanh(17.1/34) = 0.47` of its own
+maximum, which would weaken exactly the shaping we are trying to strengthen.
+`SPIN_WHEEL_OMEGA_SCALE` is therefore re-corrected to **17.0**, with the same measured
+half-track (0.0499 m) kept as the reference.
 
-### Rewards reprises de `roller_crouch` (stabilité / sim2real)
+### Rewards taken from `roller_crouch` (stability / sim2real)
 
-| Reward | Poids |
+| Reward | Weight |
 |---|---|
-| `upright` (tronc vertical) | 2.0 |
-| `feet_flat` (lames à plat) | −2.0 |
+| `upright` (vertical trunk) | 2.0 |
+| `feet_flat` (blades flat) | −2.0 |
 | `self_collisions` | −1.0 |
-| `body_ang_vel` (xy seulement) | −0.05 |
+| `body_ang_vel` (xy only) | −0.05 |
 | `action_rate_l2` | −1.0 (curriculum −0.5 → −1.0) |
 | `neck_action_rate_l2` | −0.5 |
 | `joint_torques_l2` | −1e-3 |
-| `neck_joint_pos_l2` **hors `head_yaw`** | −0.2 |
+| `neck_joint_pos_l2` **excluding `head_yaw`** | −0.2 |
 
-**La tête** : tangage/roulis de la nuque tenus près du neutre (sim2real), mais
-`head_yaw` **exclu** du terme → libre de servir de volant d'inertie pour lancer la
-rotation. Implémentation : `neck_joint_pos_l2` résout ses joints par regex
-`.*(neck|head).*` en dur ; il faut donc soit ajouter un paramètre de regex à cette
-fonction, soit écrire une variante `neck_joint_pos_l2_no_yaw`. Choix : **ajouter un
-paramètre `pattern`** à `neck_joint_pos_l2` (défaut inchangé) pour ne pas dupliquer.
+**The head**: neck pitch/roll held near neutral (sim2real), but
+`head_yaw` is **excluded** from the term → free to act as a flywheel to launch the
+rotation. Implementation: `neck_joint_pos_l2` resolves its joints by a hardcoded
+`.*(neck|head).*` regex; we must therefore either add a regex parameter to that
+function or write a `neck_joint_pos_l2_no_yaw` variant. Choice: **add a
+`pattern` parameter** to `neck_joint_pos_l2` (default unchanged) so as not to duplicate.
 
-## Reset / état d'entrée
+## Reset / entry state
 
 ```python
 cfg.events["reset_base"].params["pose_range"]["z"] = (0.1335, 0.1435)
 cfg.events["reset_base"].params["velocity_range"] = {"x": (0.0, 0.3)}
 ```
 
-Injection via `reset_root_state_uniform`. **Jamais** `push_by_setting_velocity` en
-`mode="reset"` : c'est ce qui avait produit les NaN sur le crouch (`root_vel +=` sur
-une vitesse racine potentiellement divergente → le free-joint de la base explose).
+Injected through `reset_root_state_uniform`. **Never** `push_by_setting_velocity` in
+`mode="reset"`: that is what produced the NaNs on the crouch (`root_vel +=` on
+a potentially divergent root velocity → the base free joint blows up).
 
 ## Domain randomization
 
-Identique à `roller_crouch`, sans dévier (recette sim2real validée du repo) : COM
-tronc + tête, masse/inertie, friction articulaire BAM, armature, friction roues,
-pushes 0.2 m/s toutes les 3–6 s, désalignement IMU 6°, biais d'encodeurs ±0.015 rad.
+Identical to `roller_crouch`, with no deviation (the repo's validated sim2real recipe): trunk +
+head CoM, mass/inertia, BAM joint friction, armature, wheel friction,
+0.2 m/s pushes every 3–6 s, 6° IMU misalignment, ±0.015 rad encoder bias.
 
 ## Observations
 
-Layout **61D à l'identique** de roller / ground_pick / crouch — condition pour que
-l'ONNX charge dans le slot :
+The **61D layout, identical** to roller / ground_pick / crouch — the condition for the
+ONNX to load in the slot:
 `[gyro(3), projected_gravity(3), joint_pos(14), joint_vel(14), last_action(14), command(13)]`
-avec `command = [twist(3), head_pose(4), body_pose(6)]`, head/body zero-paddés.
+with `command = [twist(3), head_pose(4), body_pose(6)]`, head/body zero-padded.
 
-Donc : retrait de `base_lin_vel` de l'actor (gardé côté critic), retrait des
-`height_scan` et `foot_height`, `wheel_vel` côté critic, joints passifs exclus des
-termes `joint_pos`/`joint_vel`, délais et bruits identiques au crouch.
+Hence: `base_lin_vel` removed from the actor (kept on the critic side), `height_scan` and
+`foot_height` removed, `wheel_vel` on the critic side, passive joints excluded from the
+`joint_pos`/`joint_vel` terms, delays and noise identical to the crouch.
 
-Le gyro est dans l'obs → la policy **observe** son propre ω_z : la tâche est observable.
+The gyro is in the obs → the policy **observes** its own ω_z: the task is observable.
 
 ## Terminations
 
-`time_out`, `fell_over`, `out_of_terrain_bounds` (héritées) + `nan_state`
-(`microduck_mdp.robot_state_is_nan`), comme le crouch.
+`time_out`, `fell_over`, `out_of_terrain_bounds` (inherited) + `nan_state`
+(`microduck_mdp.robot_state_is_nan`), like the crouch.
 
 ## Curriculum
 
-| Terme | Étapes |
+| Term | Stages |
 |---|---|
 | `action_rate_weight` | −0.5 (0) → −0.8 (250 it.) → −1.0 (500 it.) |
 | `leg_antisym_weight` | 1.0 (0) → 0.5 (1500 it.) → 0.25 (3000 it.) |
 | `com_range` | 0.003 → 0.005 (500 it.) → 0.01 (1000 it.) |
 | `head_com_range` | 0.003 → 0.005 (500 it.) → 0.01 (1000 it.) |
 
-(itérations × 24 pas/env, comme les autres envs)
+(iterations × 24 steps/env, like the other envs)
 
-**Pas de curriculum sur la vitesse cible** : 6 rad/s d'emblée *(cible initiale ;
-ramenée à 3 rad/s, toujours sans curriculum, voir l'amendement)*. Voir « Plan B ».
+**No curriculum on the target speed**: 6 rad/s from the start *(the initial target;
+reduced to 3 rad/s, still without a curriculum, see the amendment)*. See "Plan B".
 
 ## PPO
 
-`MicroduckSpinRlCfg` = copie de `MicroduckRollerCrouchRlCfg` : actor/critic
-(512, 256, 128) elu, obs normalization, PPO adaptatif lr 1e-3, `desired_kl=0.01`,
+`MicroduckSpinRlCfg` = a copy of `MicroduckRollerCrouchRlCfg`: actor/critic
+(512, 256, 128) elu, obs normalization, adaptive PPO lr 1e-3, `desired_kl=0.01`,
 `num_steps_per_env=24`, `symmetry_cfg=None`, `experiment_name="spin"`,
 `run_name="spin"`, `max_iterations=8000`.
 
 ## Tests
 
-`tests/test_spin.py` — fonctions pures, sans simulateur :
-- `spin_rate_by_phase` : valeurs aux bornes des 4 segments (0, rate_max, rate_max, 0, 0)
-- monotonie croissante sur la rampe de lancement, décroissante sur le freinage
-- **intégrale sur un cycle ≈ 4π** à `rate_max = 6.0` (garantit la **forme** du
-  trapèze, `2.1 × rate_max` rad par cycle) — ne protège plus la cible en vigueur
-  depuis l'amendement, cf. bullet suivant. Valeur exacte de l'enveloppe : 12.6 rad
-  contre 4π = 12.566 → tolérance 1 %
-- **la cible réellement expédiée** (`mdp.SPIN_RATE_MAX`) intègre bien à
-  `2.1 × SPIN_RATE_MAX` rad par cycle, quel que soit `rate_max` — ajouté en
-  7d916aa, c'est ce test qui échoue si la cible change sans qu'on ait réfléchi au
-  nombre de tours. Avec la valeur en vigueur (3.0 rad/s) : 6.3 rad ≈ 1 tour
-- `gate(φ) = 0` sur tout le segment repos, `∈ [0,1]` partout
+`tests/test_spin.py` — pure functions, no simulator:
+- `spin_rate_by_phase`: values at the boundaries of the 4 segments (0, rate_max, rate_max, 0, 0)
+- increasing monotonicity on the launch ramp, decreasing on the braking ramp
+- **integral over one cycle ≈ 4π** at `rate_max = 6.0` (guarantees the **shape** of the
+  trapezoid, `2.1 × rate_max` rad per cycle) — no longer protects the target in force
+  since the amendment, cf. the next bullet. Exact envelope value: 12.6 rad
+  against 4π = 12.566 → 1% tolerance
+- **the target actually shipped** (`mdp.SPIN_RATE_MAX`) does integrate to
+  `2.1 × SPIN_RATE_MAX` rad per cycle, whatever `rate_max` is — added in
+  7d916aa, this is the test that fails if the target changes without anyone thinking about the
+  number of turns. With the value in force (3.0 rad/s): 6.3 rad ≈ 1 turn
+- `gate(φ) = 0` over the whole rest segment, `∈ [0,1]` everywhere
 
-`tests/test_spin_cfg.py` — l'env se construit :
-- commande = `GroundPickPhaseCommand`, `period == 4.0`, `randomize_phase is False`
-- `"angular_momentum" not in cfg.rewards` (le piège de la section rewards)
+`tests/test_spin_cfg.py` — the env builds:
+- command = `GroundPickPhaseCommand`, `period == 4.0`, `randomize_phase is False`
+- `"angular_momentum" not in cfg.rewards` (the pitfall from the rewards section)
 - `symmetry_cfg is None`
-- dimension de l'obs actor == 61
-- **parité exacte de l'ordre des termes d'observation** (actor + critic) avec
-  `roller_crouch`, groupe par groupe — ajouté en 7d916aa, condition stricte pour
-  que l'ONNX exporté charge dans le slot du runtime
+- actor obs dimension == 61
+- **exact parity of the observation term ordering** (actor + critic) with
+  `roller_crouch`, group by group — added in 7d916aa, a strict condition for
+  the exported ONNX to load in the runtime slot
 
-Lancer : `uv run --with pytest pytest tests/ -q`
+Run: `uv run --with pytest pytest tests/ -q`
 
-## Entraînement / déploiement
+## Training / deployment
 
 ```bash
 uv run train Mjlab-Spin-Flat-MicroDuck --env.scene.num-envs 4096 --agent.max_iterations 8000
-# surveiller Episode_Reward/spin_rate_track (doit monter)
+# watch Episode_Reward/spin_rate_track (it must rise)
 uv run scripts/play_latest.py     # alias md-play
-uv run scripts/export_latest.py   # ONNX, normaliseur d'obs baké
+uv run scripts/export_latest.py   # ONNX, obs normalizer baked in
 ```
 
 ```bash
@@ -278,140 +278,140 @@ microduck_runtime --variant pre-alpha --new-cmd-obs --roller \
   --model output.onnx --new-dxl-imu --kp 200 --action-scale 0.8 \
   --ground-pick spin.onnx \
   --ground-pick-period 4.0 \      # = SPIN_PERIOD
-  --ground-pick-kp-ratio 1.0 \    # défaut 0.6 -> forcer 1.0 (entraîné kp 200)
-  --ground-pick-action-scale 0.8  # matcher action_scale runtime
+  --ground-pick-kp-ratio 1.0 \    # default 0.6 -> force 1.0 (trained at kp 200)
+  --ground-pick-action-scale 0.8  # match the runtime action_scale
 ```
 
-Bouton **A** → spin, puis retour auto à la policy roller.
+Button **A** → spin, then automatic return to the roller policy.
 
-## Critère de succès
+## Success criterion
 
-En play : ~2 tours anti-horaire en ~2.6 s, dérive du tronc < ~10 cm, robot debout tout
-du long, station neutre stable pendant le segment repos avant le cycle suivant.
-*(Critère formulé pour la cible initiale de 6 rad/s / 2 tours ; à 3 rad/s, voir
-l'amendement, ce serait ~1 tour sur la durée du régime — critère non révisé, le
-robot ne tenant pas encore jusque-là.)*
+At play time: ~2 counter-clockwise turns in ~2.6 s, trunk drift < ~10 cm, robot upright
+throughout, a stable neutral stance during the rest segment before the next cycle.
+*(Criterion formulated for the initial target of 6 rad/s / 2 turns; at 3 rad/s, see
+the amendment, it would be ~1 turn over the duration of the steady state — criterion not revised, as the
+robot does not yet stay up that long.)*
 
-## Plan B si l'entraînement plafonne
+## Plan B if training plateaus
 
-Dans l'ordre :
-1. **Curriculum de vitesse** : `SPIN_RATE_MAX` 3 → 6 rad/s (nécessite de rendre
-   `rate_max` pilotable par un `CurriculumTermCfg` sur les params de reward).
-   **Partiellement suivi** : suite au run de calibrage, la cible a bien été
-   abaissée à 3 rad/s (voir l'amendement), mais **sans curriculum** — 3 rad/s
-   est pour l'instant une cible fixe, pas un point de départ ramping vers 6.
-   L'humain a choisi de voir d'abord ce que le robot parvient à faire à cette
-   vitesse avant d'envisager une remontée graduelle.
-2. Monter `spin_wheel_differential` et retarder la décroissance de `leg_antisymmetry`.
-3. Élargir `std` de `spin_rate_track` (1.5 → 2.5) pour un gradient utile plus loin.
-4. En dernier recours, basculer sur l'approche B (poses de ciseau composées à la main
-   dans un pose editor) pour amorcer le geste, puis relâcher.
+In order:
+1. **Speed curriculum**: `SPIN_RATE_MAX` 3 → 6 rad/s (requires making
+   `rate_max` drivable by a `CurriculumTermCfg` on the reward params).
+   **Partially followed**: after the calibration run, the target was indeed
+   lowered to 3 rad/s (see the amendment), but **without a curriculum** — 3 rad/s
+   is for now a fixed target, not a starting point ramping toward 6.
+   The human chose to first see what the robot manages to do at that
+   speed before considering a gradual increase.
+2. Raise `spin_wheel_differential` and delay the decay of `leg_antisymmetry`.
+3. Widen the `std` of `spin_rate_track` (1.5 → 2.5) for a useful gradient further out.
+4. As a last resort, switch to approach B (scissor poses composed by hand
+   in a pose editor) to prime the gesture, then release it.
 
-## Hors périmètre
+## Out of scope
 
-- Spin à droite (policy miroir dans un autre slot) — plus tard.
-- Variante à pied (sans rollers).
-- Spin commandé en vitesse continue (nécessiterait un canal de commande runtime).
+- Spinning right (a mirrored policy in another slot) — later.
+- A footed variant (without rollers).
+- A continuously speed-commanded spin (would require a runtime command channel).
 
-## Résultats de la vérification initiale
+## Initial verification results
 
-### Demi-voie mesurée et `omega_scale`
+### Measured half-track and `omega_scale`
 
-La demi-voie a été mesurée sur les sites `left_foot` / `right_foot` du modèle
-rollers : **0.0499 m**, contre l'estimation de 0.03 m du spec. Différentiel de
-roues attendu au régime (6 rad/s) : `2 · 6.0 · 0.0499 / 0.0175` = **34.2 rad/s**,
-soit 71 % au-dessus du défaut 20.0 — au-delà du seuil de 30 % fixé par le plan.
-`SPIN_WHEEL_OMEGA_SCALE` a donc été changé de 20.0 à **34.0**. Les tests continuent
-de passer `omega_scale=20.0` explicitement, pour rester indépendants de la
-constante.
+The half-track was measured on the `left_foot` / `right_foot` sites of the roller
+model: **0.0499 m**, against the spec's estimate of 0.03 m. Expected wheel
+differential at steady state (6 rad/s): `2 · 6.0 · 0.0499 / 0.0175` = **34.2 rad/s**,
+i.e. 71% above the 20.0 default — beyond the 30% threshold set by the plan.
+`SPIN_WHEEL_OMEGA_SCALE` was therefore changed from 20.0 to **34.0**. The tests keep
+passing `omega_scale=20.0` explicitly, to stay independent of the
+constant.
 
-### Smoke run (Step 2 : 5 itérations, 64 envs, garde NaN)
+### Smoke run (Step 2: 5 iterations, 64 envs, NaN guard)
 
-Terminé sans exception. `Episode_Termination/nan_state` est resté à 0.0000 sur
-toute la durée, et `/tmp/mjlab/nan_dumps/` n'a jamais été créé. Les six rewards
-spin apparaissent bien dans les clés `Episode_Reward/` loggées : `spin_rate_track`,
+Completed without an exception. `Episode_Termination/nan_state` stayed at 0.0000 for
+the whole duration, and `/tmp/mjlab/nan_dumps/` was never created. The six spin
+rewards do appear in the logged `Episode_Reward/` keys: `spin_rate_track`,
 `spin_rate_l1`, `spin_stay_in_place`, `spin_wheel_differential`, `spin_grounded`,
 `leg_antisymmetry`.
 
-Parité d'observation (Step 1) : la liste des termes de l'obs actor de l'env spin
-est **identique** à celle de `roller_crouch` — 8 termes, même ordre :
+Observation parity (Step 1): the list of terms in the spin env's actor obs
+is **identical** to `roller_crouch`'s — 8 terms, same order:
 `base_ang_vel, projected_gravity, joint_pos, joint_vel, actions, command,
-head_command, body_command`. C'est la condition pour que l'ONNX exporté charge
-dans le slot du runtime.
+head_command, body_command`. That is the condition for the exported ONNX to load
+in the runtime slot.
 
-**Note d'usage à retenir** : la commande d'exemple du plan avec `--enable-nan-guard`
-en flag nu est rejetée par le CLI de ce repo — il faut passer
+**Usage note worth remembering**: the plan's example command with `--enable-nan-guard`
+as a bare flag is rejected by this repo's CLI — you must pass
 `--enable-nan-guard True`.
 
-### Run de calibrage 500 itérations (Step 3)
+### 500-iteration calibration run (Step 3)
 
-4096 envs, 500 itérations, ~2,32 s/itération, code de sortie 0, logger wandb (donc
-`scripts/play_latest.py` / `md-play` retrouve le run).
+4096 envs, 500 iterations, ~2.32 s/iteration, exit code 0, wandb logger (so
+`scripts/play_latest.py` / `md-play` finds the run).
 
-**Ce qui a réellement été établi** : `Mean episode length` = **57.83 pas** sur un
-épisode de 1000 pas (20 s à 50 Hz), soit **~1,16 s**. `Episode_Termination/fell_over`
-≈ **70**, `time_out = 0.0000`, `nan_state = 0`. Le robot **tombe à chaque épisode**,
-à une phase φ ≈ 0,29 — en plein milieu du segment de régime. Il n'atteint jamais le
-freinage (φ ≥ 0,525) ni le repos (φ ≥ 0,650) : **71 % du cycle n'est jamais
-entraîné**.
+**What was actually established**: `Mean episode length` = **57.83 steps** out of a
+1000-step episode (20 s at 50 Hz), i.e. **~1.16 s**. `Episode_Termination/fell_over`
+≈ **70**, `time_out = 0.0000`, `nan_state = 0`. The robot **falls every episode**,
+at a phase φ ≈ 0.29 — right in the middle of the steady-state segment. It never reaches the
+braking (φ ≥ 0.525) nor the rest (φ ≥ 0.650) segment: **71% of the cycle is never
+trained**.
 
-La longueur d'épisode est passée de 23,98 à 57,83 pas sur la durée du run : la
-montée de `Episode_Reward/spin_rate_track` (0,0291 → 0,3168) reflète donc
-principalement une **survie qui s'allonge**, pas un suivi qui s'améliore. Le
-critère de succès de cette étape tel qu'énoncé dans le plan (« la courbe doit
-monter ») **n'est pas un signal valide** pour ce terme : un robot totalement
-immobile score déjà `6.0 × 0.405 = 2.43` dessus — le segment de repos paie plein
-tarif pour rester debout sans bouger, donc toute policy qui survit plus longtemps
-capte mécaniquement plus de ce segment-là, indépendamment de la qualité du suivi.
+Episode length went from 23.98 to 57.83 steps over the run: the
+rise in `Episode_Reward/spin_rate_track` (0.0291 → 0.3168) therefore mainly reflects
+**lengthening survival**, not improving tracking. The
+success criterion for this step as stated in the plan ("the curve must
+rise") **is not a valid signal** for that term: a completely
+motionless robot already scores `6.0 × 0.405 = 2.43` on it — the rest segment pays full
+price for staying upright without moving, so any policy that survives longer
+mechanically captures more of that segment, independently of tracking quality.
 
-### Diagnostic dérivé — estimations, pas des mesures directes
+### Derived diagnosis — estimates, not direct measurements
 
-Les valeurs ci-dessous viennent du rapport entre termes de reward dans le dernier
-bloc de log, ce qui annule le facteur de normalisation inconnu appliqué par le
-logger. À prendre comme des estimations, reproductibles à partir de la même
-méthode :
+The values below come from the ratio between reward terms in the last
+log block, which cancels the unknown normalization factor applied by the
+logger. To be taken as estimates, reproducible from the same
+method:
 
-**Ce qui tient** : pendant les ~1,2 s où il reste debout, le robot suit la cible
-d'assez près. Rapport `spin_rate_l1 / spin_rate_track` (−0,0097 / 0,3168, poids 0,5
-et 6,0, `std = 1.5`), en résolvant `e = 0.3674 · exp(−(e/1.5)²)` : erreur moyenne
-absolue de suivi de vitesse de lacet ≈ **0,35 rad/s**, confirmée par deux voies
-indépendantes — ce ratio `spin_rate_l1 / spin_rate_track`, et un calcul inverse à
-partir de la normalisation du reward manager. Il **peut lancer** le spin ; il **ne
-peut pas rester debout** en le faisant.
+**What holds up**: during the ~1.2 s it stays upright, the robot tracks the target
+fairly closely. The `spin_rate_l1 / spin_rate_track` ratio (−0.0097 / 0.3168, weights 0.5
+and 6.0, `std = 1.5`), solving `e = 0.3674 · exp(−(e/1.5)²)`: a mean absolute
+yaw-rate tracking error of ≈ **0.35 rad/s**, confirmed by two independent
+routes — that `spin_rate_l1 / spin_rate_track` ratio, and a back-calculation from
+the reward manager's normalization. It **can launch** the spin; it **cannot
+stay upright** while doing so.
 
-**Ce qui ne tient pas** : le bloc de shaping (`spin_wheel_differential` 1,0,
-`spin_grounded` 0,5, `spin_stay_in_place` −1,0) totalise ~1,0 de poids contre 6,0
-pour l'objectif principal — environ **13 %** de ce qu'une policy en patinage
-renoncerait à gagner en ignorant ce bloc. Et `spin_wheel_differential` est
-**invariant au centre instantané de rotation** : un spin centré à 6 rad/s et un
-pivot sur le patin gauche à 6 rad/s produisent tous les deux un différentiel de
-34,2 — ce terme n'encode donc **pas** le roulement centré, seul
-`spin_stay_in_place` le fait. `spin_stay_in_place` ≈ −0,0069 implique
-`‖v_xy‖ ≈ 0,35 m/s` : le robot est encore en translation, cohérent avec un pivot
-excentré (patin comme pivot) plutôt qu'une rotation autour du centre du corps.
+**What does not hold up**: the shaping block (`spin_wheel_differential` 1.0,
+`spin_grounded` 0.5, `spin_stay_in_place` −1.0) totals ~1.0 of weight against 6.0
+for the main objective — about **13%** of what a skidding policy
+would give up by ignoring that block. And `spin_wheel_differential` is
+**invariant to the instantaneous center of rotation**: a centered spin at 6 rad/s and a
+pivot on the left skate at 6 rad/s both produce a differential of
+34.2 — so that term does **not** encode centered rolling, only
+`spin_stay_in_place` does. `spin_stay_in_place` ≈ −0.0069 implies
+`‖v_xy‖ ≈ 0.35 m/s`: the robot is still translating, consistent with an off-center
+pivot (a skate as the pivot) rather than a rotation about the body center.
 
-### Changement de configuration décidé suite à ce diagnostic
+### Configuration change decided from this diagnosis
 
-Cible réduite de moitié — `SPIN_RATE_MAX` 6.0 → **3.0 rad/s** — et
-`spin_stay_in_place` renforcé −1.0 → **−3.0** (voir le tableau des rewards et
-`SPIN_WHEEL_OMEGA_SCALE` recalibré à 17.0 plus haut). **Délibérément sans
-curriculum** sur la vitesse cible : c'est un premier essai pour voir ce que le
-robot parvient à faire à vitesse moitié, avant d'envisager une remontée graduelle
-si besoin.
+Target halved — `SPIN_RATE_MAX` 6.0 → **3.0 rad/s** — and
+`spin_stay_in_place` strengthened −1.0 → **−3.0** (see the rewards table and
+`SPIN_WHEEL_OMEGA_SCALE` recalibrated to 17.0 above). **Deliberately without a
+curriculum** on the target speed: this is a first attempt to see what the
+robot manages at half speed, before considering a gradual increase
+if needed.
 
-**Atténuation du coût de dérive pendant le lancement.** Renforcer
-`spin_stay_in_place` à −3.0 a rendu plus aigu un défaut relevé par la revue : ce
-terme était le seul du spin à ne pas être modulé par la phase, donc il facturait à
-plein tarif la translation transitoire pendant la rampe de lancement — précisément
-le moment où le robot doit pousser au sol pour s'injecter du moment angulaire, et
-où l'élan d'entrée (jusqu'à 0.3 m/s) doit être **converti** en rotation. Le coût
-est désormais multiplié par `SPIN_LAUNCH_DRIFT_SCALE = 0.2` sur `[0, ACCEL_END)`
-et vaut plein tarif ensuite. Il n'est volontairement **pas** éteint pendant le
-repos, contrairement aux amorces : c'est là que l'immobilité est le vrai critère.
+**Attenuating the drift cost during the launch.** Strengthening
+`spin_stay_in_place` to −3.0 sharpened a flaw raised in review: that
+term was the only one in the spin not modulated by the phase, so it charged full
+price for the transient translation during the launch ramp — precisely
+the moment when the robot must push against the ground to inject angular momentum, and
+when the entry momentum (up to 0.3 m/s) must be **converted** into rotation. The cost
+is now multiplied by `SPIN_LAUNCH_DRIFT_SCALE = 0.2` over `[0, ACCEL_END)`
+and is full price afterwards. It is deliberately **not** switched off during the
+rest segment, unlike the priming terms: that is where stillness is the real criterion.
 
-L'étape 4 (regarder le geste) reste à faire, réservée à l'humain.
+Step 4 (watching the gesture) remains to be done, reserved for the human.
 
-⚠️ Ces quatre tests (trois nouveaux sur l'atténuation, un modifié) n'ont **pas**
-été exécutés — la machine était réservée à autre chose au moment du commit. À
-lancer avant tout run long : `uv run --with pytest pytest tests/test_spin.py
+⚠️ These four tests (three new ones on the attenuation, one modified) were **not**
+run — the machine was reserved for something else at commit time. To be
+run before any long run: `uv run --with pytest pytest tests/test_spin.py
 tests/test_spin_cfg.py -q`.

--- a/scripts/crouch_pose_editor.py
+++ b/scripts/crouch_pose_editor.py
@@ -1,11 +1,11 @@
 """Interactive crouch pose editor (roller robot).
 
-Ouvre le viewer MuJoCo avec le robot rollers debout. Dans le panneau "Control"
-du viewer, bouge les sliders (genoux/hanches/chevilles…) pour composer la pose
-ACCROUPIE voulue. La gravité est coupée et la base est maintenue droite +
-abaissée pour que le point le plus bas reste au sol (tu vois donc le tronc
-descendre quand tu plies les genoux). À la fermeture de la fenêtre, la pose est
-imprimée en dict CROUCH_POSE  {nom_articulation: angle_rad}  prêt à coller.
+Opens the MuJoCo viewer with the roller robot standing. In the viewer's
+"Control" panel, move the sliders (knees/hips/ankles…) to compose the CROUCH
+pose you want. Gravity is turned off and the base is held upright and lowered so
+that the lowest point stays on the ground (so you see the trunk descend as you
+bend the knees). When the window is closed, the pose is printed as a CROUCH_POSE
+dict  {joint_name: angle_rad}  ready to paste.
 
 Usage:
     uv run python scripts/crouch_pose_editor.py
@@ -30,15 +30,15 @@ def home_value(joint_name: str):
     return 0.0
 
 
-# Modèle direct depuis le spec du robot (14 actionneurs <position> dans le XML).
+# Model built directly from the robot spec (14 <position> actuators in the XML).
 model = get_walk_rollers_spec().compile()
 data = mujoco.MjData(model)
 mujoco.mj_resetData(model, data)
-model.opt.gravity[:] = [0, 0, 0]  # rien ne s'effondre : seuls les sliders bougent
+model.opt.gravity[:] = [0, 0, 0]  # nothing collapses: only the sliders move it
 
 has_free = model.jnt_type[0] == mujoco.mjtJoint.mjJNT_FREE
 
-# Articulations actionnées (hors roues passives), avec adresse qpos.
+# Actuated joints (excluding passive wheels), with their qpos address.
 joints = []
 for i in range(model.njnt):
     name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, i)
@@ -46,7 +46,7 @@ for i in range(model.njnt):
         continue
     joints.append((name, model.jnt_qposadr[i]))
 
-# ctrl initial = pose HOME (les actionneurs position tiennent cette cible).
+# Initial ctrl = HOME pose (the position actuators hold that target).
 for a in range(model.nu):
     aname = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, a)
     data.ctrl[a] = home_value(aname or "")
@@ -63,9 +63,9 @@ robot_geoms = [g for g in range(model.ngeom)
 mujoco.mj_forward(model, data)
 
 print("=== Crouch Pose Editor (rollers) ===")
-print(f"actionneurs: {model.nu} | base flottante: {has_free}")
-print("Ouvre le panneau 'Control' du viewer et bouge les sliders pour composer")
-print("la pose ACCROUPIE. Ferme la fenêtre quand c'est bon.\n")
+print(f"actuators: {model.nu} | floating base: {has_free}")
+print("Open the viewer's 'Control' panel and move the sliders to compose")
+print("the CROUCH pose. Close the window when you are happy with it.\n")
 
 with mujoco.viewer.launch_passive(model, data) as viewer:
     while viewer.is_running():
@@ -73,7 +73,7 @@ with mujoco.viewer.launch_passive(model, data) as viewer:
             data.qpos[0:2] = base_xy
             data.qpos[3:7] = base_quat
             data.qvel[0:6] = 0.0
-        mujoco.mj_step(model, data)  # actionneurs position -> les joints suivent ctrl
+        mujoco.mj_step(model, data)  # position actuators -> the joints follow ctrl
         if has_free:
             data.qpos[0:2] = base_xy
             data.qpos[3:7] = base_quat
@@ -89,11 +89,11 @@ with mujoco.viewer.launch_passive(model, data) as viewer:
         viewer.sync()
         time.sleep(1.0 / 60.0)
 
-print("\n=== Pose accroupie capturée ===\n")
+print("\n=== Captured crouch pose ===\n")
 print("CROUCH_POSE = {")
 for name, adr in joints:
     print(f'    "{name}": {float(data.qpos[adr]):.4f},')
 print("}")
 if has_free:
-    print(f"\n# hauteur de base finale (info) : z = {float(data.qpos[2]):.4f}")
-print("# Colle CROUCH_POSE ici et donne-le a Claude pour cabler la reward.")
+    print(f"\n# final base height (info): z = {float(data.qpos[2]):.4f}")
+print("# Paste CROUCH_POSE here and hand it to Claude to wire up the reward.")

--- a/scripts/play_latest.py
+++ b/scripts/play_latest.py
@@ -1,20 +1,20 @@
 """Find the latest wandb run for a given user and launch `uv run play`.
 
-Par défaut : le tout dernier run (toutes tâches confondues).
-Avec un flag de type, le dernier run de CE type seulement :
-    md-play --crouch      # dernier Mjlab-RollerCrouch-...
-    md-play --roller      # dernier Mjlab-...-Rollers
-    md-play --swizzle     # dernier Mjlab-...-Swizzle-...
-    md-play --slope       # dernier Mjlab-RollerSlope-...
-Les arguments inconnus sont transmis tels quels à `uv run play`
-(ex: md-play --crouch --action-scale 0.8).
+By default: the very latest run (across all tasks).
+With a type flag, the latest run of THAT type only:
+    md-play --crouch      # latest Mjlab-RollerCrouch-...
+    md-play --roller      # latest Mjlab-...-Rollers
+    md-play --swizzle     # latest Mjlab-...-Swizzle-...
+    md-play --slope       # latest Mjlab-RollerSlope-...
+Unknown arguments are forwarded verbatim to `uv run play`
+(e.g. md-play --crouch --action-scale 0.8).
 """
 
 import argparse
 
 from wandb_utils import resolve_run, run_command
 
-# flag -> sous-chaîne recherchée dans le task_id (metadata args[0])
+# flag -> substring looked up in the task_id (metadata args[0])
 TYPE_SUBSTR = {
     "crouch": "Crouch",     # Mjlab-RollerCrouch-Flat-MicroDuck
     "roller": "MicroDuck-Rollers",  # Mjlab-Velocity-Flat-MicroDuck-Rollers (≠ RollerSlope/RollerCrouch)

--- a/scripts/view_slope_terrain.py
+++ b/scripts/view_slope_terrain.py
@@ -1,19 +1,19 @@
-"""Observer la rampe du mode pente (roller_slope) dans le viewer MuJoCo.
+"""Inspect the slope-mode ramp (roller_slope) in the MuJoCo viewer.
 
-Construit UNIQUEMENT le terrain « plat + rampe » (FlatRampTerrainCfg), sur
-plusieurs rangées de difficulté croissante (raideur 2° -> 20°), et ouvre le
-viewer natif MuJoCo. Aucune politique entraînée n'est nécessaire — c'est fait
-pour valider à l'œil la géométrie (jointure plat/rampe, sens de descente).
+Builds ONLY the "flat + ramp" terrain (FlatRampTerrainCfg), across several rows
+of increasing difficulty (steepness 2° -> 20°), and opens the native MuJoCo
+viewer. No trained policy is needed — this exists to eyeball the geometry
+(flat/ramp joint, direction of descent).
 
-Usage :
+Usage:
     uv run python scripts/view_slope_terrain.py
     uv run python scripts/view_slope_terrain.py --rows 6 --ramp-max 8 --runout 4
-    uv run python scripts/view_slope_terrain.py --build-only   # test sans GUI
+    uv run python scripts/view_slope_terrain.py --build-only   # test without GUI
 
-Dans le viewer : molette pour zoomer, clic-gauche glisser pour orbiter,
-clic-droit glisser pour translater. Chaque rangée est une rampe de plus en plus
-raide (difficulté 0 -> 1), de longueur tirée au hasard dans [ramp-min, ramp-max],
-et se termine par un plat de sortie. « Devant » (+x) doit descendre.
+In the viewer: scroll wheel to zoom, left-click drag to orbit, right-click drag
+to pan. Each row is a progressively steeper ramp (difficulty 0 -> 1), of a length
+drawn at random from [ramp-min, ramp-max], ending in a flat runout. "Forward"
+(+x) must go downhill.
 """
 
 import argparse
@@ -30,13 +30,13 @@ from mjlab_microduck.tasks.slope_terrain import (
 
 
 def build_model(rows, size, flat_length, ramp_range, runout, deg_min, deg_max):
-    """Construit le modèle MuJoCo du terrain seul (rows rampes de raideur croissante)."""
+    """Build the MuJoCo model of the terrain alone (rows ramps of increasing steepness)."""
     cfg = TerrainGeneratorCfg(
         seed=0,
         size=size,
         num_rows=rows,
         num_cols=1,
-        curriculum=True,  # difficulté croissante le long des rangées
+        curriculum=True,  # difficulty increases along the rows
         difficulty_range=(0.0, 1.0),
         add_lights=True,
         sub_terrains={
@@ -58,15 +58,15 @@ def build_model(rows, size, flat_length, ramp_range, runout, deg_min, deg_max):
 
 def main():
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--rows", type=int, default=5, help="Nb de rangées = nb de raideurs affichées (défaut 5)")
-    p.add_argument("--size", type=float, nargs=2, default=(15.0, 4.0), help="Taille d'une tuile (x y) en m")
-    p.add_argument("--flat-length", type=float, default=2.0, help="Longueur du plat de départ (m)")
-    p.add_argument("--ramp-min", type=float, default=3.0, help="Longueur horizontale mini de la rampe (m)")
-    p.add_argument("--ramp-max", type=float, default=8.0, help="Longueur horizontale maxi de la rampe (m)")
-    p.add_argument("--runout", type=float, default=4.0, help="Longueur du plat de sortie (m)")
-    p.add_argument("--deg-min", type=float, default=RAMP_DEG_MIN, help=f"Raideur min en degrés (défaut {RAMP_DEG_MIN})")
-    p.add_argument("--deg-max", type=float, default=RAMP_DEG_MAX, help=f"Raideur max en degrés (défaut {RAMP_DEG_MAX})")
-    p.add_argument("--build-only", action="store_true", help="Construit le modèle et quitte (test sans GUI)")
+    p.add_argument("--rows", type=int, default=5, help="Number of rows = number of steepness levels shown (default 5)")
+    p.add_argument("--size", type=float, nargs=2, default=(15.0, 4.0), help="Tile size (x y) in m")
+    p.add_argument("--flat-length", type=float, default=2.0, help="Length of the starting flat (m)")
+    p.add_argument("--ramp-min", type=float, default=3.0, help="Minimum horizontal ramp length (m)")
+    p.add_argument("--ramp-max", type=float, default=8.0, help="Maximum horizontal ramp length (m)")
+    p.add_argument("--runout", type=float, default=4.0, help="Length of the flat runout (m)")
+    p.add_argument("--deg-min", type=float, default=RAMP_DEG_MIN, help=f"Minimum steepness in degrees (default {RAMP_DEG_MIN})")
+    p.add_argument("--deg-max", type=float, default=RAMP_DEG_MAX, help=f"Maximum steepness in degrees (default {RAMP_DEG_MAX})")
+    p.add_argument("--build-only", action="store_true", help="Build the model and exit (test without GUI)")
     args = p.parse_args()
 
     model = build_model(
@@ -82,15 +82,15 @@ def main():
     mujoco.mj_forward(model, data)
 
     print(
-        f"Terrain construit : {args.rows} rampes, raideur {args.deg_min}°->{args.deg_max}°, "
-        f"longueur rampe {args.ramp_min}-{args.ramp_max}m + sortie {args.runout}m, "
-        f"{model.ngeom} géométries."
+        f"Terrain built: {args.rows} ramps, steepness {args.deg_min}°->{args.deg_max}°, "
+        f"ramp length {args.ramp_min}-{args.ramp_max}m + runout {args.runout}m, "
+        f"{model.ngeom} geoms."
     )
     if args.build_only:
-        print("--build-only : OK, pas de GUI.")
+        print("--build-only: OK, no GUI.")
         return
 
-    print("Ouverture du viewer MuJoCo (Ctrl+C pour quitter)…")
+    print("Opening the MuJoCo viewer (Ctrl+C to quit)…")
     with mujoco.viewer.launch_passive(model, data, show_left_ui=False, show_right_ui=False) as viewer:
         while viewer.is_running():
             mujoco.mj_forward(model, data)

--- a/src/mjlab_microduck/hf_jobs.py
+++ b/src/mjlab_microduck/hf_jobs.py
@@ -55,9 +55,9 @@ apt-get install -qq -y --no-install-recommends git curl ca-certificates xz-utils
 # "The wheel is invalid: Missing .dist-info directory").
 curl -LsSf https://astral.sh/uv/0.11.30/install.sh | sh >/dev/null
 export PATH="/root/.local/bin:$PATH"
-# HF Jobs met le cache uv et /work sur des FS différents -> uv ne peut pas
-# hardlink et son fallback corrompt les wheels construits (bam -> "Missing
-# .dist-info directory"). copy = install fiable (le remède que uv suggère).
+# HF Jobs puts the uv cache and /work on different filesystems -> uv cannot
+# hardlink, and its fallback corrupts built wheels (bam -> "Missing .dist-info
+# directory"). copy = reliable install (the remedy uv itself suggests).
 export UV_LINK_MODE=copy
 
 mkdir -p /work && cd /work

--- a/src/mjlab_microduck/tasks/__init__.py
+++ b/src/mjlab_microduck/tasks/__init__.py
@@ -207,7 +207,7 @@ register_mjlab_task(
     runner_cls=MicroduckOnPolicyRunner,
 )
 
-# Spin task — rotation rapide sur place, sur rollers (slot ground-pick).
+# Spin task — fast spin in place, on rollers (ground-pick slot).
 register_mjlab_task(
     task_id="Mjlab-Spin-Flat-MicroDuck",
     env_cfg=make_microduck_spin_env_cfg(),

--- a/src/mjlab_microduck/tasks/__init__.py
+++ b/src/mjlab_microduck/tasks/__init__.py
@@ -198,7 +198,7 @@ register_mjlab_task(
     runner_cls=MicroduckOnPolicyRunner,
 )
 
-# Roller STANDUP — se relever sur rollers (policy dédiée, départ au sol).
+# Roller STANDUP — standing up on rollers (dedicated policy, starts on the ground).
 register_mjlab_task(
     task_id="Mjlab-RollerStandUp-Flat-MicroDuck",
     env_cfg=make_microduck_roller_standup_env_cfg(),

--- a/src/mjlab_microduck/tasks/mdp.py
+++ b/src/mjlab_microduck/tasks/mdp.py
@@ -3127,7 +3127,7 @@ def apply_mouth_payload_force(
     p_com = asset.data.body_com_pos_w[:, bid, :]         # (N,3)
     F = torch.zeros((env.num_envs, 3), device=env.device, dtype=p_mouth.dtype)
     F[:, 2] = fz
-    tau = torch.cross(p_mouth - p_com, F, dim=-1)        # applique F au mouth_tip
+    tau = torch.cross(p_mouth - p_com, F, dim=-1)        # applies F at the mouth_tip
     asset.write_external_wrench_to_sim(
         forces=F.unsqueeze(1), torques=tau.unsqueeze(1), body_ids=[bid],
     )

--- a/src/mjlab_microduck/tasks/mdp.py
+++ b/src/mjlab_microduck/tasks/mdp.py
@@ -981,14 +981,13 @@ def robot_state_is_nan(
     but standard mjlab rewards can still be NaN here. One NaN reward is
     tolerable because done=True prevents it propagating backward through GAE.
 
-    Couvre TOUT l'état physique, pas seulement joint_pos : la divergence du
-    contact fait souvent exploser le FREE-JOINT de base (position/orientation/
-    vitesse) ou les ROUES passives, pas les joints actionnés. Ces quantités
-    alimentent des termes d'obs critic (base_lin_vel, base_ang_vel,
-    projected_gravity, wheel_vel) ; si on ne les surveille pas, l'env ne se
-    reset pas et le NaN atteint l'obs → le check_nan de rsl_rl tue tout
-    l'entraînement. On teste la non-finitude (NaN ET inf, l'inf devenant NaN en
-    aval lors de la normalisation de projected_gravity).
+    Covers the WHOLE physical state, not just joint_pos: contact divergence
+    usually blows up the base FREE JOINT (position/orientation/velocity) or the
+    passive WHEELS, not the actuated joints. Those quantities feed critic obs
+    terms (base_lin_vel, base_ang_vel, projected_gravity, wheel_vel); if we do
+    not watch them, the env never resets and the NaN reaches the obs → rsl_rl's
+    check_nan kills the whole run. We test for non-finiteness (NaN AND inf, inf
+    turning into NaN downstream when projected_gravity is normalized).
     """
     asset: Entity = env.scene[asset_cfg.name]
     d = asset.data
@@ -1021,12 +1020,11 @@ def root_height_below(
 ) -> torch.Tensor:
     """Terminate when the trunk drops below ``min_height`` in world z.
 
-    Utilisé par roller_slope comme « tombé dans le vide » : le terrain a un
-    plat de sortie au bas de la rampe, donc une descente normale ne passe
-    jamais sous le niveau du plat de sortie le plus bas. Choisir min_height
-    en dessous de ce niveau => la terminaison ne se déclenche que si le robot
-    quitte le solide et chute dans le vide. Indépendant de la géométrie exacte
-    de la rampe (longueur/pente).
+    Used by roller_slope as "fell into the void": the terrain has a flat runout
+    at the bottom of the ramp, so a normal descent never goes below the level of
+    the lowest runout. Choosing min_height below that level => the termination
+    only fires if the robot leaves the solid and falls into the void.
+    Independent of the ramp's exact geometry (length/slope).
     """
     asset: Entity = env.scene[asset_cfg.name]
     return asset.data.root_link_pos_w[:, 2] < min_height
@@ -1037,13 +1035,13 @@ def descent_speed_reward(
     cap: float = 0.8,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Récompense la vitesse d'avance vers le BAS de la pente (monde +x).
+    """Reward forward speed DOWN the slope (world +x).
 
-    La rampe descend en +x, donc la vitesse linéaire monde en x mesure la
-    progression de descente. Plafonnée à ``cap`` m/s : encourage à se laisser
-    glisser sans pousser à dévaler de plus en plus vite. Nulle si le robot
-    recule/remonte (vx < 0). Sans cette récompense, l'optimum est de rester
-    immobile et droit (le robot « freine » au lieu de glisser). NaN-safe.
+    The ramp descends along +x, so world linear velocity in x measures descent
+    progress. Capped at ``cap`` m/s: encourages letting oneself glide without
+    pushing to go ever faster. Zero if the robot backs up / climbs (vx < 0).
+    Without this reward, the optimum is to stay motionless and upright (the
+    robot "brakes" instead of gliding). NaN-safe.
     """
     asset: Entity = env.scene[asset_cfg.name]
     vx = torch.nan_to_num(
@@ -1059,28 +1057,27 @@ def reset_rolling_entry(
     wheel_radius: float = 0.0175,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> None:
-    """Départ en ROULEMENT sans glissement (élan aux roues).
+    """Start ROLLING without slipping (momentum in the wheels).
 
-    Tire une vitesse d'avance v par env ; met la vitesse LINÉAIRE de base (x
-    monde) = v ET la vitesse de ROTATION des 4 roues passives = v / r, donc
-    ω·r = v => zéro glissement au contact. Évite l'à-coup de l'ancienne poussée
-    base-seule (base qui bouge, roues immobiles = patinage brutal au 1er pas).
-    À exécuter APRÈS reset_base (qui pose la base ; ne plus lui donner de
-    velocity_range).
+    Draws a forward speed v per env; sets the base LINEAR velocity (world x) = v
+    AND the ROTATION speed of the 4 passive wheels = v / r, so ω·r = v => zero
+    slip at the contact. Avoids the jolt of the old base-only push (base moving,
+    wheels still = brutal skidding on the first step). Run AFTER reset_base
+    (which places the base; stop giving it a velocity_range).
     """
     asset: Entity = env.scene[asset_cfg.name]
     if env_ids is None:
         env_ids = torch.arange(env.num_envs, device=env.device)
     n = int(env_ids.shape[0])
     lo, hi = speed_range
-    v = torch.rand(n, device=env.device) * (hi - lo) + lo  # (n,) vitesse avant
+    v = torch.rand(n, device=env.device) * (hi - lo) + lo  # (n,) forward speed
 
-    # Vitesse de base (monde) : uniquement +x.
+    # Base velocity (world): +x only.
     root_vel = torch.zeros(n, 6, device=env.device)
     root_vel[:, 0] = v
     asset.write_root_link_velocity_to_sim(root_vel, env_ids=env_ids)
 
-    # Rotation des 4 roues passives = v / r (positif = avant, cf. wheel_speed).
+    # Rotation of the 4 passive wheels = v / r (positive = forward, cf. wheel_speed).
     wheel_ids = []
     for name in ("passive_LF_?wheel", "passive_LR_?wheel", "passive_RF_?wheel", "passive_RR_?wheel"):
         ids, _ = asset.find_joints(name)
@@ -1095,14 +1092,14 @@ def wheel_glide_reward(
     cap_speed: float = 0.35,
     wheel_radius: float = 0.0175,
 ) -> torch.Tensor:
-    """Récompense le ROULEMENT des roues vers l'avant (glisse), plafonné.
+    """Reward forward WHEEL ROLLING (gliding), capped.
 
-    Contrairement à descent_speed (vitesse de la BASE, qu'on peut atteindre en
-    "courant"/poussant), on récompense la rotation des ROUES passives = vraie
-    glisse par roulement. Indépendant de toute commande (la tâche pente a une
-    commande nulle : la glisse vient de la gravité). Plafonné à ``cap_speed``
-    (m/s de vitesse de roulement) -> AUCUNE incitation à accélérer au-delà ; nul
-    si les roues reculent (remontée). NaN-safe.
+    Unlike descent_speed (BASE velocity, which can be reached by "running"/
+    pushing), this rewards the rotation of the passive WHEELS = genuine rolling
+    glide. Independent of any command (the slope task has a zero command: the
+    glide comes from gravity). Capped at ``cap_speed`` (m/s of rolling speed) ->
+    NO incentive to accelerate beyond it; zero if the wheels turn backward
+    (climbing). NaN-safe.
     """
     asset: Entity = env.scene["robot"]
     lf, _ = asset.find_joints("passive_LF_?wheel")
@@ -1110,7 +1107,7 @@ def wheel_glide_reward(
     rf, _ = asset.find_joints("passive_RF_?wheel")
     rr, _ = asset.find_joints("passive_RR_?wheel")
     vel = asset.data.joint_vel
-    # Les 4 roues tournent en positif pour l'avant (cf. wheel_speed_reward).
+    # All 4 wheels spin positive for forward motion (cf. wheel_speed_reward).
     omega = (vel[:, lf[0]] + vel[:, lr[0]] + vel[:, rf[0]] + vel[:, rr[0]]) / 4.0
     speed = torch.nan_to_num(omega * wheel_radius, nan=0.0, posinf=0.0, neginf=0.0)
     return torch.clamp(speed, min=0.0, max=cap_speed)
@@ -1181,19 +1178,19 @@ def crouch_height_target(
     hold_lo: float = 0.375,
     hold_hi: float = 0.625,
 ) -> torch.Tensor:
-    """Cible de hauteur du tronc « en trapèze » le long de la phase [0,1).
+    """Trapezoidal trunk-height target along the phase [0,1).
 
-    phase ∈ [0, hold_lo)      : descente   height_high -> height_low
-    phase ∈ [hold_lo, hold_hi): palier      height_low   (la glisse accroupie)
-    phase ∈ [hold_hi, 1.0)    : remontée    height_low  -> height_high
+    phase ∈ [0, hold_lo)      : descent   height_high -> height_low
+    phase ∈ [hold_lo, hold_hi): plateau    height_low   (the crouched glide)
+    phase ∈ [hold_hi, 1.0)    : rise       height_low  -> height_high
 
     Args:
-        phase: (B,) phase par env, dans [0, 1).
-        height_low: hauteur du tronc accroupi (m).
-        height_high: hauteur du tronc debout (m).
-        hold_lo, hold_hi: bornes du palier bas en fraction de phase.
+        phase: (B,) per-env phase, in [0, 1).
+        height_low: crouched trunk height (m).
+        height_high: standing trunk height (m).
+        hold_lo, hold_hi: bounds of the low plateau, as a fraction of phase.
     Returns:
-        (B,) hauteur-cible en mètres.
+        (B,) target height in meters.
     """
     descend = phase < hold_lo
     hold = (phase >= hold_lo) & (phase < hold_hi)
@@ -1219,10 +1216,10 @@ def crouch_glide_reward_from_values(
     hold_hi: float = 0.625,
     std: float = 0.02,
 ) -> torch.Tensor:
-    """Récompense gaussienne du suivi de la cible de hauteur (fonction pure).
+    """Gaussian reward for tracking the height target (pure function).
 
-    Décode la phase depuis [cos, sin] puis compare la hauteur mesurée à la
-    cible-trapèze. Retourne exp(-((h - cible)/std)^2) ∈ (0, 1].
+    Decodes the phase from [cos, sin], then compares the measured height to the
+    trapezoidal target. Returns exp(-((h - target)/std)^2) ∈ (0, 1].
     """
     phase = (torch.atan2(cmd_sin, cmd_cos) / (2 * torch.pi)) % 1.0
     target = crouch_height_target(phase, height_low, height_high, hold_lo, hold_hi)
@@ -1239,10 +1236,10 @@ def crouch_glide_height_by_phase(
     std: float = 0.02,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Reward principale : suit la cible de hauteur du tronc le long de la phase.
+    """Main reward: tracks the trunk-height target along the phase.
 
-    La hauteur du CoM est calculée comme dans `com_height_target` (world z moins
-    l'origine du terrain, nan->0). La phase provient de la commande GroundPick.
+    The CoM height is computed as in `com_height_target` (world z minus the
+    terrain origin, nan->0). The phase comes from the GroundPick command.
     """
     asset: Entity = env.scene[asset_cfg.name]
     com_height = torch.nan_to_num(
@@ -1260,10 +1257,10 @@ def forward_speed_reward(
     vel_ref: float = 0.2,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Récompense la vitesse avant du tronc (conserver l'élan / ne pas freiner).
+    """Reward the trunk's forward speed (keep the momentum / do not brake).
 
-    Indépendante de la commande (la commande porte la phase, pas la vitesse).
-    tanh(clamp(vx, 0)/vel_ref) → sature à ~1, ne récompense jamais reculer.
+    Independent of the command (the command carries the phase, not the speed).
+    tanh(clamp(vx, 0)/vel_ref) → saturates at ~1, never rewards going backward.
     """
     asset: Entity = env.scene[asset_cfg.name]
     vx = asset.data.root_link_lin_vel_b[:, 0]
@@ -1389,12 +1386,12 @@ def crouch_forward_lean(
     rise_end: float = 0.60,
     asset_cfg: SceneEntityCfg = SceneEntityCfg("robot", body_names=("trunk_base",)),
 ) -> torch.Tensor:
-    """Léger penché AVANT du tronc pendant l'accroupi (gaté par le blend crouch).
+    """Slight FORWARD trunk lean during the crouch (gated by the crouch blend).
 
-    Contre la bascule arrière induite par la flexion rapide des hanches. Proxy de
-    pitch = projected_gravity_b[:,0] (positif = vers l'avant, vérifié). La porte
-    (blend) vaut 1 pendant descente+bas, 0 debout → ne biaise QUE l'accroupi.
-    target_pitch petit = "de très peu".
+    Counters the backward tip induced by fast hip flexion. Pitch proxy =
+    projected_gravity_b[:,0] (positive = forward, verified). The gate (blend) is
+    1 during descent+bottom, 0 while standing → biases the crouch ONLY.
+    A small target_pitch means "by just a little".
     """
     asset: Entity = env.scene[asset_cfg.name]
     cmd = env.command_manager.get_command(command_name)
@@ -1563,9 +1560,9 @@ def neck_joint_pos_l2(
     SceneEntityCfg singleton is reused across robots with different joint layouts
     (e.g. walk robot vs rollers robot where passive wheels shift neck indices).
 
-    ``pattern`` sélectionne les joints comptés (défaut : toute la nuque + la tête).
-    La tâche spin passe un motif qui EXCLUT `head_yaw`, pour laisser la tête servir
-    de volant d'inertie au lancement de la rotation.
+    ``pattern`` selects which joints are counted (default: the whole neck + head).
+    The spin task passes a pattern that EXCLUDES `head_yaw`, so the head can act
+    as a flywheel when launching the rotation.
     """
     asset: Entity = env.scene[asset_cfg.name]
     # Exclude passive_* joints (backlash hinges also contain "neck"/"head").
@@ -2606,14 +2603,14 @@ def kick_pose_target(
     kick_end: float,
     return_end: float,
 ) -> torch.Tensor:
-    """Cible articulaire interpolée d'un geste de shoot à 4 keyframes.
+    """Interpolated joint target for a 4-keyframe kick gesture.
 
-    phase (B,) ∈ [0,1). stand/back/forward (k,) ou (1,k). Retour (B,k).
+    phase (B,) ∈ [0,1). stand/back/forward (k,) or (1,k). Returns (B,k).
 
-    [0, windup_end)        STAND   -> BACK     (armement)
-    [windup_end, kick_end) BACK    -> FORWARD  (frappe sèche)
-    [kick_end, return_end) FORWARD -> STAND    (retour)
-    [return_end, 1.0)      STAND             (repos)
+    [0, windup_end)        STAND   -> BACK     (wind-up)
+    [windup_end, kick_end) BACK    -> FORWARD  (sharp strike)
+    [kick_end, return_end) FORWARD -> STAND    (return)
+    [return_end, 1.0)      STAND             (rest)
     """
     p = phase.unsqueeze(-1)  # (B,1)
 
@@ -2626,7 +2623,7 @@ def kick_pose_target(
 
     seg1 = interp(stand, back, s1)
     seg2 = interp(back, forward, s2)
-    seg3 = interp(forward, stand, s3)  # à s3=1 (phase>=return_end) => STAND
+    seg3 = interp(forward, stand, s3)  # at s3=1 (phase>=return_end) => STAND
 
     out = seg1
     out = torch.where(p >= windup_end, seg2, out)
@@ -2646,12 +2643,12 @@ def _kick_pose_error(
     return_end: float,
     joint_names: Optional[list] = None,
 ):
-    """(cur, target) pour le geste de shoot, joints résolus PAR NOM.
+    """(cur, target) for the kick gesture, joints resolved BY NAME.
 
-    Les 3 poses partagent les mêmes clés (14 joints). L'ordre des noms est
-    donné par `stand_pose` (ou par `joint_names` si fourni — un sous-ensemble
-    des clés, ex. jambe droite + cou d'un côté, jambe gauche de l'autre, pour
-    appliquer des std différents au geste vs à la jambe d'appui).
+    The 3 poses share the same keys (14 joints). The name ordering comes from
+    `stand_pose` (or from `joint_names` if given — a subset of the keys, e.g.
+    right leg + neck on one side, left leg on the other, so different stds can
+    be applied to the gesture vs the support leg).
     """
     if not stand_pose:
         raise ValueError("_kick_pose_error requires a non-empty stand_pose dict")
@@ -2686,12 +2683,12 @@ def kick_pose_track(
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
     joint_names: Optional[list] = None,
 ) -> torch.Tensor:
-    """Gaussienne sur la pose articulaire vs cible interpolée du shoot.
+    """Gaussian on joint pose vs the interpolated kick target.
 
-    Reward directif et symétrique : chaque phase impose la config articulaire
-    exacte. Résolution PAR NOM. `joint_names` restreint l'évaluation à un
-    sous-ensemble (ex. jambe droite + cou tracés serré, jambe gauche d'appui
-    tracée lâche pour la laisser équilibrer).
+    A directive, symmetric reward: each phase prescribes the exact joint
+    configuration. Resolution BY NAME. `joint_names` restricts the evaluation to
+    a subset (e.g. right leg + neck tracked tightly, the left support leg
+    tracked loosely so it can balance).
     """
     cur, target = _kick_pose_error(
         env, asset_cfg, command_name, stand_pose or {}, back_pose or {},
@@ -2712,7 +2709,7 @@ def kick_pose_track_l1(
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
     joint_names: Optional[list] = None,
 ) -> torch.Tensor:
-    """Bootstrap L1 vers la cible interpolée (gradient constant, pénalité<=0)."""
+    """L1 bootstrap toward the interpolated target (constant gradient, penalty<=0)."""
     cur, target = _kick_pose_error(
         env, asset_cfg, command_name, stand_pose or {}, back_pose or {},
         forward_pose or {}, windup_end, kick_end, return_end, joint_names,
@@ -2725,12 +2722,12 @@ def kick_engagement(
     windup_end: float,
     return_end: float,
 ) -> torch.Tensor:
-    """Gate d'engagement du geste ∈ [0,1] (pur) — pour pondérer les rewards
-    d'équilibre unipède qui ne doivent s'appliquer que hors du repos STAND.
+    """Gesture engagement gate ∈ [0,1] (pure) — used to weight single-leg
+    balance rewards that should only apply outside the STAND rest phase.
 
-    [0, windup_end)        : 0 -> 1  (montée pendant l'armement)
-    [windup_end, return_end): 1       (phase de frappe = appui unipède attendu)
-    [return_end, 1.0)      : 0        (repos STAND, appui bipède, CoM centré OK)
+    [0, windup_end)        : 0 -> 1  (ramp up during the wind-up)
+    [windup_end, return_end): 1       (strike phase = single-leg support expected)
+    [return_end, 1.0)      : 0        (STAND rest, double support, centered CoM OK)
     """
     g = torch.zeros_like(phase)
     ramp = phase < windup_end
@@ -2748,16 +2745,16 @@ def com_over_support_foot(
     windup_end: float = 0.35,
     return_end: float = 0.75,
 ) -> torch.Tensor:
-    """Reward gaussien : projection horizontale du CoM proche du pied d'appui,
-    gaté sur la phase de frappe (kick_engagement).
+    """Gaussian reward: horizontal CoM projection close to the support foot,
+    gated on the strike phase (kick_engagement).
 
-    Apprend le transfert latéral du poids sur le pied d'appui (support). Sans
-    ça, un geste à un pied issu de poses relevées en appui bipède garde le CoM
-    centré entre les deux pieds → bascule et chute dès que l'autre pied se lève.
-    Au repos STAND le gate est 0 (appui bipède, CoM centré autorisé).
+    Teaches the lateral weight transfer onto the support foot. Without it, a
+    one-footed gesture built from poses recorded in double support keeps the CoM
+    centered between both feet → it tips and falls as soon as the other foot
+    lifts. At STAND rest the gate is 0 (double support, centered CoM allowed).
 
-    `asset_cfg` doit cibler le site du pied d'appui (ex. site_names=["left_foot"]).
-    `std` en mètres (rayon de tolérance CoM↔pied, ~taille du pied).
+    `asset_cfg` must target the support-foot site (e.g. site_names=["left_foot"]).
+    `std` in meters (CoM↔foot tolerance radius, ~foot size).
     """
     asset: Entity = env.scene[asset_cfg.name]
     com_xy = asset.data.root_com_pos_w[:, :2]
@@ -2782,10 +2779,10 @@ def _phase_pose_error(
     rise_end: float,
     source_pose: Optional[dict] = None,
 ):
-    """(cur, target) pour la pose interpolée par la phase, résolue PAR NOM.
+    """(cur, target) for the phase-interpolated pose, resolved BY NAME.
 
-    Cible = source + blend(phase)·(target_pose - source), source = STAND
-    (`source_pose` si fourni, sinon le DEFAULT/HOME du modèle). blend ∈ [0,1]
+    Target = source + blend(phase)·(target_pose - source), source = STAND
+    (`source_pose` if given, otherwise the model's DEFAULT/HOME). blend ∈ [0,1]
     (0 = STAND, 1 = target_pose) via `phase_pose_blend`.
     """
     if not target_pose:
@@ -2825,11 +2822,11 @@ def phase_pose_track(
     rise_end: float = 0.65,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Gaussienne sur la pose articulaire vs cible interpolée STAND<->DOWN.
+    """Gaussian on joint pose vs the interpolated STAND<->DOWN target.
 
-    Reward directif : indique la config articulaire exacte à chaque phase. Se
-    relever (cible → STAND) est récompensé exactement comme se baisser (cible →
-    DOWN) — symétrique par construction. Résolution PAR NOM.
+    A directive reward: it prescribes the exact joint configuration at each
+    phase. Rising (target → STAND) is rewarded exactly like going down (target →
+    DOWN) — symmetric by construction. Resolution BY NAME.
     """
     cur, target = _phase_pose_error(
         env, asset_cfg, command_name, target_pose or {},
@@ -2848,10 +2845,10 @@ def phase_pose_track_l1(
     rise_end: float = 0.65,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Bootstrap L1 vers la cible interpolée (pénalité négative).
+    """L1 bootstrap toward the interpolated target (negative penalty).
 
-    Gradient constant partout — donne une direction vers la cible même quand la
-    gaussienne ci-dessus a saturé à ~0 loin de la cible.
+    Constant gradient everywhere — gives a direction toward the target even when
+    the Gaussian above has saturated to ~0 far from it.
     """
     cur, target = _phase_pose_error(
         env, asset_cfg, command_name, target_pose or {},
@@ -2960,18 +2957,18 @@ def ground_pick_return_upright(
 
 
 # --------------------------------------------------------------------------- #
-# Ground-pick : gating de phase SEGMENTÉ (durées descente/palier/remontée/repos #
-# indépendantes, au lieu de la pondération sinusoïdale max(0,±sin)).            #
+# Ground-pick: SEGMENTED phase gating (independent descent/hold/rise/rest       #
+# durations, instead of the sinusoidal max(0,±sin) weighting).                  #
 #   down-gate  = phase_pose_blend(phase, descent_end, hold_end, rise_end)       #
-#               0 (haut) -> 1 (descente) -> 1 (palier bas) -> 0 (remontée/repos) #
-#   up-gate    = phase_rise_gate(phase, hold_end, rise_end)                      #
-#               0 avant la remontée -> 0..1 (remontée) -> 1 (repos debout)       #
+#               0 (up) -> 1 (descent) -> 1 (low hold) -> 0 (rise/rest)          #
+#   up-gate    = phase_rise_gate(phase, hold_end, rise_end)                     #
+#               0 before the rise -> 0..1 (rise) -> 1 (standing rest)           #
 # --------------------------------------------------------------------------- #
 def phase_rise_gate(
     phase: torch.Tensor, hold_end: float, rise_end: float
 ) -> torch.Tensor:
-    """Gate montante pour le RETOUR : 0 avant hold_end, 0->1 sur [hold_end,
-    rise_end), 1 après (repos debout)."""
+    """Rising gate for the RETURN: 0 before hold_end, 0->1 over [hold_end,
+    rise_end), 1 afterwards (standing rest)."""
     g = torch.zeros_like(phase)
     rising = (phase >= hold_end) & (phase < rise_end)
     g = torch.where(rising, (phase - hold_end) / (rise_end - hold_end), g)
@@ -2994,7 +2991,7 @@ def mouth_ground_proximity_phased(
     hold_end: float = 0.35,
     rise_end: float = 0.60,
 ) -> torch.Tensor:
-    """mouth_ground_proximity gaté par la down-gate segmentée (descente+palier)."""
+    """mouth_ground_proximity gated by the segmented down-gate (descent+hold)."""
     asset = env.scene[asset_cfg.name]
     mouth_z = asset.data.site_pos_w[:, asset_cfg.site_ids[0], 2]
     proximity = torch.exp(-((mouth_z - target_height) / std) ** 2)
@@ -3010,12 +3007,12 @@ def mouth_perpendicular_phased(
     hold_end: float = 0.35,
     rise_end: float = 0.60,
 ) -> torch.Tensor:
-    """mouth_perpendicular_to_ground gaté par la down-gate segmentée."""
+    """mouth_perpendicular_to_ground gated by the segmented down-gate."""
     asset = env.scene[asset_cfg.name]
     q = asset.data.site_quat_w[:, asset_cfg.site_ids[0], :]
     w, qx, qy, qz = q[:, 0], q[:, 1], q[:, 2], q[:, 3]
     x_axis_z = 2.0 * (qx * qz - w * qy)
-    alignment = -x_axis_z  # 1 = bouche pointe droit vers le bas
+    alignment = -x_axis_z  # 1 = mouth points straight down
     gate = phase_pose_blend(_gp_phase(env, command_name), descent_end, hold_end, rise_end)
     return gate * alignment
 
@@ -3029,7 +3026,7 @@ def ground_pick_return_pose_phased(
     hold_end: float = 0.35,
     rise_end: float = 0.60,
 ) -> torch.Tensor:
-    """ground_pick_return_pose gaté par la up-gate segmentée (remontée+repos)."""
+    """ground_pick_return_pose gated by the segmented up-gate (rise+rest)."""
     asset = env.scene[asset_cfg.name]
     joint_pos = _servo_joint_pos(env, asset)
     default_pos = _servo_default_joint_pos(env, asset)
@@ -3049,7 +3046,7 @@ def ground_pick_return_upright_phased(
     hold_end: float = 0.35,
     rise_end: float = 0.60,
 ) -> torch.Tensor:
-    """ground_pick_return_upright gaté par la up-gate segmentée."""
+    """ground_pick_return_upright gated by the segmented up-gate."""
     asset: Entity = env.scene[asset_cfg.name]
     quat = asset.data.root_link_quat_w
     tilt_sq = 2.0 * (quat[:, 1] ** 2 + quat[:, 2] ** 2)
@@ -3065,12 +3062,11 @@ def neck_vel_descent_penalty(
     joint_indices: Optional[list] = None,
     hold_end: float = 0.35,
 ) -> torch.Tensor:
-    """Pénalise la vitesse des joints du cou pendant la DESCENTE+palier (freine le
-    piqué de la tête).
+    """Penalize neck joint velocity during the DESCENT+hold (damps the head dive).
 
-    Coût = mean(joint_vel²) sur les joints donnés, gaté à 1 pour phase < hold_end
-    (descente + palier bas) et 0 ensuite (remontée + repos) -> ne gêne PAS le
-    relever du cou. Retourne un coût positif ; à utiliser avec un poids négatif.
+    Cost = mean(joint_vel²) over the given joints, gated to 1 for phase <
+    hold_end (descent + low hold) and 0 afterwards (rise + rest) -> does NOT
+    hinder lifting the neck. Returns a positive cost; use with a negative weight.
     """
     asset = env.scene[asset_cfg.name]
     vel = _servo_joint_vel(env, asset)
@@ -3078,7 +3074,7 @@ def neck_vel_descent_penalty(
         vel = vel[:, joint_indices]
     cost = (vel ** 2).mean(dim=-1)
     phase = _gp_phase(env, command_name)
-    gate = (phase < hold_end).to(vel.dtype)  # descente + palier bas uniquement
+    gate = (phase < hold_end).to(vel.dtype)  # descent + low hold only
     return gate * cost
 
 
@@ -3088,8 +3084,8 @@ def sample_mouth_payload(
     min_kg: float = 0.01,
     max_kg: float = 0.04,
 ) -> None:
-    """Event de reset : tire une masse d'objet 'tenu dans la bouche' par env (kg),
-    stockée sur env._mouth_payload_kg. Utilisée par apply_mouth_payload_force."""
+    """Reset event: draws a per-env mass (kg) for the object 'held in the mouth',
+    stored on env._mouth_payload_kg. Used by apply_mouth_payload_force."""
     buf = getattr(env, "_mouth_payload_kg", None)
     if buf is None:
         buf = torch.zeros(env.num_envs, device=env.device)
@@ -3109,21 +3105,21 @@ def apply_mouth_payload_force(
     ramp: float = 0.05,
     gravity: float = 9.81,
 ) -> torch.Tensor:
-    """Hook par-step (utilisé comme reward de poids 0) : applique le POIDS de
-    l'objet tenu dans la bouche comme force externe verticale au mouth_tip, gaté
-    sur la remontée (phase >= hold_end, rampe rapide au moment du 'grab').
+    """Per-step hook (used as a weight-0 reward): applies the WEIGHT of the object
+    held in the mouth as a vertical external force at mouth_tip, gated on the rise
+    (phase >= hold_end, fast ramp at the moment of the 'grab').
 
-    Émule une masse ponctuelle au bout de la bouche pendant le relever : la force
-    m·g est appliquée au CoM du corps + le couple (p_mouth - p_com) × F, ce qui
-    équivaut à l'appliquer au mouth_tip (bon bras de levier pour le cou). Retourne
-    0 (ce n'est pas une vraie récompense — juste le hook d'application)."""
+    Emulates a point mass at the tip of the mouth during the lift: the force m·g
+    is applied at the body's CoM plus the torque (p_mouth - p_com) × F, which is
+    equivalent to applying it at mouth_tip (the right lever arm for the neck).
+    Returns 0 (this is not a real reward — just the application hook)."""
     asset: Entity = env.scene[asset_cfg.name]
     payload = getattr(env, "_mouth_payload_kg", None)
     if payload is None:
         return torch.zeros(env.num_envs, device=env.device)
     phase = _gp_phase(env, command_name)
-    gate = ((phase - hold_end) / ramp).clamp(0.0, 1.0)  # 0 avant grab -> 1 après
-    fz = -(gate * payload) * gravity                     # (N,) force verticale (bas)
+    gate = ((phase - hold_end) / ramp).clamp(0.0, 1.0)  # 0 before grab -> 1 after
+    fz = -(gate * payload) * gravity                     # (N,) vertical force (down)
 
     bid = int(asset_cfg.body_ids[0])
     sid = int(asset_cfg.site_ids[0])
@@ -3502,16 +3498,16 @@ def com_range_curriculum(
 
 
 def slope_move_masks(distance: "torch.Tensor", size_x: float):
-    """Masques de promotion/rétrogradation du curriculum de pente.
+    """Promotion/demotion masks for the slope curriculum.
 
-    move_up   : a parcouru plus de 40% de la tuile → il a dévalé la rampe,
-                on la rend plus raide. Aligné sur la termination
-                terrain_edge_reached (~3.8 m, threshold_fraction=0.95 par
-                défaut sur size_x=8.0), qui termine l'épisode avant le seuil
-                de moitié (4.0 m) — sans cet alignement un traverseur réussi
-                n'est jamais promu.
-    move_down : a à peine avancé (< 20% de la tuile) → chute/blocage précoce,
-                on adoucit la rampe.
+    move_up   : travelled more than 40% of the tile → it rode the ramp down, so
+                we make it steeper. Aligned with the terrain_edge_reached
+                termination (~3.8 m, threshold_fraction=0.95 by default on
+                size_x=8.0), which ends the episode before the half-tile
+                threshold (4.0 m) — without that alignment a successful
+                traversal is never promoted.
+    move_down : barely moved (< 20% of the tile) → early fall/stall, so we
+                flatten the ramp.
     """
     move_up = distance > size_x * 0.4
     move_down = (distance < size_x * 0.2) & (~move_up)
@@ -3519,9 +3515,9 @@ def slope_move_masks(distance: "torch.Tensor", size_x: float):
 
 
 def terrain_levels_slope(env: ManagerBasedRlEnv, env_ids: torch.Tensor) -> torch.Tensor:
-    """Curriculum de raideur pour roller_slope (pas de vitesse commandée).
+    """Steepness curriculum for roller_slope (no commanded velocity).
 
-    Progression basée sur la distance en x parcourue depuis l'origine de spawn.
+    Progression based on the x distance travelled from the spawn origin.
     """
     asset = env.scene["robot"]
     terrain = env.scene.terrain
@@ -5854,16 +5850,16 @@ def ball_vel_in_base(
 
 
 # --------------------------------------------------------------------------- #
-# Tâche SPIN — rotation rapide sur place sur rollers                            #
+# SPIN task — fast spin in place on rollers                                     #
 # --------------------------------------------------------------------------- #
-# Enveloppe de phase : la commande du slot bouton porte une phase, qui pilote
-# une VITESSE DE LACET cible en trapèze (et non une pose comme le crouch).
-#   [0, accel_end)        0.5 s   0 -> rate_max    (lancement)
-#   [accel_end, hold_end) 1.6 s   rate_max         (régime)
-#   [hold_end, brake_end) 0.5 s   rate_max -> 0    (freinage)
-#   [brake_end, 1.0)      1.4 s   0                (repos debout)
-# Aire sous l'enveloppe sur un cycle = 2.1 * SPIN_RATE_MAX rad. À 3.0 rad/s :
-# 2.1 * 3.0 = 6.3 rad ~ 1 tour (et non ~2, comme avec l'ancienne cible 6.0).
+# Phase envelope: the button-slot command carries a phase, which drives a
+# trapezoidal target YAW RATE (not a pose, unlike the crouch).
+#   [0, accel_end)        0.5 s   0 -> rate_max    (launch)
+#   [accel_end, hold_end) 1.6 s   rate_max         (steady state)
+#   [hold_end, brake_end) 0.5 s   rate_max -> 0    (braking)
+#   [brake_end, 1.0)      1.4 s   0                (standing rest)
+# Area under the envelope over one cycle = 2.1 * SPIN_RATE_MAX rad. At 3.0 rad/s:
+# 2.1 * 3.0 = 6.3 rad ~ 1 turn (not ~2, as with the old target of 6.0).
 SPIN_PERIOD = 4.0
 SPIN_RATE_MAX = 3.0
 SPIN_ACCEL_END = 0.125
@@ -5878,7 +5874,7 @@ def spin_rate_by_phase(
     hold_end: float = SPIN_HOLD_END,
     brake_end: float = SPIN_BRAKE_END,
 ) -> torch.Tensor:
-    """Vitesse de lacet cible (rad/s, positive = anti-horaire) le long de la phase."""
+    """Target yaw rate (rad/s, positive = counter-clockwise) along the phase."""
     w = torch.zeros_like(phase)
     accel = phase < accel_end
     w = torch.where(accel, rate_max * phase / accel_end, w)
@@ -5898,17 +5894,17 @@ def spin_gate_by_phase(
     hold_end: float = SPIN_HOLD_END,
     brake_end: float = SPIN_BRAKE_END,
 ) -> torch.Tensor:
-    """Porte de shaping dans [0,1] = enveloppe normalisée.
+    """Shaping gate in [0,1] = the normalized envelope.
 
-    Vaut 0 sur tout le segment de repos : les amorces (ciseau des jambes,
-    différentiel des roues) ne s'appliquent que pendant lancement + régime, donc
-    le robot revient en station neutre avant de rendre la main à la policy roller.
+    Zero over the whole rest segment: the priming terms (leg scissor, wheel
+    differential) only apply during launch + steady state, so the robot returns
+    to a neutral stance before handing control back to the roller policy.
     """
     return spin_rate_by_phase(phase, rate_max, accel_end, hold_end, brake_end) / rate_max
 
 
 def spin_phase_from_command(cmd: torch.Tensor) -> torch.Tensor:
-    """Récupère la phase [0,1) depuis la commande [cos(2πφ), sin(2πφ), 0] du slot."""
+    """Recover the phase [0,1) from the slot command [cos(2πφ), sin(2πφ), 0]."""
     return (torch.atan2(cmd[:, 1], cmd[:, 0]) / (2 * torch.pi)) % 1.0
 
 
@@ -5939,7 +5935,7 @@ def _spin_gate(
 def spin_rate_reward_from_values(
     omega_z: torch.Tensor, omega_target: torch.Tensor, std: float
 ) -> torch.Tensor:
-    """Gaussienne sur l'erreur de vitesse de lacet (fonction pure, testable)."""
+    """Gaussian on the yaw-rate error (pure, testable function)."""
     return torch.exp(-(((omega_z - omega_target) / std) ** 2))
 
 
@@ -5953,11 +5949,11 @@ def spin_rate_track(
     brake_end: float = SPIN_BRAKE_END,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Objectif principal du spin : suivre la vitesse de lacet cible ω*(φ).
+    """Main spin objective: track the target yaw rate ω*(φ).
 
-    ω_z est pris en repère corps (c'est ce que voit le gyro de l'IMU, donc ce que
-    la policy observe). Une rotation dans le mauvais sens est plus punie que
-    l'immobilité, la gaussienne étant centrée sur une cible positive.
+    ω_z is taken in the body frame (that is what the IMU gyro sees, hence what
+    the policy observes). Spinning the wrong way is punished more than standing
+    still, since the Gaussian is centered on a positive target.
     """
     asset: Entity = env.scene[asset_cfg.name]
     omega_z = asset.data.root_link_ang_vel_b[:, 2]
@@ -5974,16 +5970,16 @@ def spin_rate_l1(
     brake_end: float = SPIN_BRAKE_END,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Bootstrap L1 : gradient constant vers la cible même quand la gaussienne
-    de `spin_rate_track` sature loin de la cible. À utiliser avec un poids
-    POSITIF (la valeur retournée est déjà négative)."""
+    """L1 bootstrap: constant gradient toward the target even when the Gaussian
+    of `spin_rate_track` saturates far from it. Use with a POSITIVE weight (the
+    returned value is already negative)."""
     asset: Entity = env.scene[asset_cfg.name]
     omega_z = asset.data.root_link_ang_vel_b[:, 2]
     target = _spin_target_rate(env, command_name, rate_max, accel_end, hold_end, brake_end)
     return -torch.abs(omega_z - target)
 
 
-SPIN_LAUNCH_DRIFT_SCALE = 0.2  # atténuation du coût de dérive pendant le lancement
+SPIN_LAUNCH_DRIFT_SCALE = 0.2  # drift-cost attenuation during the launch
 
 
 def spin_stay_in_place(
@@ -5993,22 +5989,22 @@ def spin_stay_in_place(
     accel_end: float = SPIN_ACCEL_END,
     asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-    """Coût ‖v_xy‖² du tronc : tourner SUR PLACE, et tuer l'élan d'entrée.
+    """Trunk ‖v_xy‖² cost: spin IN PLACE, and kill the entry momentum.
 
-    Pas d'état de référence (contrairement à une dérive mesurée depuis le reset),
-    donc reste valide sur les 5 cycles d'un épisode. À utiliser avec un poids
-    NÉGATIF.
+    No reference state (unlike a drift measured from the reset), so it stays
+    valid across the 5 cycles of an episode. Use with a NEGATIVE weight.
 
-    ATTÉNUÉ PENDANT LE LANCEMENT : sur `[0, accel_end)` le robot doit pousser au
-    sol pour s'injecter du moment angulaire, et l'état d'entrée lui donne jusqu'à
-    0.3 m/s qu'il est censé CONVERTIR en rotation. Facturer la translation à plein
-    tarif à cet instant s'oppose donc directement à l'objectif. Le coût est
-    multiplié par `launch_scale` sur ce seul segment, et vaut plein tarif ensuite
-    (régime, freinage, repos) où « sur place » est le vrai critère.
+    ATTENUATED DURING THE LAUNCH: over `[0, accel_end)` the robot must push
+    against the ground to inject angular momentum, and the entry state gives it
+    up to 0.3 m/s that it is supposed to CONVERT into rotation. Charging full
+    price for translation at that moment therefore works directly against the
+    objective. The cost is multiplied by `launch_scale` over that segment only,
+    and is full price afterwards (steady state, braking, rest) where "in place"
+    is the real criterion.
 
-    Contrairement aux autres amorces du spin, ce terme n'est PAS éteint par
-    `spin_gate_by_phase` : pendant le repos on veut justement qu'il reste plein,
-    puisque c'est là que le robot doit être immobile.
+    Unlike the spin's other priming terms, this one is NOT switched off by
+    `spin_gate_by_phase`: during the rest segment we specifically want it at full
+    strength, since that is when the robot must be motionless.
     """
     asset: Entity = env.scene[asset_cfg.name]
     v_xy = asset.data.root_link_lin_vel_b[:, :2]
@@ -6023,21 +6019,22 @@ def spin_stay_in_place(
     return cost * scale
 
 
-# Demi-voie mesurée sur le modèle rollers (pose HOME, sites left_foot/right_foot) :
-# 0.0499 m, contre 0.03 m estimé au spec. Conséquence mécanique de SPIN_RATE_MAX
-# (A1) : différentiel attendu = 2*SPIN_RATE_MAX*demi_voie/r, r = 0.0175 m.
-# À l'ancienne cible 6.0 rad/s : 2*6.0*0.0499/0.0175 = 34.2 rad/s (retenu comme
-# 34.0, soit +71% par rapport aux 20.0 estimés au spec -> seuil de 30% dépassé).
-# À la nouvelle cible 3.0 rad/s : 2*3.0*0.0499/0.0175 = 17.1 rad/s. Laisser 34.0
-# ici plafonnerait le terme à tanh(17.1/34) = 0.47 de son propre maximum, ce qui
-# affaiblirait exactement le shaping qu'on veut renforcer (cf. spin_stay_in_place).
-SPIN_WHEEL_OMEGA_SCALE = 17.0  # rad/s ; recalibré sur la demi-voie mesurée et SPIN_RATE_MAX = 3.0
+# Half-track width measured on the roller model (HOME pose, left_foot/right_foot
+# sites): 0.0499 m, against the 0.03 m estimated in the spec. Mechanical
+# consequence of SPIN_RATE_MAX (A1): expected differential =
+# 2*SPIN_RATE_MAX*half_track/r, r = 0.0175 m.
+# At the old target of 6.0 rad/s: 2*6.0*0.0499/0.0175 = 34.2 rad/s (kept as 34.0,
+# i.e. +71% over the 20.0 estimated in the spec -> the 30% threshold was passed).
+# At the new target of 3.0 rad/s: 2*3.0*0.0499/0.0175 = 17.1 rad/s. Leaving 34.0
+# here would cap the term at tanh(17.1/34) = 0.47 of its own maximum, which would
+# weaken exactly the shaping we want to strengthen (cf. spin_stay_in_place).
+SPIN_WHEEL_OMEGA_SCALE = 17.0  # rad/s; recalibrated on the measured half-track and SPIN_RATE_MAX = 3.0
 
 
 def spin_wheel_differential_from_values(
     diff: torch.Tensor, gate: torch.Tensor, omega_scale: float
 ) -> torch.Tensor:
-    """Fonction pure : tanh du différentiel de roues, portée par gate, clampée ≥ 0."""
+    """Pure function: tanh of the wheel differential, carried by gate, clamped ≥ 0."""
     return gate * torch.tanh(torch.clamp(diff, min=0.0) / omega_scale)
 
 
@@ -6050,11 +6047,12 @@ def spin_wheel_differential(
     hold_end: float = SPIN_HOLD_END,
     brake_end: float = SPIN_BRAKE_END,
 ) -> torch.Tensor:
-    """Récompense la rotation EN ROULEMENT (et non en patinage).
+    """Reward spinning BY ROLLING (rather than by skidding).
 
-    Pour un spin anti-horaire, le patin gauche recule et le droit avance ; les 4
-    roues tournant positif en marche avant, cela donne ω_D − ω_G > 0. Le tanh
-    sature à `omega_scale` pour éviter la course à la vitesse de roue.
+    For a counter-clockwise spin the left skate goes backward and the right one
+    forward; since all 4 wheels spin positive when moving forward, this gives
+    ω_R − ω_L > 0. The tanh saturates at `omega_scale` to avoid a race to
+    maximum wheel speed.
     """
     asset: Entity = env.scene["robot"]
     lf_ids, _ = asset.find_joints("passive_LF_?wheel")
@@ -6080,10 +6078,10 @@ def spin_grounded(
     hold_end: float = SPIN_HOLD_END,
     brake_end: float = SPIN_BRAKE_END,
 ) -> torch.Tensor:
-    """Les deux lames au sol pendant le spin — empêche « je saute et je vrille ».
+    """Both blades on the ground during the spin — prevents "jump and twist".
 
-    Variante de `grounded_reward` du swizzle, qui n'est pas réutilisable ici :
-    elle se pondère par cmd_x, qui vaut cos(2πφ) sur la commande de phase.
+    Variant of the swizzle's `grounded_reward`, which is not reusable here: it
+    weights itself by cmd_x, which equals cos(2πφ) under the phase command.
     """
     from mjlab.sensor import ContactSensor
 
@@ -6106,13 +6104,13 @@ def leg_antisymmetry(
     hold_end: float = SPIN_HOLD_END,
     brake_end: float = SPIN_BRAKE_END,
 ) -> torch.Tensor:
-    """Amorce le CISEAU des jambes (une avant / une arrière) pendant le spin.
+    """Prime the leg SCISSOR (one forward / one back) during the spin.
 
-    Le robot a des conventions de signe MIROIR gauche/droite : une pose
-    symétrique satisfait q_G + q_D ≈ 0 (cf. `leg_symmetry_reward`), donc le
-    ciseau satisfait q_G ≈ q_D. On retourne `gate(φ) · (−mean|q_G − q_D|)` — à
-    utiliser avec un poids POSITIF, décroissant par curriculum : l'amorce
-    s'efface pour laisser la policy affiner son propre geste.
+    The robot has MIRRORED left/right sign conventions: a symmetric pose
+    satisfies q_L + q_R ≈ 0 (cf. `leg_symmetry_reward`), so the scissor
+    satisfies q_L ≈ q_R. We return `gate(φ) · (−mean|q_L − q_R|)` — use with a
+    POSITIVE weight, decayed by curriculum: the priming fades away so the policy
+    can refine its own gesture.
     """
     asset: Entity = env.scene[asset_cfg.name]
     left, right = [], []
@@ -6805,7 +6803,7 @@ def reset_roulade_state(
 
     Standing bucket: upright (±standing_tilt_max pitch/roll noise), random yaw,
     HOME joints (left from reset_robot_joints), z in [standing_z_min, _max].
-    ``forward_vel_range`` is the élan hook: a per-env forward base velocity
+    ``forward_vel_range`` is the momentum hook: a per-env forward base velocity
     (body x, mapped to world through the spawn yaw) sampled uniformly — 0 for
     a standstill roll, widen it later to train rolls out of a walk.
 
@@ -6890,7 +6888,7 @@ def reset_roulade_state(
         )
         env.sim.data.qvel[mid_env_ids, 4] = _ROULADE_FWD_SIGN * omega
 
-    # Élan hook: forward base velocity for STANDING spawns, body x → world xy
+    # Momentum hook: forward base velocity for STANDING spawns, body x → world xy
     # through the spawn yaw. (0, 0) = standstill start, disabled.
     stand_env_ids = env_ids[~is_mid]
     if len(stand_env_ids) > 0 and forward_vel_range[1] > 0.0:

--- a/src/mjlab_microduck/tasks/mdp.py
+++ b/src/mjlab_microduck/tasks/mdp.py
@@ -1273,12 +1273,12 @@ def crouch_pose_blend(
     hold_end: float,
     rise_end: float,
 ) -> torch.Tensor:
-    """Blend 0..1 le long de la phase [0,1) — 0 = pose debout, 1 = pose accroupie.
+    """Blend 0..1 along the phase [0,1) — 0 = standing pose, 1 = crouched pose.
 
-    [0, descent_end)      : 0 -> 1  (se baisser)
-    [descent_end, hold_end): 1      (bas / accroupi)
-    [hold_end, rise_end)  : 1 -> 0  (se lever)
-    [rise_end, 1.0)       : 0       (haut / debout, repos)
+    [0, descent_end)      : 0 -> 1  (crouch down)
+    [descent_end, hold_end): 1      (low / crouched)
+    [hold_end, rise_end)  : 1 -> 0  (stand up)
+    [rise_end, 1.0)       : 0       (high / standing, rest)
     """
     b = torch.zeros_like(phase)
     descend = phase < descent_end
@@ -2577,12 +2577,12 @@ def phase_pose_blend(
     hold_end: float,
     rise_end: float,
 ) -> torch.Tensor:
-    """Blend 0..1 le long de la phase [0,1) — 0 = pose STAND, 1 = pose DOWN.
+    """Blend 0..1 along the phase [0,1) — 0 = STAND pose, 1 = DOWN pose.
 
-    [0, descent_end)       : 0 -> 1  (se baisser)
-    [descent_end, hold_end): 1       (bas)
-    [hold_end, rise_end)   : 1 -> 0  (se lever)
-    [rise_end, 1.0)        : 0       (haut / repos)
+    [0, descent_end)       : 0 -> 1  (go down)
+    [descent_end, hold_end): 1       (low)
+    [hold_end, rise_end)   : 1 -> 0  (rise)
+    [rise_end, 1.0)        : 0       (high / rest)
     """
     b = torch.zeros_like(phase)
     descend = phase < descent_end

--- a/src/mjlab_microduck/tasks/microduck_ball_kick_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_ball_kick_env_cfg.py
@@ -15,7 +15,7 @@ Key design decisions:
     function can anticipate the kick payoff.
   - No phase command: the kick reward is available from t=0 and an earlier
     kick collects more ball-rolling reward, so the policy kicks immediately.
-    At deployment: hard ONNX swap to this policy (à la jump/ground-pick), it
+    At deployment: hard ONNX swap to this policy (like jump/ground-pick), it
     kicks, then auto-swap back after ~2s.
   - Right-foot kick is enforced geometrically + economically: the ball spawns
     at the right toe, and an always-on LEFT-foot-grounded reward makes the

--- a/src/mjlab_microduck/tasks/microduck_ground_pick_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_ground_pick_env_cfg.py
@@ -6,9 +6,10 @@ returns to a clean standing pose — all while remaining stable and robust to
 pushes.  The obs/action spaces are identical to the walking policy so the two
 can be switched at runtime with a single key-press.
 
-Objectif espace-tâche (pas de pose DOWN) : mouth_ground_proximity tire la bouche
-vers le sol, head_impact_penalty (fort) interdit le contact -> équilibre = bouche
-juste au-dessus ; mouth_perpendicular_to_ground l'oriente vers le bas.
+Task-space objective (no DOWN pose): mouth_ground_proximity pulls the mouth
+toward the ground, head_impact_penalty (strong) forbids contact -> the
+equilibrium is the mouth just above it; mouth_perpendicular_to_ground orients it
+downward.
 
 Phase encoding (in the command slot, 3-D):
     command = [cos(2π·phase), sin(2π·phase), 0]
@@ -59,7 +60,7 @@ KD_RANDOMIZATION_RANGE           = (0.9, 1.1)
 JOINT_FRICTION_RANDOMIZATION_RANGE = (0.9, 1.1)
 ARMATURE_RANDOMIZATION_RANGE     = (0.9, 1.1)
 VELOCITY_PUSH_INTERVAL_S         = (3.0, 6.0)
-VELOCITY_PUSH_RANGE              = (-0.15, 0.15)  # geste quasi-statique -> pushes doux (±0.3 le faisait tomber même droit)
+VELOCITY_PUSH_RANGE              = (-0.15, 0.15)  # quasi-static gesture -> gentle pushes (±0.3 knocked it over even upright)
 IMU_ORIENTATION_RANDOMIZATION_ANGLE = 6.0       # match velocity (was 1.0)
 ENCODER_BIAS_RANGE               = (-0.015, 0.015)
 
@@ -93,18 +94,18 @@ from mjlab_microduck.tasks.microduck_velocity_env_cfg import (
 from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg, SYMMETRY_CFG
 
 
-# ── Profil de phase SEGMENTÉ (durées indépendantes) ──────────────────────────
-# Au lieu de la pondération sinusoïdale (qui couple descente/palier/remontée),
-# on gate les rewards par un profil à 4 segments : descente et remontée LENTES,
-# palier bas COURT, repos debout long.
-# Durées à GP_PERIOD = 4 s :
-#   descente   [0, DESCENT_END)        1.5 s  transition STAND->bas
-#   palier bas [DESCENT_END, HOLD_END) 0.2 s  effleure (court)
-#   remontée   [HOLD_END, RISE_END)    1.5 s  transition bas->STAND
-#   repos      [RISE_END, 1)           0.8 s  debout
-# ⚠️ RISE_END=0.80 > coupure φ=0.7 du script infer_policy : la remontée n'est
-# complète que si le slot joue jusqu'à φ~1.0 (toute la période). Vérifier la
-# fenêtre réelle du runtime.  ⚠️ --ground-pick-period au déploiement = 4.0.
+# ── SEGMENTED phase profile (independent durations) ─────────────────────────
+# Instead of the sinusoidal weighting (which couples descent/hold/rise), we gate
+# the rewards with a 4-segment profile: SLOW descent and rise, SHORT low hold,
+# long standing rest.
+# Durations at GP_PERIOD = 4 s:
+#   descent  [0, DESCENT_END)        1.5 s  STAND->low transition
+#   low hold [DESCENT_END, HOLD_END) 0.2 s  brief touch-close (short)
+#   rise     [HOLD_END, RISE_END)    1.5 s  low->STAND transition
+#   rest     [RISE_END, 1)           0.8 s  standing
+# ⚠️ RISE_END=0.80 > the infer_policy script's φ=0.7 cutoff: the rise is only
+# complete if the slot plays through to φ~1.0 (the whole period). Check the
+# runtime's actual window.  ⚠️ --ground-pick-period at deployment = 4.0.
 GP_PERIOD    = 4.0
 DESCENT_END  = 0.375
 HOLD_END     = 0.425
@@ -180,10 +181,10 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
     # ── Rewards: main ground pick objectives ──────────────────────────────────
 
     # Approach phase: reward mouth tip getting AS CLOSE AS POSSIBLE to the ground.
-    # target_height=0 tire la bouche vers le sol ; std=0.10 donne du gradient dès
-    # ~20 cm (depuis la station debout). Le "SANS TOUCHER" est assuré par
-    # head_impact_penalty (fort) plus bas -> l'équilibre est la bouche juste
-    # au-dessus du sol. Poids monté 2.0 -> 3.0 pour tirer plus près.
+    # target_height=0 pulls the mouth toward the ground; std=0.10 gives gradient
+    # from ~20 cm away (from the standing stance). "WITHOUT TOUCHING" is enforced
+    # by head_impact_penalty (strong) further down -> the equilibrium is the
+    # mouth just above the ground. Weight raised 2.0 -> 3.0 to pull it closer.
     cfg.rewards["mouth_ground_proximity"] = RewardTermCfg(
         func=microduck_mdp.mouth_ground_proximity_phased,
         weight=3.0,
@@ -200,8 +201,8 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
 
     # Approach phase: reward mouth tip x-axis pointing downward (perpendicular to ground).
     # alignment ∈ [-1, 1]: 1 = x-axis perfectly vertical, 0 = horizontal, -1 = pointing up.
-    # Orientation : axe bouche vers le bas (perpendiculaire au sol). Poids monté
-    # 1.0 -> 2.0 -> "orienter correctement" est un objectif explicite.
+    # Orientation: mouth axis pointing down (perpendicular to the ground). Weight
+    # raised 1.0 -> 2.0 -> "orient it correctly" is an explicit objective.
     cfg.rewards["mouth_perpendicular_to_ground"] = RewardTermCfg(
         func=microduck_mdp.mouth_perpendicular_phased,
         weight=2.0,
@@ -221,7 +222,7 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
     _LEG_JOINTS = [0, 1, 2, 3, 4, 9, 10, 11, 12, 13]
     cfg.rewards["ground_pick_return_pose_legs"] = RewardTermCfg(
         func=microduck_mdp.ground_pick_return_pose_phased,
-        weight=6.0,  # 4->6 : renforce l'extension des jambes au relever
+        weight=6.0,  # 4->6: strengthens leg extension during the rise
         params={
             "std": 0.3,
             "command_name": "twist",
@@ -247,14 +248,14 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
         },
     )
 
-    # Aide au RELEVER : tronc vertical récompensé UNIQUEMENT pendant la remontée
-    # (pondéré max(0,-sin) comme le retour de pose). Le retour de pose seul ne
-    # garantit pas l'équilibre dynamique en se relevant ; ce terme pousse le tronc
-    # à rester vertical pendant l'extension. Gaté sur le retour -> ne gêne PAS le
-    # penché avant de l'approche (upright always-on reste faible, 0.2).
+    # RISE assist: trunk uprightness rewarded ONLY during the rise (weighted by
+    # max(0,-sin) like the pose return). The pose return alone does not guarantee
+    # dynamic balance while standing back up; this term pushes the trunk to stay
+    # vertical during the extension. Gated on the return -> does NOT hinder the
+    # forward lean of the approach (the always-on upright stays low, 0.2).
     cfg.rewards["return_upright"] = RewardTermCfg(
         func=microduck_mdp.ground_pick_return_upright_phased,
-        weight=4.0,  # 2->4 : aide plus fort l'équilibre du tronc au relever
+        weight=4.0,  # 2->4: stronger help for trunk balance during the rise
         params={
             "asset_cfg": SceneEntityCfg("robot"),
             "std": 0.4,
@@ -264,9 +265,9 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
         },
     )
 
-    # Anti-piqué : pénalise la vitesse du cou pendant la descente+palier
-    # (gate=0 à la remontée -> ne bride PAS le relever). Freine le plongeon de
-    # la tête sans l'empêcher de revenir.
+    # Anti nose-dive: penalizes neck velocity during the descent+hold (gate=0 on
+    # the rise -> does NOT restrict standing back up). Damps the head's plunge
+    # without preventing it from coming back.
     cfg.rewards["neck_vel_descent"] = RewardTermCfg(
         func=microduck_mdp.neck_vel_descent_penalty,
         weight=-0.1,
@@ -277,10 +278,11 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
         },
     )
 
-    # Poids aléatoire "dans la bouche" au relever (objet soulevé, 10-40 g/épisode).
-    # Reward de poids 0 : sert de hook par-step qui applique le POIDS de l'objet
-    # comme force externe au mouth_tip, gaté sur la remontée (phase >= HOLD_END).
-    # Le payload lui-même est tiré au reset par l'event sample_mouth_payload.
+    # Random weight "in the mouth" during the rise (lifted object, 10-40 g per
+    # episode). Weight-0 reward: acts as a per-step hook that applies the object's
+    # WEIGHT as an external force at mouth_tip, gated on the rise (phase >=
+    # HOLD_END). The payload itself is drawn at reset by the sample_mouth_payload
+    # event.
     cfg.rewards["mouth_payload_force"] = RewardTermCfg(
         func=microduck_mdp.apply_mouth_payload_force,
         weight=0.0,
@@ -306,21 +308,21 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
 
     cfg.rewards["soft_landing"].weight = -1e-5
 
-    # Keep BOTH feet in contact throughout the pick (les pieds ne décollent pas).
-    # NB: c'est le CONTACT seulement ; la bascule du pied sur la cheville est gérée
-    # par feet_flat ci-dessous (pas par ce terme).
+    # Keep BOTH feet in contact throughout the pick (the feet do not lift off).
+    # NB: this is CONTACT only; the foot rolling over the ankle is handled by
+    # feet_flat below (not by this term).
     cfg.rewards["feet_grounded"] = RewardTermCfg(
         func=microduck_mdp.feet_grounded_reward,
         weight=3.0,
         params={"sensor_name": feet_ground_cfg.name},
     )
 
-    # Pieds À PLAT. feet_grounded ne voit que le CONTACT (found par pied) : un pied
-    # qui PIVOTE sur la cheville (bascule sur la tranche/pointe) en gardant un point
-    # de contact passe au travers -> "il se retourne le pied". feet_flat_penalty
-    # projette la gravité dans le repère du site pied : à plat le site Z est
-    # vertical (xy²≈0) ; toute bascule -> xy²>0. Interdit donc le retournement du
-    # pied sur l'axe cheville.
+    # FLAT feet. feet_grounded only sees CONTACT (found per foot): a foot that
+    # PIVOTS on the ankle (rolling onto its edge/toe) while keeping one contact
+    # point slips through -> "it rolls its foot over". feet_flat_penalty projects
+    # gravity into the foot site's frame: when flat, the site Z is vertical
+    # (xy²≈0); any roll -> xy²>0. It therefore forbids rolling the foot over the
+    # ankle axis.
     cfg.rewards["feet_flat"] = RewardTermCfg(
         func=microduck_mdp.feet_flat_penalty,
         weight=-2.0,
@@ -357,10 +359,10 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
         params={"sensor_name": self_collision_cfg.name},
     )
 
-    # No-touch enforcement : on ne VEUT PAS de contact (la bouche doit rester juste
-    # au-dessus). Pénalité forte et seuil bas -> tout contact au sol coûte cher.
-    # C'est ce terme qui, contre mouth_ground_proximity, fixe l'équilibre "au plus
-    # près sans toucher".
+    # No-touch enforcement: we do NOT want contact (the mouth must stay just
+    # above). Strong penalty and low threshold -> any ground contact is expensive.
+    # This is the term that, opposing mouth_ground_proximity, sets the "as close
+    # as possible without touching" equilibrium.
     cfg.rewards["head_impact_penalty"] = RewardTermCfg(
         func=microduck_mdp.body_impact_cost,
         weight=-2.0,
@@ -459,9 +461,9 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
     command: UniformVelocityCommandCfg = cfg.commands["twist"]
     command.rel_standing_envs = 0.0
     command.rel_heading_envs  = 0.0
-    # Période = GP_PERIOD (6 s). Le profil segmenté (constantes en tête de fichier)
-    # découple descente/palier/remontée/repos : descente & remontée ~1.5 s
-    # (lentes -> pas de déséquilibre), palier bas ~0.6 s (court), repos ~2.4 s.
+    # Period = GP_PERIOD (6 s). The segmented profile (constants at the top of the
+    # file) decouples descent/hold/rise/rest: descent & rise ~1.5 s (slow -> no
+    # loss of balance), low hold ~0.6 s (short), rest ~2.4 s.
     cfg.commands["twist"] = microduck_mdp.GroundPickPhaseCommandCfg(
         **{**vars(command), "class_type": microduck_mdp.GroundPickPhaseCommand, "period": GP_PERIOD}
     )
@@ -486,8 +488,9 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
         mode="reset",
     )
 
-    # Poids aléatoire "dans la bouche" : tiré par épisode (10-40 g), appliqué au
-    # relever par le hook mouth_payload_force. Imagine que le robot soulève un objet.
+    # Random weight "in the mouth": drawn per episode (10-40 g), applied during
+    # the rise by the mouth_payload_force hook. Emulates the robot lifting an
+    # object.
     cfg.events["sample_mouth_payload"] = EventTermCfg(
         func=microduck_mdp.sample_mouth_payload,
         mode="reset",
@@ -498,9 +501,9 @@ def make_microduck_ground_pick_env_cfg(play: bool = False, rough: bool = False) 
     cfg.events["reset_base"].params["pose_range"]["z"] = (0.12, 0.13)
 
     if ENABLE_VELOCITY_PUSHES:
-        # Play : intervalle espacé (2-4 s) pour juger le geste sur un comportement
-        # réaliste, pas sous mitraille (0.5-1 s était un stress-test agressif qui
-        # faisait "tomber même droit").
+        # Play: spaced-out interval (2-4 s) so the gesture is judged on realistic
+        # behavior, not under a barrage (0.5-1 s was an aggressive stress test
+        # that "knocked it over even upright").
         interval = (2.0, 4.0) if play else VELOCITY_PUSH_INTERVAL_S
         cfg.events["push_robot"] = EventTermCfg(
             func=mdp.push_by_setting_velocity,

--- a/src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 
 ENABLE_SYMMETRY = False
 
-# DR — repris du roller env
+# DR — taken from the roller env
 ENABLE_COM_RANDOMIZATION             = True
 ENABLE_HEAD_COM_RANDOMIZATION        = True
 ENABLE_MASS_INERTIA_RANDOMIZATION    = True

--- a/src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_roller_crouch_env_cfg.py
@@ -1,16 +1,16 @@
 """Microduck roller crouch-glide task.
 
-Geste one-shot déclenché au bouton A via le slot --ground-pick du runtime :
-le robot s'accroupit et glisse sur son élan (palier ~1 s), puis se relève et
-rend la main à la policy roller.
+One-shot gesture triggered by button A through the runtime's --ground-pick
+slot: the robot crouches and glides on its momentum (~1 s plateau), then stands
+back up and hands control back to the roller policy.
 
-Hybride :
-  - physique / robot roller  ← microduck_velocity_rollers_env_cfg.py
-  - machinerie phase one-shot ← microduck_ground_pick_env_cfg.py
-    (commande GroundPickPhaseCommand : [cos(2πφ), sin(2πφ), 0], période 4 s)
+Hybrid:
+  - roller physics / robot     ← microduck_velocity_rollers_env_cfg.py
+  - one-shot phase machinery   ← microduck_ground_pick_env_cfg.py
+    (GroundPickPhaseCommand: [cos(2πφ), sin(2πφ), 0], period 4 s)
 
-Cible de hauteur « en trapèze » (haut→bas→palier 1 s→haut) via
-crouch_glide_height_by_phase. Obs 61D unifié → interchangeable au runtime.
+Trapezoidal height target (high→low→1 s plateau→high) via
+crouch_glide_height_by_phase. Unified 61D obs → hot-swappable at runtime.
 """
 
 import math
@@ -39,29 +39,30 @@ VELOCITY_PUSH_RANGE              = (-0.2, 0.2)
 IMU_ORIENTATION_RANDOMIZATION_ANGLE = 6.0
 ENCODER_BIAS_RANGE               = (-0.015, 0.015)
 
-ENTRY_VELOCITY_X   = (0.2, 0.5)  # m/s : le robot arrive en roulant
+ENTRY_VELOCITY_X   = (0.2, 0.5)  # m/s: the robot arrives already rolling
 
-# Timing du cycle (phase), 4 segments sur une période de 5 s :
-#   descente     [0, DESCENT_END]        = 0.10*5 = 0.5 s  (se baisser)
-#   bas/accroupi [DESCENT_END, HOLD_END] = 0.40*5 = 2.0 s  (glisse accroupie)
-#   remontée     [HOLD_END, RISE_END]    = 0.10*5 = 0.5 s  (se lever)
-#   haut/debout  [RISE_END, 1.0]         = 0.40*5 = 2.0 s  (repos debout)
-# NB: la période DOIT matcher --ground-pick-period au déploiement (5.0).
+# Cycle timing (phase), 4 segments over a 5 s period:
+#   descent      [0, DESCENT_END]        = 0.10*5 = 0.5 s  (crouch down)
+#   low/crouched [DESCENT_END, HOLD_END] = 0.40*5 = 2.0 s  (crouched glide)
+#   rise         [HOLD_END, RISE_END]    = 0.10*5 = 0.5 s  (stand up)
+#   high/standing[RISE_END, 1.0]         = 0.40*5 = 2.0 s  (standing rest)
+# NB: the period MUST match --ground-pick-period at deployment (5.0).
 CROUCH_PERIOD = 5.0
 DESCENT_END   = 0.10
 HOLD_END      = 0.50
 RISE_END      = 0.60
 
-# Pose ACCROUPI cible (rad, par NOM d'articulation) — composée dans
-# scripts/crouch_pose_editor.py. La reward interpole DEBOUT(HOME) <-> cette pose
-# selon la phase. Résolution par nom -> robuste aux roues intercalées.
-# Pose DEBOUT (départ/fin du trick). Défaut = HOME du sim (convention validée
-# égale à la lecture robot). Remplace ces valeurs par une lecture read_pose.py
-# du robot debout si tu veux une autre station debout.
-# ⚠️ au déploiement, à la fin du trick le runtime rend la main à la policy roller
-# qui repart de HOME — garde STAND_POSE proche de HOME pour un retour propre.
+# Target CROUCH pose (rad, by joint NAME) — composed in
+# scripts/crouch_pose_editor.py. The reward interpolates STANDING(HOME) <-> this
+# pose along the phase. Name-based resolution -> robust to interleaved wheels.
+# STANDING pose (start/end of the trick). Default = the sim's HOME (a convention
+# verified to match the robot reading). Replace these values with a read_pose.py
+# reading of the standing robot if you want a different standing stance.
+# ⚠️ at deployment, at the end of the trick the runtime hands control back to the
+# roller policy, which starts from HOME — keep STAND_POSE close to HOME for a
+# clean handover.
 STAND_POSE = {
-    # Lue sur le VRAI robot (read_pose.py) — station debout voulue pour le trick.
+    # Read off the REAL robot (read_pose.py) — the standing stance wanted for the trick.
     "left_hip_yaw": -0.0476, "left_hip_roll": -0.0629, "left_hip_pitch": -0.2869,
     "left_knee": 0.9618, "left_ankle": 1.1674,
     "neck_pitch": 0.6029, "head_pitch": 0.543, "head_yaw": -0.069, "head_roll": -0.0414,
@@ -70,7 +71,7 @@ STAND_POSE = {
 }
 
 CROUCH_POSE = {
-    # Lue sur le VRAI robot (Dynamixel XL330, read_pose.py) — pose tenable.
+    # Read off the REAL robot (Dynamixel XL330, read_pose.py) — a holdable pose.
     "left_hip_yaw": -0.0184,
     "left_hip_roll": 0.0307,
     "left_hip_pitch": 1.4082,
@@ -86,8 +87,8 @@ CROUCH_POSE = {
     "right_knee": -1.5907,
     "right_ankle": 0.0568,
 }
-CROUCH_POSE_STD = 0.4  # tolérance gaussienne par joint (rad)
-CROUCH_LEAN_PITCH = 0.08  # léger penché avant pendant l'accroupi (rad ≈ 4.6°)
+CROUCH_POSE_STD = 0.4  # per-joint gaussian tolerance (rad)
+CROUCH_LEAN_PITCH = 0.08  # slight forward lean during the crouch (rad ≈ 4.6°)
 
 from mjlab.envs import ManagerBasedRlEnvCfg
 from mjlab.envs.mdp import dr
@@ -114,7 +115,7 @@ from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg, SYMMETRY_CFG
 
 
 def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
-    """Env crouch-glide sur rollers, piloté par la phase du slot ground-pick."""
+    """Crouch-glide-on-rollers env, driven by the ground-pick slot's phase."""
 
     feet_ground_cfg = ContactSensorCfg(
         name="feet_ground_contact",
@@ -160,10 +161,10 @@ def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEn
     cfg.rewards["angular_momentum"].weight = -0.02
     cfg.rewards["action_rate_l2"].weight = -1.0
 
-    # Reward principale : POSE interpolée par la phase (DEBOUT <-> ACCROUPI).
-    # Directive : dit au robot la configuration articulaire exacte à chaque
-    # instant. « Se relever » (phase->1, cible = HOME) est récompensé EXACTEMENT
-    # comme « s'accroupir » (palier, cible = CROUCH_POSE) — symétrique.
+    # Main reward: phase-interpolated POSE (STANDING <-> CROUCHED).
+    # Directive: it tells the robot the exact joint configuration at every
+    # instant. "Standing back up" (phase->1, target = HOME) is rewarded EXACTLY
+    # like "crouching down" (plateau, target = CROUCH_POSE) — symmetric.
     _pose_params = {
         "command_name": "twist",
         "crouch_pose": CROUCH_POSE,
@@ -177,21 +178,21 @@ def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEn
         weight=6.0,
         params={**_pose_params, "std": CROUCH_POSE_STD},
     )
-    # Bootstrap L1 : gradient constant vers la cible même quand la gaussienne
-    # sature loin de la pose.
+    # L1 bootstrap: constant gradient toward the target even when the gaussian
+    # saturates far from the pose.
     cfg.rewards["crouch_glide_pose_l1"] = RewardTermCfg(
         func=microduck_mdp.crouch_glide_pose_l1,
         weight=2.0,
         params=_pose_params,
     )
-    # Conserver l'élan (ne pas freiner) — indépendant de la commande.
+    # Preserve the momentum (do not brake) — independent of the command.
     cfg.rewards["forward_speed"] = RewardTermCfg(
         func=microduck_mdp.forward_speed_reward,
         weight=1.0,
         params={"vel_ref": 0.2},
     )
-    # Léger penché avant pendant l'accroupi -> contre la bascule arrière observée
-    # sur le vrai robot lors de la descente rapide. Gaté par le blend (crouch only).
+    # Slight forward lean during the crouch -> counters the backward tip observed
+    # on the real robot during the fast descent. Gated by the blend (crouch only).
     cfg.rewards["crouch_forward_lean"] = RewardTermCfg(
         func=microduck_mdp.crouch_forward_lean,
         weight=1.0,
@@ -204,7 +205,7 @@ def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEn
             "rise_end": RISE_END,
         },
     )
-    # Stabilité de glisse
+    # Glide stability
     cfg.rewards["feet_flat"] = RewardTermCfg(
         func=microduck_mdp.feet_flat_penalty,
         weight=-2.0,
@@ -248,11 +249,11 @@ def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEn
         )
 
     cfg.events["reset_base"].params["pose_range"]["z"] = (0.1335, 0.1435)
-    # Vitesse d'entrée : le robot démarre en roulant vers l'avant (élan à conserver
-    # pendant l'accroupi). Injectée via reset_root_state_uniform (état par défaut
-    # PROPRE + range), et NON via push_by_setting_velocity en mode reset qui, lui,
-    # additionne à la vitesse racine courante (potentiellement divergente) et fait
-    # exploser le free-joint de la base -> NaN. Voir le commentaire ENTRY_VELOCITY_X.
+    # Entry velocity: the robot starts rolling forward (momentum to preserve
+    # during the crouch). Injected through reset_root_state_uniform (CLEAN default
+    # state + range), and NOT through push_by_setting_velocity in reset mode,
+    # which adds to the current root velocity (potentially divergent) and blows up
+    # the base free joint -> NaN. See the ENTRY_VELOCITY_X comment.
     cfg.events["reset_base"].params["velocity_range"] = {"x": ENTRY_VELOCITY_X}
 
     if ENABLE_WHEEL_FRICTION_RANDOMIZATION:
@@ -378,13 +379,13 @@ def make_microduck_roller_crouch_env_cfg(play: bool = False) -> ManagerBasedRlEn
             func=microduck_mdp.zero_command_padding, params={"dim": 6},
         )
 
-    # === COMMAND: phase (comme ground_pick) ===
+    # === COMMAND: phase (like ground_pick) ===
     command: UniformVelocityCommandCfg = cfg.commands["twist"]
     command.rel_standing_envs = 0.0
     command.rel_heading_envs = 0.0
-    # period=CROUCH_PERIOD (descente plus lente) ; randomize_phase=False -> chaque
-    # épisode démarre debout (phase 0), comme au déploiement (le bouton lance le
-    # cycle à phase 0). Évite d'apprendre "reste bas" depuis des départs déjà bas.
+    # period=CROUCH_PERIOD (slower descent); randomize_phase=False -> every
+    # episode starts standing (phase 0), like at deployment (the button starts the
+    # cycle at phase 0). Avoids learning "stay low" from already-low starts.
     cfg.commands["twist"] = microduck_mdp.GroundPickPhaseCommandCfg(
         **{
             **vars(command),

--- a/src/mjlab_microduck/tasks/microduck_roller_slope_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_roller_slope_env_cfg.py
@@ -1,11 +1,11 @@
-"""Microduck roller slope — descente passive équilibrée.
+"""Microduck roller slope — balanced passive descent.
 
-Le robot spawne sur du plat (impulsion vers l'avant), roule sur une rampe
-descendante et se laisse glisser en restant debout. Aucun pilotage : la
-commande twist est neutralisée (rel_standing_envs=1.0). Terrain custom
-plat+rampe (FlatRampTerrainCfg), curriculum de raideur (terrain_levels_slope).
-Obs 61D unifié → interchangeable au runtime (--new-cmd-obs) — hérité tel quel
-de make_microduck_velocity_rollers_env_cfg (DR/obs/reset non touchés ici).
+The robot spawns on the flat section (with a forward impulse), rolls onto a
+downhill ramp and lets itself glide while staying upright. No steering: the
+twist command is neutralized (rel_standing_envs=1.0). Custom flat+ramp terrain
+(FlatRampTerrainCfg), steepness curriculum (terrain_levels_slope). Unified 61D
+obs → hot-swappable at runtime (--new-cmd-obs) — inherited as-is from
+make_microduck_velocity_rollers_env_cfg (DR/obs/reset untouched here).
 """
 
 import math
@@ -26,24 +26,24 @@ from mjlab_microduck.tasks.microduck_velocity_rollers_env_cfg import (
 )
 from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg
 
-# Géométrie du terrain plat+rampe+sortie.
+# Geometry of the flat + ramp + runout terrain.
 FLAT_LENGTH        = 2.0
-RAMP_LENGTH_RANGE  = (3.0, 8.0)   # longueur horizontale de la rampe, tirée au hasard par tuile
-RUNOUT_LENGTH      = 4.0          # plat de sortie en bas
-SPAWN_ON_RAMP      = 0.3          # spawn ce nb de m sur la rampe (gravité -> roulement, pas de patinage)
-ENTRY_VELOCITY_X   = (0.25, 0.45) # petit élan initial vers l'avant/descente (m/s)
-TILE_SIZE          = (15.0, 4.0)  # >= flat + ramp_max + runout (= 14) + marge
-SPAWN_YAW          = (0.0, 0.0)   # face à la descente (+x), fixe
+RAMP_LENGTH_RANGE  = (3.0, 8.0)   # horizontal ramp length, drawn at random per tile
+RUNOUT_LENGTH      = 4.0          # flat runout at the bottom
+SPAWN_ON_RAMP      = 0.3          # spawn this many m onto the ramp (gravity -> rolling, no skidding)
+ENTRY_VELOCITY_X   = (0.25, 0.45) # small initial forward/downhill momentum (m/s)
+TILE_SIZE          = (15.0, 4.0)  # >= flat + ramp_max + runout (= 14) + margin
+SPAWN_YAW          = (0.0, 0.0)   # facing downhill (+x), fixed
 
-# Raideur au PLAY : None = aléatoire (comme à l'entraînement). Mettre une valeur
-# 0..1 pour forcer une pente précise (1.0 = la plus raide ~20°, 0.5 = moyenne).
-# Surchargeable sans éditer le code via la variable d'env SLOPE_PLAY_DIFFICULTY
-# (ex: SLOPE_PLAY_DIFFICULTY=1.0 uv run play ... ; "none"/"random" = aléatoire).
+# Steepness at PLAY time: None = random (as during training). Set a value in
+# 0..1 to force a specific slope (1.0 = steepest ~20°, 0.5 = medium).
+# Overridable without editing the code through the SLOPE_PLAY_DIFFICULTY env var
+# (e.g. SLOPE_PLAY_DIFFICULTY=1.0 uv run play ... ; "none"/"random" = random).
 PLAY_DIFFICULTY    = None
 
 
 def _resolve_play_difficulty():
-    """Difficulté de play : env SLOPE_PLAY_DIFFICULTY sinon la constante."""
+    """Play difficulty: env SLOPE_PLAY_DIFFICULTY, else the constant."""
     raw = os.environ.get("SLOPE_PLAY_DIFFICULTY")
     if raw is None:
         return PLAY_DIFFICULTY
@@ -53,12 +53,12 @@ def _resolve_play_difficulty():
     try:
         return max(0.0, min(1.0, float(raw)))
     except ValueError:
-        print(f"[roller_slope] SLOPE_PLAY_DIFFICULTY='{raw}' invalide -> défaut {PLAY_DIFFICULTY}")
+        print(f"[roller_slope] SLOPE_PLAY_DIFFICULTY='{raw}' invalid -> default {PLAY_DIFFICULTY}")
         return PLAY_DIFFICULTY
 
-# Terminaison « tombé dans le vide » : sous le plat de sortie le plus bas
-# (rampe la plus raide et la plus longue), avec marge => ne se déclenche jamais
-# pendant une descente normale, seulement si le robot quitte le solide.
+# "Fell into the void" termination: below the lowest runout (steepest and
+# longest ramp), with margin => never fires during a normal descent, only if the
+# robot leaves the solid.
 _MAX_DROP  = RAMP_LENGTH_RANGE[1] * math.tan(math.radians(RAMP_DEG_MAX))
 VOID_FLOOR = -_MAX_DROP - 0.5
 
@@ -66,13 +66,13 @@ VOID_FLOOR = -_MAX_DROP - 0.5
 def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
     cfg = make_microduck_velocity_rollers_env_cfg(play=play)
 
-    # === TERRAIN : plat + rampe (longueur aléatoire) + plat de sortie ===
+    # === TERRAIN: flat + ramp (random length) + flat runout ===
     cfg.scene.terrain = TerrainEntityCfg(
         terrain_type="generator",
         terrain_generator=TerrainGeneratorCfg(
             size=TILE_SIZE,
             curriculum=True,
-            num_rows=10,          # 10 niveaux de raideur
+            num_rows=10,          # 10 steepness levels
             num_cols=1,
             difficulty_range=(0.0, 1.0),
             sub_terrains={
@@ -84,12 +84,12 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
                 )
             },
         ),
-        max_init_terrain_level=0,  # curriculum : démarrer sur la rampe la plus douce
+        max_init_terrain_level=0,  # curriculum: start on the gentlest ramp
     )
 
-    # Au play : montrer des pentes variées. difficulté None -> raideurs aléatoires
-    # (niveau tiré sur toutes les rangées) ; une valeur 0..1 force une raideur
-    # précise (1.0 = la plus raide). Pilotable via SLOPE_PLAY_DIFFICULTY.
+    # At play time: show a variety of slopes. difficulty None -> random
+    # steepness (level drawn across all rows); a value in 0..1 forces a specific
+    # steepness (1.0 = the steepest). Controlled via SLOPE_PLAY_DIFFICULTY.
     if play:
         play_difficulty = _resolve_play_difficulty()
         if play_difficulty is not None:
@@ -97,7 +97,7 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
         else:
             cfg.scene.terrain.max_init_terrain_level = None
 
-    # === COMMANDE neutralisée (équilibre pur) ===
+    # === Neutralized COMMAND (pure balance) ===
     command = cfg.commands["twist"]
     command.rel_standing_envs = 1.0
     command.rel_heading_envs = 0.0
@@ -106,24 +106,24 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
     if getattr(command.ranges, "ang_vel_z", None) is not None:
         command.ranges.ang_vel_z = (0.0, 0.0)
 
-    # === RESET : toujours face à la descente (+x), PAS de poussée de base ===
-    # Le yaw hérité est aléatoire (-180°/+180°) -> on le fixe à 0 (face au bas de
-    # la pente). Aucune vitesse de base injectée : le robot spawne sur la rampe
-    # (voir spawn_on_ramp), la gravité fait rouler les roues (élan aux roues,
-    # sans glissement). L'ancienne poussée de base (base rapide, roues immobiles)
-    # patinait -> pic de contact -> divergence NaN, et le robot "marchait pour
-    # s'arrêter" au lieu de rouler.
+    # === RESET: always facing downhill (+x), NO base push ===
+    # The inherited yaw is random (-180°/+180°) -> we fix it at 0 (facing the
+    # bottom of the slope). No base velocity injected: the robot spawns on the
+    # ramp (see spawn_on_ramp) and gravity spins the wheels (momentum in the
+    # wheels, no slip). The old base push (fast base, stationary wheels) skidded
+    # -> contact spike -> NaN divergence, and the robot "walked to a stop"
+    # instead of rolling.
     cfg.events["reset_base"].params["pose_range"]["yaw"] = SPAWN_YAW
-    # PAS de poussée de base ici (base qui bouge + roues immobiles = à-coup de
-    # patinage au 1er pas). L'élan initial est donné en ROULEMENT cohérent
-    # (base + roues, ω·r = v) par reset_rolling_entry ci-dessous -> départ propre.
+    # NO base push here (moving base + stationary wheels = skidding jolt on the
+    # first step). The initial momentum is given as consistent ROLLING (base +
+    # wheels, ω·r = v) by reset_rolling_entry below -> clean start.
     cfg.events["reset_base"].params["velocity_range"] = {}
 
-    # === RÉCOMPENSES : équilibre LIBRE (il place son centre de gravité lui-même) ===
-    # PAS de récompense de pose fixe : on ne lui dicte plus la posture debout du
-    # plat (qui l'empêchait de fléchir/pencher). Il est libre de bouger son CoM
-    # (hanches/genoux, inclinaison) pour tenir la pente. On récompense juste :
-    # rester debout, vivre, glisser, aller droit — et ne pas tomber (terminaisons).
+    # === REWARDS: FREE balance (it places its own center of gravity) ===
+    # NO fixed pose reward: we no longer dictate the flat-ground standing posture
+    # (which prevented it from flexing/leaning). It is free to move its CoM
+    # (hips/knees, lean) to hold the slope. We only reward: staying upright,
+    # being alive, gliding, going straight — and not falling (terminations).
     keep = {"action_rate_l2"}
     for name in list(cfg.rewards.keys()):
         if name not in keep:
@@ -135,17 +135,17 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
         params={"asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)), "std": 0.2},
     )
     cfg.rewards["alive"] = RewardTermCfg(func=microduck_mdp.is_alive, weight=1.0)
-    # Se LAISSER GLISSER (rouler), PAS accélérer/courir : récompense le ROULEMENT
-    # des roues vers le bas, plafonné à cap_speed. Plafonné => pas d'incitation à
-    # pousser plus vite ; basé sur les roues => "courir" (pousser la base sans
-    # rouler) ne rapporte pas. Sans récompense de glisse, l'optimum serait de
-    # rester immobile ; avec, il se laisse rouler tant qu'il tient l'équilibre.
+    # LET IT GLIDE (roll), do NOT accelerate/run: rewards downhill WHEEL ROLLING,
+    # capped at cap_speed. Capped => no incentive to push faster; wheel-based =>
+    # "running" (pushing the base without rolling) pays nothing. Without a glide
+    # reward the optimum would be to stand still; with it, the robot lets itself
+    # roll as long as it can hold its balance.
     cfg.rewards["wheel_glide"] = RewardTermCfg(
         func=microduck_mdp.wheel_glide_reward, weight=2.0, params={"cap_speed": 0.35},
     )
-    # ALLER DROIT : maintenir le yaw de spawn (= 0 = face à la descente). Corrigeant
-    # (le robot peut se rattraper), c'est la bonne façon d'aller tout droit. NB: la
-    # symétrie PPO (SYMMETRY_CFG) est codée pour l'ancien obs 51D -> inutilisable ici.
+    # GO STRAIGHT: hold the spawn yaw (= 0 = facing downhill). Being corrective
+    # (the robot can recover), this is the right way to go straight. NB: the PPO
+    # symmetry (SYMMETRY_CFG) is coded for the old 51D obs -> unusable here.
     cfg.rewards["heading_hold"] = RewardTermCfg(
         func=microduck_mdp.heading_hold_reward, weight=1.5, params={"std": 0.4},
     )
@@ -160,10 +160,10 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
     cfg.rewards["neck_action_rate_l2"] = RewardTermCfg(
         func=microduck_mdp.neck_action_rate_l2, weight=-0.5,
     )
-    # GARDER LA TÊTE DROITE : pénalise la déviation des joints cou/tête par rapport
-    # à la position home. On a retiré la pose fixe des JAMBES (pour l'équilibre
-    # libre), mais rien ne tenait la tête -> elle partait n'importe où. Ceci ne
-    # contraint QUE la tête/cou, pas les jambes.
+    # KEEP THE HEAD UPRIGHT: penalizes neck/head joint deviation from the home
+    # position. We removed the fixed LEG pose (for free balance), but nothing was
+    # holding the head -> it drifted anywhere. This constrains the head/neck
+    # ONLY, not the legs.
     cfg.rewards["neck_joint_pos_l2"] = RewardTermCfg(
         func=microduck_mdp.neck_joint_pos_l2, weight=-0.75,
     )
@@ -172,11 +172,11 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
     )
     cfg.rewards["action_rate_l2"].weight = -1.0
 
-    # === TERMINATIONS : chute + tombé dans le vide ===
-    # Le plat de sortie donne du solide au bas de la rampe, donc plus besoin de
-    # terminer « au bord » (terrain_edge_reached coupait trop tôt les rampes
-    # longues). On garde : chute (bad_orientation), NaN, et « tombé dans le vide »
-    # (trunk sous le plat de sortie le plus bas) au cas où le robot quitte le solide.
+    # === TERMINATIONS: fall + fell into the void ===
+    # The runout provides solid ground at the bottom of the ramp, so terminating
+    # "at the edge" is no longer needed (terrain_edge_reached cut long ramps off
+    # too early). We keep: fall (bad_orientation), NaN, and "fell into the void"
+    # (trunk below the lowest runout) in case the robot leaves the solid.
     cfg.terminations["fell_over"] = TerminationTermCfg(
         func=base_mdp.bad_orientation,
         params={"limit_angle": 1.0, "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",))},
@@ -191,12 +191,13 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
         func=microduck_mdp.robot_state_is_nan, time_out=False,
     )
 
-    # === OBS : assainir les NaN/Inf (robustesse aux divergences de contact rares) ===
-    # Un contact rare (~1/25M pas-env) fait diverger le free-joint en NaN. À cause
-    # du décalage d'un sous-pas, la terminaison nan_state ne l'attrape qu'AU PAS
-    # SUIVANT (reset), mais le NaN atteint déjà l'obs du pas courant -> check_nan de
-    # rsl_rl tue l'entraînement. nan_policy="sanitize" remplace NaN/Inf par 0 dans
-    # l'obs renvoyée (pas de crash) ; nan_state reset ensuite l'env fautif.
+    # === OBS: sanitize NaN/Inf (robustness to rare contact divergences) ===
+    # A rare contact (~1 in 25M env-steps) makes the free joint diverge to NaN.
+    # Because of a one-substep offset, the nan_state termination only catches it
+    # on the NEXT STEP (reset), but the NaN already reaches the current step's obs
+    # -> rsl_rl's check_nan kills training. nan_policy="sanitize" replaces NaN/Inf
+    # with 0 in the returned obs (no crash); nan_state then resets the offending
+    # env.
     for grp in ("actor", "critic"):
         cfg.observations[grp].nan_policy = "sanitize"
 
@@ -204,18 +205,18 @@ def make_microduck_roller_slope_env_cfg(play: bool = False) -> ManagerBasedRlEnv
     cfg.events["reset_action_history"] = EventTermCfg(
         func=microduck_mdp.reset_action_history, mode="reset",
     )
-    # Départ en roulement (élan aux roues, sans patinage). APRÈS reset_base.
+    # Rolling start (momentum in the wheels, no skidding). AFTER reset_base.
     cfg.events["reset_rolling_entry"] = EventTermCfg(
         func=microduck_mdp.reset_rolling_entry, mode="reset",
         params={"speed_range": ENTRY_VELOCITY_X},
     )
 
-    # === CURRICULUM : raideur doux -> raide ===
-    # Démarre sur la pente la plus douce (2°) et promeut vers plus raide (jusqu'à
-    # 20°) quand le robot a descendu assez loin (terrain_levels_slope, basé sur la
-    # distance parcourue). Viable maintenant que descent_speed le fait AVANCER
-    # (avant il restait immobile -> jamais promu). Il apprend l'équilibre
-    # progressivement au lieu d'être jeté d'emblée sur du 20° (où il pique du nez).
+    # === CURRICULUM: steepness gentle -> steep ===
+    # Starts on the gentlest slope (2°) and promotes to steeper ones (up to 20°)
+    # once the robot has descended far enough (terrain_levels_slope, based on the
+    # distance travelled). Viable now that descent_speed makes it MOVE (before it
+    # stood still -> never promoted). It learns balance progressively instead of
+    # being thrown straight onto 20° (where it nose-dives).
     for name in list(cfg.curriculum.keys()):
         del cfg.curriculum[name]
     cfg.curriculum["terrain_levels"] = CurriculumTermCfg(func=microduck_mdp.terrain_levels_slope)

--- a/src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py
@@ -1,32 +1,30 @@
-"""Microduck roller standup — se relever sur rollers.
+"""Microduck roller standup — standing up on rollers.
 
-Policy DÉDIÉE épisodique : le robot démarre au sol (à plat ventre, à plat dos) ou
-déjà debout, et doit se remettre debout sur ses rollers puis TENIR la station.
-Portage de la recette `standup` (canard marcheur) vers le modèle rollers.
+DEDICATED episodic policy: the robot starts on the ground (face down, face up)
+or already standing, and must get back up on its rollers and then HOLD the
+stance. Port of the `standup` recipe (walking duck) to the roller model.
 
-Dérive de l'env roller (`make_microduck_velocity_rollers_env_cfg`) → hérite tel
-quel le robot rollers, les capteurs, toute la DR et l'observation 61D, donc
-interchangeable au runtime (--new-cmd-obs). C'est le pattern de roller_slope.
+Derives from the roller env (`make_microduck_velocity_rollers_env_cfg`) → inherits
+the roller robot, the sensors, the whole DR stack and the 61D observation as-is,
+so it is hot-swappable at runtime (--new-cmd-obs). Same pattern as roller_slope.
 
-Deux différences structurelles avec `standup` :
-  - les roues passives sont INTERCALÉES dans l'ordre des joints → indices
-    remappés (_LEG_JOINTS ci-dessous), verrouillés par
-    tests/test_roller_standup_cfg.py ;
-  - pas de commande head_pose : les slots head/body restent zero-paddés
-    (convention de la famille roller) et la tête est tenue droite par
-    neck_joint_pos_l2, qui résout par NOM.
+Two structural differences from `standup`:
+  - the passive wheels are INTERLEAVED in the joint ordering → remapped indices
+    (_LEG_JOINTS below), locked in by tests/test_roller_standup_cfg.py;
+  - no head_pose command: the head/body slots stay zero-padded (roller family
+    convention) and the head is held upright by neck_joint_pos_l2, which
+    resolves by NAME.
 
-La pièce nouvelle est le curriculum de friction de roulement, INVERSÉ (roues
-freinées → libres) : les roues roulent, donc il n'y a aucune adhérence pour
-pousser sur le sol. On bootstrappe avec des roues quasi bloquées puis on rampe
-vers la vraie valeur. Si `standing_composite` s'écroule à un palier, le geste
-« pieds adhérents » ne transfère pas et il faudra guider une technique de
-patineur (appui genou, un patin à la fois).
+The genuinely new piece is the rolling-friction curriculum, REVERSED (braked
+wheels → free wheels): the wheels roll, so there is no traction at all to push
+against the ground. We bootstrap with near-locked wheels and then ramp toward
+the real value. If `standing_composite` collapses at a stage, the "sticky feet"
+gesture does not transfer and we will have to guide a skater technique (knee
+support, one skate at a time).
 
-Déploiement visé : en `--standing` face à la policy roller en `--walking`, avec
-la bascule automatique sur la magnitude de la commande de vitesse
-(infer_policy.py:262, seuil 0.05) ; le slot twist y est laissé à zéro
-(infer_policy.py:239).
+Intended deployment: in `--standing` alongside the roller policy in `--walking`,
+with the automatic switch on velocity command magnitude (infer_policy.py:262,
+threshold 0.05); the twist slot is left at zero there (infer_policy.py:239).
 """
 
 import math
@@ -47,38 +45,39 @@ from mjlab_microduck.tasks.microduck_velocity_rollers_env_cfg import (
 )
 from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg
 
-# ── Hauteurs de tronc (m) ─────────────────────────────────────────────────────
-# Mesurées par cinématique exacte (minimum des sommets de maillage des géoms
-# collidantes, pose STAND, tronc ramené au contact) sur scene_rollers.xml :
-# debout 0.1407, repos à plat ventre 0.0752, repos à plat dos 0.0475.
-# Contrôle : le modèle SANS roues donne 0.1172 en cinématique contre STAND_Z=0.115
-# mesuré sous charge par standup → ~2 mm d'affaissement, appliqué ici aussi.
-# 0.138 tombe dans le reset_base z (0.1335–0.1435) déjà utilisé par l'env roller.
+# ── Trunk heights (m) ─────────────────────────────────────────────────────────
+# Measured by exact kinematics (minimum over the mesh vertices of the colliding
+# geoms, STAND pose, trunk lowered to contact) on scene_rollers.xml:
+# standing 0.1407, face-down rest 0.0752, face-up rest 0.0475.
+# Cross-check: the model WITHOUT wheels gives 0.1172 kinematically against
+# STAND_Z=0.115 measured under load by standup → ~2 mm of sag, applied here too.
+# 0.138 falls inside the reset_base z range (0.1335–0.1435) already used by the
+# roller env.
 ROLLER_STAND_Z = 0.138
 ROLLER_PRONE_Z = 0.075
 
-EPISODE_LENGTH_S  = 6.0   # monter + stabiliser, comme standup
+EPISODE_LENGTH_S  = 6.0   # rise + stabilize, same as standup
 NUM_STEPS_PER_ENV = 24
 
-# ── Override de play : forcer la proportion de départs SUR LE DOS ─────────────
-# Au play, l'env est reconstruit à neuf : common_step_counter repart à 0, donc le
-# curriculum ground_state_mix applique son palier 0, où face_up_prob = 0. On ne
-# voit donc JAMAIS de départ sur le dos au play — or c'est le cas le plus dur,
-# celui qu'on veut inspecter à l'œil. Cette variable le force.
-#   STANDUP_PLAY_FACE_UP=1.0  -> 100 % de départs sur le dos
-#   STANDUP_PLAY_FACE_UP=0.4  -> le mélange du dernier palier du curriculum
-#   non définie / "none" / "random" -> comportement par défaut (palier 0)
-# N'a d'effet QUE sur play=True. Même motif que SLOPE_PLAY_DIFFICULTY dans
+# ── Play override: force the share of FACE-UP starts ──────────────────────────
+# At play time the env is rebuilt from scratch: common_step_counter restarts at
+# 0, so the ground_state_mix curriculum applies its stage 0, where face_up_prob
+# = 0. We therefore NEVER see a face-up start at play — yet that is the hardest
+# case, the one we want to eyeball. This variable forces it.
+#   STANDUP_PLAY_FACE_UP=1.0  -> 100% face-up starts
+#   STANDUP_PLAY_FACE_UP=0.4  -> the mix of the curriculum's last stage
+#   unset / "none" / "random" -> default behavior (stage 0)
+# Has an effect ONLY when play=True. Same pattern as SLOPE_PLAY_DIFFICULTY in
 # roller_slope.
 PLAY_FACE_UP = None
-# Rapport ventre:debout du DERNIER palier du curriculum (0.40 / 0.20 = 2:1). Le
-# reste (1 - face_up) est réparti dans ce rapport, si bien que 0.4 reproduit
-# exactement le mélange de fin d'entraînement.
+# Face-down:standing ratio of the curriculum's LAST stage (0.40 / 0.20 = 2:1).
+# The remainder (1 - face_up) is split in that ratio, so 0.4 reproduces the
+# end-of-training mix exactly.
 _PLAY_FACE_DOWN_SHARE = 2.0 / 3.0
 
 
 def _resolve_play_face_up():
-    """Proportion de départs sur le dos au play : env STANDUP_PLAY_FACE_UP sinon la constante."""
+    """Share of face-up starts at play: env STANDUP_PLAY_FACE_UP, else the constant."""
     raw = os.environ.get("STANDUP_PLAY_FACE_UP")
     if raw is None:
         return PLAY_FACE_UP
@@ -88,33 +87,33 @@ def _resolve_play_face_up():
     try:
         return max(0.0, min(1.0, float(raw)))
     except ValueError:
-        print(f"[roller_standup] STANDUP_PLAY_FACE_UP='{raw}' invalide -> défaut {PLAY_FACE_UP}")
+        print(f"[roller_standup] STANDUP_PLAY_FACE_UP='{raw}' invalid -> default {PLAY_FACE_UP}")
         return PLAY_FACE_UP
 
-# ── Indices de joints — les roues passives sont INTERCALÉES ───────────────────
-# Ordre réel du modèle rollers (18 joints après le free-joint), vérifié dans
-# MuJoCo via get_walk_rollers_spec().compile() :
+# ── Joint indices — the passive wheels are INTERLEAVED ────────────────────────
+# Actual ordering of the roller model (18 joints after the free joint), verified
+# in MuJoCo via get_walk_rollers_spec().compile():
 #   0-4   left_hip_yaw, left_hip_roll, left_hip_pitch, left_knee, left_ankle
 #   5-6   passive_LF_wheel, passive_LR_wheel
 #   7-10  neck_pitch, head_pitch, head_yaw, head_roll
 #   11-15 right_hip_yaw, right_hip_roll, right_hip_pitch, right_knee, right_ankle
 #   16-17 passive_RF_wheel, passive_RR_wheel
-# Le standup utilise [0-4, 9-13] / [5-8] : ce sont les indices du modèle SANS
-# roues, ils ne valent PAS ici. Verrouillé par tests/test_roller_standup_cfg.py.
+# standup uses [0-4, 9-13] / [5-8]: those are the indices of the model WITHOUT
+# wheels, they do NOT hold here. Locked in by tests/test_roller_standup_cfg.py.
 #
-# Seul _LEG_JOINTS est consommé (par les récompenses de pose). _NECK_JOINTS et
-# _WHEEL_JOINTS servent à la documentation et au test d'indices : le cou est
-# résolu par NOM (neck_joint_pos_l2 appelle find_joints(r".*(neck|head).*") à
-# chaque pas) et les roues par la regex ^passive_.*.
+# Only _LEG_JOINTS is consumed (by the pose rewards). _NECK_JOINTS and
+# _WHEEL_JOINTS exist for documentation and for the index test: the neck is
+# resolved by NAME (neck_joint_pos_l2 calls find_joints(r".*(neck|head).*") every
+# step) and the wheels by the ^passive_.* regex.
 _LEG_JOINTS   = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]
 _NECK_JOINTS  = [7, 8, 9, 10]
 _WHEEL_JOINTS = [5, 6, 16, 17]
 
-# Récompenses de PATINAGE de l'env roller : aucun sens quand on est par terre.
-# feet_flat : les lames ne sont PAS à plat pendant la montée → combattrait le geste.
-# hip_roll_neutral : se relever demande d'écarter les jambes.
-# pose / com_height_target : remplacés par les cibles pose/hauteur du relevé.
-# upright (gaussienne de base) : remplacée par upright_linear + upright_sharp.
+# SKATING rewards from the roller env: meaningless while lying on the ground.
+# feet_flat: the blades are NOT flat during the rise → would fight the gesture.
+# hip_roll_neutral: standing up requires spreading the legs.
+# pose / com_height_target: replaced by the standup pose/height targets.
+# upright (base gaussian): replaced by upright_linear + upright_sharp.
 _SKATING_REWARDS = (
     "wheel_speed",
     "braking",
@@ -133,20 +132,20 @@ _SKATING_REWARDS = (
 
 
 def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
-    """Env « se relever sur rollers » : départ au sol, cible = debout sur roues."""
+    """"Stand up on rollers" env: start on the ground, target = standing on wheels."""
     cfg = make_microduck_velocity_rollers_env_cfg(play=play)
 
     cfg.episode_length_s = EPISODE_LENGTH_S
 
-    # ── Récompenses de patinage retirées ─────────────────────────────────────
+    # ── Skating rewards removed ──────────────────────────────────────────────
     for name in _SKATING_REWARDS:
         cfg.rewards.pop(name, None)
 
-    # ── Commande : slot twist neutralisé (≈ 0) ───────────────────────────────
-    # L'env roller installe un RelativeHeadingVelocityCommandCfg (cmd[2] = erreur
-    # de cap calculée en interne). Ici on ne pilote rien : on repasse au
-    # command-only neutralisé, comme standup. Les slots head_pose (4) et
-    # body_pose (6) restent zero-paddés → parité d'obs 61D préservée.
+    # ── Command: twist slot neutralized (≈ 0) ────────────────────────────────
+    # The roller env installs a RelativeHeadingVelocityCommandCfg (cmd[2] =
+    # heading error computed internally). Here we steer nothing: we go back to
+    # the neutralized command-only variant, like standup. The head_pose (4) and
+    # body_pose (6) slots stay zero-padded → 61D obs parity preserved.
     command = cfg.commands["twist"]
     command.rel_standing_envs = 0.0
     command.rel_heading_envs  = 0.0
@@ -159,22 +158,22 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
     command.ranges.ang_vel_z = (-0.05, 0.05)
     cfg.commands["twist"] = microduck_mdp.VelocityCommandCommandOnlyCfg(**vars(command))
 
-    # ── Robustesse numérique (même choix que roller_slope) ───────────────────
-    # Un contact rare (~1/25M pas) fait diverger le free-joint en NaN : on
-    # assainit l'obs (→ 0) pour ne pas tuer l'entraînement, l'env fautif se reset
-    # au pas suivant.
+    # ── Numerical robustness (same choice as roller_slope) ───────────────────
+    # A rare contact (~1 in 25M steps) makes the free joint diverge to NaN: we
+    # sanitize the obs (→ 0) so training is not killed, and the offending env
+    # resets on the next step.
     for grp in ("actor", "critic"):
         cfg.observations[grp].nan_policy = "sanitize"
 
-    # ── Récompenses de relevé — transplant du standup, remappé ───────────────
-    # Les poids viennent des itérations documentées dans
-    # microduck_standup_env_cfg.py : ne les retoucher qu'avec une raison. Seuls
-    # les indices de joints et les deux hauteurs changent ici.
-    # NB : un SceneEntityCfg NEUF par terme — mjlab les résout et les mute en
-    # place, un objet partagé donne des indices périmés.
+    # ── Standup rewards — transplanted from standup, remapped ────────────────
+    # The weights come from the iterations documented in
+    # microduck_standup_env_cfg.py: only touch them with a reason. Only the
+    # joint indices and the two heights change here.
+    # NB: a FRESH SceneEntityCfg per term — mjlab resolves and mutates them in
+    # place, so a shared object yields stale indices.
 
-    # Pose cible = HOME (target_overrides=None), JAMBES seulement : le cou et la
-    # tête sont tenus par neck_joint_pos_l2 (hérité), qui résout par NOM.
+    # Target pose = HOME (target_overrides=None), LEGS only: the neck and head
+    # are held by neck_joint_pos_l2 (inherited), which resolves by NAME.
     cfg.rewards["pose_stand_legs"] = RewardTermCfg(
         func=microduck_mdp.pose_target_match,
         weight=8.0,
@@ -184,7 +183,7 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
             "target_overrides": None,
         },
     )
-    # Bootstrap L1 : gradient constant même loin de HOME (la gaussienne sature).
+    # L1 bootstrap: constant gradient even far from HOME (the gaussian saturates).
     cfg.rewards["pose_stand_l1"] = RewardTermCfg(
         func=microduck_mdp.pose_l1_penalty,
         weight=5.0,
@@ -194,10 +193,10 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
         },
     )
 
-    # Hauteur en trois couches : gaussienne large (tire depuis le sol),
-    # gaussienne étroite (force les derniers cm, là où la large est saturée),
-    # et L1 fort qui rend « rester par terre » net NÉGATIF — sans lui, la policy
-    # se contente de l'optimum paresseux « immobile au sol ».
+    # Height in three layers: wide gaussian (pulls up from the ground), narrow
+    # gaussian (forces the last few cm, where the wide one is saturated), and a
+    # strong L1 that makes "stay on the ground" net NEGATIVE — without it the
+    # policy settles for the lazy optimum "motionless on the floor".
     cfg.rewards["height_stand"] = RewardTermCfg(
         func=microduck_mdp.height_target_gaussian,
         weight=4.0,
@@ -225,10 +224,10 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
         },
     )
 
-    # Paye le MOUVEMENT de montée, pas seulement la destination : sans ça,
-    # « rester assis en collectant la pose partielle » domine. La coupure est
-    # 10 mm AU-DESSUS de la cible, sinon la policy se gare à l'altitude de
-    # coupure et ne finit pas la montée.
+    # Pays for the UPWARD MOTION, not just the destination: without it,
+    # "sit still and farm the partial pose reward" dominates. The cutoff is
+    # 10 mm ABOVE the target, otherwise the policy parks at the cutoff altitude
+    # and never finishes the rise.
     cfg.rewards["com_upward_velocity"] = RewardTermCfg(
         func=microduck_mdp.com_upward_velocity,
         weight=3.0,
@@ -237,34 +236,34 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
             "max_height": ROLLER_STAND_Z + 0.010,
         },
     )
-    # Montée douce : pénalise |a_z|. Compatible avec com_upward_velocity — une
-    # vitesse verticale constante collecte l'une ET a a_z = 0 → les deux
-    # pressions sélectionnent ensemble une montée lisse à vitesse constante.
+    # Gentle rise: penalizes |a_z|. Compatible with com_upward_velocity — a
+    # constant vertical velocity collects the latter AND has a_z = 0 → the two
+    # pressures jointly select a smooth constant-speed rise.
     #
-    # ⚠️ POIDS POSITIF, et ce n'est pas une faute de frappe. mdp.py mélange deux
-    # conventions de signe : trunk_vertical_accel_penalty renvoie déjà -|a_z|
-    # (mdp.py:2171), comme height_l1_penalty et pose_l1_penalty — qui sont d'ailleurs
-    # employées ici avec des poids +30 et +5. Le -0.02 hérité du standup formait donc
-    # un double négatif et RÉCOMPENSAIT l'accélération verticale : mesuré à
-    # Episode_Reward/gentle_rise = +0.0118 (seul terme de pénalité loggé positif) sur
-    # le run vweolw91. C'est la cause du « très violent », et elle explique aussi les
-    # tentatives d'amortissement infructueuses documentées dans le standup, qui
-    # combattaient un terme poussant activement dans l'autre sens.
+    # ⚠️ POSITIVE WEIGHT, and that is not a typo. mdp.py mixes two sign
+    # conventions: trunk_vertical_accel_penalty already returns -|a_z|
+    # (mdp.py:2171), like height_l1_penalty and pose_l1_penalty — which are in fact
+    # used here with weights +30 and +5. The -0.02 inherited from standup therefore
+    # formed a double negative and REWARDED vertical acceleration: measured at
+    # Episode_Reward/gentle_rise = +0.0118 (the only penalty term logged positive) on
+    # run vweolw91. That is the cause of the "very violent" behavior, and it also
+    # explains the unsuccessful damping attempts documented in standup, which were
+    # fighting a term actively pushing the other way.
     #
-    # On garde la magnitude 0.02 (celle voulue à l'origine) DÉLIBÉRÉMENT petite :
-    # |a_z| est forcément élevé pendant un retournement depuis le dos, donc un gros
-    # poids ici serait un bloqueur de mouvement. L'amortissement réel est porté par
-    # joint_torque_rate_l2, qui pénalise la VARIATION de couple et pas le mouvement.
+    # We keep the magnitude 0.02 (the originally intended one) DELIBERATELY small:
+    # |a_z| is necessarily high during a roll-over from the back, so a large weight
+    # here would be a motion blocker. The real damping is carried by
+    # joint_torque_rate_l2, which penalizes torque RATE rather than motion.
     cfg.rewards["gentle_rise"] = RewardTermCfg(
         func=microduck_mdp.trunk_vertical_accel_penalty,
         weight=+0.02,
         params={"asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",))},
     )
 
-    # Tronc vertical en deux couches : cos(tilt) a un fort gradient quand on est
-    # couché mais s'essouffle près de la verticale ; la gaussienne serrée gatée
-    # en hauteur prend le relais et tue le penché-arrière (mode d'échec du
-    # standup : basculer en arrière en tendant les jambes).
+    # Trunk uprightness in two layers: cos(tilt) has a strong gradient while
+    # lying down but runs out of steam near vertical; the tight height-gated
+    # gaussian takes over and kills the backward lean (standup's failure mode:
+    # tipping backward while extending the legs).
     cfg.rewards["upright_linear"] = RewardTermCfg(
         func=microduck_mdp.body_upright_linear,
         weight=6.0,
@@ -281,11 +280,11 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
         },
     )
 
-    # Score MULTIPLICATIF hauteur × verticalité × pose : comme les facteurs se
-    # multiplient, être bon sur 2 critères sur 3 ne rapporte rien → casse les
-    # compromis « penché à la bonne hauteur » que les récompenses additives
-    # laissent passer. Stds volontairement LARGES pour rester visible pendant la
-    # montée (des stds serrées donnaient un score ~5e-5, donc zéro gradient).
+    # MULTIPLICATIVE score height × uprightness × pose: since the factors
+    # multiply, being good on 2 criteria out of 3 pays nothing → it breaks the
+    # "leaning at the right height" compromises that additive rewards let
+    # through. Stds deliberately WIDE so the score stays visible during the rise
+    # (tight stds gave a score of ~5e-5, i.e. zero gradient).
     cfg.rewards["standing_composite"] = RewardTermCfg(
         func=microduck_mdp.standing_composite_score,
         weight=15.0,
@@ -300,98 +299,98 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
         },
     )
 
-    # Anti-jitter : pénalise la VARIATION de couple, pas son amplitude ni la
-    # rotation du tronc → amortit la tremblote sans bloquer le retournement.
-    # Le standup l'a identifié comme le seul amortisseur qui ne tue pas le
-    # relevé depuis le dos, donc c'est LE levier sûr à remonter.
+    # Anti-jitter: penalizes torque RATE, not its magnitude nor trunk rotation
+    # → damps the shakes without blocking the roll-over.
+    # standup identified this as the only damper that does not kill the rise
+    # from the back, so it is THE safe lever to turn up.
     #
-    # -2e-3 (valeur héritée du standup) ne contribuait que -0.0002/pas face à
-    # ~+41.6 de récompense de tâche saturée à 95-99 % — soit rien du tout. Tous
-    # amortisseurs confondus le rapport était de ~35:1 en faveur de la tâche, donc
-    # aucune raison d'être doux. Mesuré sur le run vweolw91 à l'itération 7500.
+    # -2e-3 (the value inherited from standup) contributed only -0.0002/step
+    # against ~+41.6 of task reward saturated at 95-99% — i.e. nothing at all.
+    # Across all dampers the ratio was ~35:1 in favor of the task, so there was
+    # no reason to be gentle. Measured on run vweolw91 at iteration 7500.
     #
-    # Recalibrage : la valeur brute de |Δτ|² vaut ~0.1 à convergence, donc
-    # contribution ≈ 0.1 × |poids|. Mesuré à -0.255/pas avec un poids -2.0 (run
-    # d8rnko6p) — donc PAS la cause du gel, mais on redescend à -0.2 pour dégager
-    # le budget d'amortissement le temps d'isoler l'effet du seul bug de signe.
-    # Si c'est encore violent, monter CE terme (formule ci-dessus) plutôt que
-    # body_ang_vel ou action_rate, qui sont des bloqueurs de mouvement et gelaient
-    # le relevé depuis le dos.
+    # Recalibration: the raw value of |Δτ|² is ~0.1 at convergence, so the
+    # contribution ≈ 0.1 × |weight|. Measured at -0.255/step with a weight of
+    # -2.0 (run d8rnko6p) — so NOT the cause of the freeze, but we drop back to
+    # -0.2 to free up the damping budget while isolating the effect of the sign
+    # bug alone. If it is still violent, raise THIS term (formula above) rather
+    # than body_ang_vel or action_rate, which are motion blockers and were
+    # freezing the rise from the back.
     cfg.rewards["joint_torque_rate_l2"] = RewardTermCfg(
         func=microduck_mdp.joint_torque_rate_l2,
         weight=-0.2,
     )
 
-    # PAS de pénalité d'impact tête. Essayée avec les valeurs de velstand
-    # (body_impact_cost, sous-arbre `neck`, poids -1.0, seuil 2.0) : la policy a
-    # convergé vers rester couchée, INERTE. Mesuré (run d8rnko6p) :
-    # head_impact_penalty -1.01/pas, le plus gros terme négatif du tableau, pendant
-    # que standing_composite s'effondrait de +14.3 à +3.3.
+    # NO head-impact penalty. Tried with velstand's values (body_impact_cost,
+    # `neck` subtree, weight -1.0, threshold 2.0): the policy converged to lying
+    # down, INERT. Measured (run d8rnko6p): head_impact_penalty -1.01/step, the
+    # largest negative term in the table, while standing_composite collapsed from
+    # +14.3 to +3.3.
     #
-    # L'erreur de raisonnement était de croire qu'une pénalité « ciblée » ne bride
-    # pas le mouvement. Faux ici : pour se relever du dos, ce robot PIVOTE sur sa
-    # tête et ses épaules. La tête est le point d'appui du retournement, pas un
-    # dégât collatéral — la pénaliser bloque le seul mécanisme disponible, et le
-    # dos était déjà le cas qui échouait.
+    # The reasoning error was believing that a "targeted" penalty does not
+    # restrict motion. False here: to get up from its back, this robot PIVOTS on
+    # its head and shoulders. The head is the fulcrum of the roll-over, not
+    # collateral damage — penalizing it blocks the only available mechanism, and
+    # the face-up case was already the failing one.
     #
-    # Hypothèse en cours de test : taper la tête était un SYMPTÔME de la violence
-    # (le bug de signe de gentle_rise payait la brutalité, et une montée brutale
-    # finit sur la tête), pas un défaut séparé. Si le slam revient une fois le signe
-    # corrigé, la reprise doit être une pénalité GATÉE EN HAUTEUR — comme
-    # upright_sharp l'est — pour épargner la phase de retournement au sol.
+    # Hypothesis under test: head banging was a SYMPTOM of the violence (the
+    # gentle_rise sign bug paid for brutality, and a brutal rise ends on the
+    # head), not a separate defect. If the slam comes back once the sign is
+    # fixed, the reintroduction must be a HEIGHT-GATED penalty — as upright_sharp
+    # is — to spare the ground roll-over phase.
     #
-    # ⚠️ Attention à l'optimum paresseux qui rend ce gel possible : pose_stand_legs
-    # restait à +7.72 sur 8 alors que le robot était allongé (jambes à HOME en
-    # position couchée → récompense encaissée quasi gratuitement). C'est
-    # height_stand_l1 (poids +30) qui doit rendre « rester au sol » net négatif.
+    # ⚠️ Beware the lazy optimum that makes this freeze possible: pose_stand_legs
+    # stayed at +7.72 out of 8 while the robot was lying flat (legs at HOME in a
+    # prone position → reward collected almost for free). It is height_stand_l1
+    # (weight +30) that must make "stay on the ground" net negative.
 
-    # ── Départ AU SOL : à plat ventre / à plat dos / déjà debout ─────────────
-    # Ajouté en DERNIER dans cfg.events : l'ordre d'exécution suit l'ordre
-    # d'insertion, et ce terme doit écraser la pose posée par reset_base /
-    # reset_robot_joints.
-    # Le bucket « déjà debout » n'est pas décoratif : sans lui la policy apprend
-    # à monter mais pas à TENIR, et elle retombe juste après s'être relevée.
-    # Pas de bucket « assis » → aucun sitting_joint_overrides à remapper (ceux du
-    # standup sont des indices du modèle SANS roues).
-    # Les probabilités ci-dessous = palier 0 du curriculum ground_state_mix.
+    # ── Start ON THE GROUND: face down / face up / already standing ─────────
+    # Added LAST in cfg.events: execution order follows insertion order, and this
+    # term must overwrite the pose set by reset_base / reset_robot_joints.
+    # The "already standing" bucket is not decorative: without it the policy
+    # learns to rise but not to HOLD, and it falls right back down after standing
+    # up.
+    # No "sitting" bucket → no sitting_joint_overrides to remap (standup's are
+    # indices of the model WITHOUT wheels).
+    # The probabilities below = stage 0 of the ground_state_mix curriculum.
     cfg.events["set_ground_state"] = EventTermCfg(
         func=microduck_mdp.set_random_ground_state,
         mode="reset",
         params={
-            "face_down_prob": 0.50,   # ventre (+90° de pitch)
-            "face_up_prob":   0.00,   # dos — le plus dur, introduit tard
+            "face_down_prob": 0.50,   # face down (+90° of pitch)
+            "face_up_prob":   0.00,   # face up — hardest, introduced late
             "sitting_prob":   0.00,
             "standing_prob":  0.50,
             "sitting_joint_overrides": None,
-            # Les deux poses de départ (ventre/dos) partagent une SEULE plage de z,
-            # or leurs contacts n'ont rien de commun : le ventre ne décolle du sol
-            # qu'à partir de 0.0752, le dos repose à 0.0475. Un plancher unique ne
-            # peut donc pas être idéal pour les deux. On choisit 0.076 pour éliminer
-            # toute interpénétration côté ventre (mesuré : à 0.05, +25 mm dans le
-            # sol), au prix d'un dos qui démarre 28–42 mm au-dessus de son repos —
-            # un artefact bien plus doux qu'un pushout de contact.
+            # The two start poses (face down / face up) share a SINGLE z range,
+            # yet their contacts have nothing in common: face down only clears the
+            # ground from 0.0752 up, face up rests at 0.0475. A single floor
+            # therefore cannot be ideal for both. We pick 0.076 to eliminate any
+            # interpenetration on the face-down side (measured: at 0.05, +25 mm
+            # into the ground), at the cost of a face-up start 28–42 mm above its
+            # rest height — a far gentler artifact than a contact pushout.
             "prone_z_min":    0.076,
             "prone_z_max":    0.09,
-            # Debout sur roues : ROLLER_STAND_Z = 0.138 (contre 0.11–0.12 sans roues).
+            # Standing on wheels: ROLLER_STAND_Z = 0.138 (vs 0.11–0.12 without wheels).
             "standing_z_min": 0.134,
             "standing_z_max": 0.144,
-            # Bruit de pitch/roll au départ. Attention : dans
-            # set_random_ground_state le bucket « debout » réutilise le quaternion
-            # du bucket « assis », donc ce bruit s'applique AUSSI aux départs
-            # debout — c'est voulu (pas de sur-apprentissage du parfaitement droit).
+            # Pitch/roll noise at start. Careful: in set_random_ground_state the
+            # "standing" bucket reuses the "sitting" bucket's quaternion, so this
+            # noise applies to standing starts TOO — that is intended (no
+            # overfitting to perfectly upright).
             "sitting_tilt_max": math.radians(10),
         },
     )
 
-    # Le robot DÉMARRE tombé → la terminaison sur inclinaison n'a aucun sens ici
-    # (elle tuerait l'épisode au premier pas). nan_state, hérité, reste.
+    # The robot STARTS fallen → the tilt termination makes no sense here (it
+    # would kill the episode on the first step). nan_state, inherited, stays.
     cfg.terminations.pop("fell_over", None)
 
-    # Curriculum des poses de départ, easy → hard. Avec un mélange plat dès le
-    # départ, la policy optimise la majorité facile et laisse le dos sous-entraîné
-    # (leçon du standup : il gelait en « ne rien faire » sur cette pose). On
-    # introduit donc debout+ventre d'abord, le dos tard, et on biaise vers les
-    # poses dures à la fin pour qu'elles reçoivent le plus d'entraînement.
+    # Start-pose curriculum, easy → hard. With a flat mix from the start, the
+    # policy optimizes the easy majority and leaves the face-up case undertrained
+    # (standup's lesson: it froze into "do nothing" on that pose). So we
+    # introduce standing+face-down first, face-up late, and bias toward the hard
+    # poses at the end so they get the most training.
     cfg.curriculum["ground_state_mix"] = CurriculumTermCfg(
         func=microduck_mdp.event_param_curriculum,
         params={
@@ -413,11 +412,11 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
         },
     )
 
-    # Override de play : forcer les départs sur le dos pour pouvoir les inspecter.
-    # On écrit les probabilités dans l'événement ET on retire le curriculum : sans
-    # ça, event_param_curriculum (qui tourne AVANT les événements de reset) les
-    # réécrirait avec son palier 0 dès le premier reset. Uniquement en play, donc
-    # l'entraînement et son curriculum easy → hard sont intouchés.
+    # Play override: force face-up starts so they can be inspected. We write the
+    # probabilities into the event AND remove the curriculum: without that,
+    # event_param_curriculum (which runs BEFORE the reset events) would rewrite
+    # them with its stage 0 on the very first reset. Play only, so training and
+    # its easy → hard curriculum are untouched.
     if play:
         play_face_up = _resolve_play_face_up()
         if play_face_up is not None:
@@ -430,22 +429,21 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
             })
             del cfg.curriculum["ground_state_mix"]
 
-    # ── Friction de roulement INVERSÉE : freinées → libres ───────────────────
-    # C'est la seule pièce vraiment nouvelle de cet env, et le cœur de la
-    # difficulté : les roues roulent, donc il n'y a AUCUNE adhérence
-    # longitudinale pour pousser sur le sol. L'env roller fait MONTER cette
-    # friction (0 → 0.0015) ; ici on la fait DESCENDRE, pour bootstrapper le
-    # geste sur un problème facile (roues quasi bloquées ≈ des pieds) avant
-    # d'imposer la physique réelle du roulement.
+    # ── REVERSED rolling friction: braked → free ─────────────────────────────
+    # This is the only genuinely new piece of this env, and the heart of the
+    # difficulty: the wheels roll, so there is NO longitudinal traction to push
+    # against the ground. The roller env ramps this friction UP (0 → 0.0015);
+    # here we ramp it DOWN, to bootstrap the gesture on an easy problem
+    # (near-locked wheels ≈ feet) before imposing the real rolling physics.
     #
-    # DIAGNOSTIC à surveiller : si Episode_Reward/standing_composite s'écroule à
-    # un palier, le geste « pieds adhérents » ne transfère pas aux roues libres
-    # → il faudra guider une technique de patineur (appui genou intermédiaire,
-    # un patin à la fois). C'est un résultat exploitable, pas un échec.
+    # DIAGNOSTIC to watch: if Episode_Reward/standing_composite collapses at a
+    # stage, the "sticky feet" gesture does not transfer to free wheels → we will
+    # have to guide a skater technique (intermediate knee support, one skate at a
+    # time). That is an actionable result, not a failure.
     #
-    # ATTENTION sim2real : seuls les checkpoints d'APRÈS le dernier palier
-    # (iter 4000+) sont candidats au déploiement. Avant, la policy s'appuie sur
-    # une friction de roulement qui n'existe pas sur le vrai robot.
+    # sim2real WARNING: only checkpoints from AFTER the last stage (iter 4000+)
+    # are deployment candidates. Before that, the policy relies on a rolling
+    # friction that does not exist on the real robot.
     _WHEEL_FRICTION_STAGE0 = (0.0500, 0.0500)
     cfg.curriculum["wheel_friction"] = CurriculumTermCfg(
         func=microduck_mdp.wheel_friction_curriculum,
@@ -460,19 +458,19 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
             ],
         },
     )
-    # Redondance défensive : le curriculum manager tourne AVANT les événements de
-    # reset à chaque reset (y compris le tout premier), et wheel_friction_curriculum
-    # défaut lui-même sur le palier 0 — donc cette ligne n'est jamais nécessaire en
-    # pratique. Elle garde juste la valeur PAR DÉFAUT de l'événement cohérente avec
-    # le palier 0 du curriculum, au cas où quelqu'un retire le curriculum plus tard
-    # en laissant l'événement en place.
+    # Defensive redundancy: the curriculum manager runs BEFORE the reset events
+    # on every reset (including the very first), and wheel_friction_curriculum
+    # itself defaults to stage 0 — so this line is never needed in practice. It
+    # just keeps the event's DEFAULT value consistent with the curriculum's stage
+    # 0, in case someone later removes the curriculum but leaves the event in
+    # place.
     cfg.events["randomize_wheel_friction"].params["ranges"] = _WHEEL_FRICTION_STAGE0
 
-    # ── action_rate : la rampe du standup, pas celle du roller ───────────────
-    # L'env roller monte à -2.0 pour un gait calme. C'est un bloqueur de
-    # mouvement : il ralentit l'action rapide dont le relevé depuis le dos a
-    # besoin (le standup documente qu'un action_rate trop fort tuait cette
-    # récupération). La douceur est portée ici par joint_torque_rate_l2.
+    # ── action_rate: standup's ramp, not the roller's ────────────────────────
+    # The roller env ramps to -2.0 for a calm gait. That is a motion blocker: it
+    # slows the fast action the rise from the back needs (standup documents that
+    # too strong an action_rate killed that recovery). Smoothness is carried here
+    # by joint_torque_rate_l2.
     cfg.rewards["action_rate_l2"].weight = -0.6
     cfg.curriculum["action_rate_weight"] = CurriculumTermCfg(
         func=microduck_mdp.reward_weight,
@@ -486,10 +484,10 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
         },
     )
 
-    # ── Poussées rampées ────────────────────────────────────────────────────
-    # push_robot est hérité de l'env roller (±0.2 m/s, toutes les 3–6 s) mais
-    # sans curriculum. Une bourrade dès le pas 0 parasite le bootstrap du
-    # relevé : on la fait monter comme le standup.
+    # ── Ramped pushes ───────────────────────────────────────────────────────
+    # push_robot is inherited from the roller env (±0.2 m/s, every 3–6 s) but
+    # without a curriculum. A shove from step 0 disturbs the bootstrap of the
+    # rise: we ramp it up like standup does.
     cfg.curriculum["push_magnitude"] = CurriculumTermCfg(
         func=microduck_mdp.push_curriculum,
         params={
@@ -508,12 +506,12 @@ def make_microduck_roller_standup_env_cfg(play: bool = False) -> ManagerBasedRlE
     return cfg
 
 
-# ── Config du runner RL — identique à standup ─────────────────────────────────
+# ── RL runner config — identical to standup ───────────────────────────────────
 MicroduckRollerStandUpRlCfg = RslRlOnPolicyRunnerCfg(
     actor=RslRlModelCfg(
         hidden_dims=(512, 256, 128),
         activation="elu",
-        obs_normalization=True,  # le normaliseur DOIT être baké dans l'ONNX par export.py
+        obs_normalization=True,  # the normalizer MUST be baked into the ONNX by export.py
         distribution_cfg={
             "class_name": "GaussianDistribution",
             "init_std": 1.0,
@@ -538,8 +536,8 @@ MicroduckRollerStandUpRlCfg = RslRlOnPolicyRunnerCfg(
         lam=0.95,
         desired_kl=0.01,
         max_grad_norm=1.0,
-        # Symétrie OFF : SYMMETRY_CFG est câblé pour l'ancien layout 51D et casse
-        # sur le 61D (même situation que tous les envs v1.5+).
+        # Symmetry OFF: SYMMETRY_CFG is wired for the old 51D layout and breaks
+        # on the 61D one (same situation as every v1.5+ env).
         symmetry_cfg=None,
     ),
     wandb_project="mjlab_microduck",

--- a/src/mjlab_microduck/tasks/microduck_roulade_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_roulade_env_cfg.py
@@ -25,7 +25,7 @@ Design (see the roulade section of mdp.py for the full history):
     tucked, with forward angular momentum, accumulator pre-set to the spawn
     angle. The second half of a roulade IS the face-up recovery problem, which
     we know is learnable.
-  • Élan hook for later: reset_roulade_state.forward_vel_range gives standing
+  • Momentum hook for later: reset_roulade_state.forward_vel_range gives standing
     spawns an initial forward base velocity — set ROULADE_FORWARD_VEL_RANGE
     to e.g. (0.0, 0.3) to train rolls out of a walk. (0, 0) = standstill-only.
 
@@ -75,7 +75,7 @@ EPISODE_LENGTH_S = 5.0
 # Empirically-measured standing trunk height (standup lesson: don't guess).
 STAND_Z = 0.115
 
-# ── Élan (run-up) hook ────────────────────────────────────────────────────────
+# ── Momentum (run-up) hook ───────────────────────────────────────────────────
 # (0, 0) = roll from a standstill (run 1). Widen to e.g. (0.0, 0.3) to train
 # rolls entered with forward momentum — standing spawns then get a random
 # initial forward base velocity, approximating a hand-off from the walking

--- a/src/mjlab_microduck/tasks/microduck_spin_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_spin_env_cfg.py
@@ -1,29 +1,29 @@
-"""Microduck SPIN task — rotation rapide sur place, sur rollers.
+"""Microduck SPIN task — fast spin in place, on rollers.
 
-Geste cyclique déclenché au bouton A via le slot --ground-pick du runtime :
-~1 tour anti-horaire à ~3 rad/s puis arrêt propre debout.
+Cyclic gesture triggered by button A through the runtime's --ground-pick slot:
+~1 counter-clockwise turn at ~3 rad/s, then a clean stop standing up.
 
-Hybride :
-  - physique / robot roller  ← microduck_velocity_rollers_env_cfg.py
-  - machinerie phase cyclique ← microduck_roller_crouch_env_cfg.py
-    (commande GroundPickPhaseCommand : [cos(2πφ), sin(2πφ), 0], période 4 s)
+Hybrid:
+  - roller physics / robot     ← microduck_velocity_rollers_env_cfg.py
+  - cyclic-phase machinery     ← microduck_roller_crouch_env_cfg.py
+    (GroundPickPhaseCommand: [cos(2πφ), sin(2πφ), 0], period 4 s)
 
-Différence de fond avec le crouch : la phase pilote une VITESSE DE LACET cible
-(objectif de résultat) et non une pose articulaire. Deux amorces décroissantes
-poussent vers le roulement différentiel — le seul mécanisme physique certain sur
-4 roues passives : patin gauche vers l'arrière, patin droit vers l'avant.
+Fundamental difference from the crouch: the phase drives a target YAW RATE (an
+outcome objective) rather than a joint pose. Two decaying priming terms push
+toward differential rolling — the only certain physical mechanism on 4 passive
+wheels: left skate backward, right skate forward.
 
-Obs 61D unifié → interchangeable au runtime avec roller / ground_pick / crouch.
-Voir docs/superpowers/specs/2026-08-04-spin-env-design.md.
+Unified 61D obs → hot-swappable at runtime with roller / ground_pick / crouch.
+See docs/superpowers/specs/2026-08-04-spin-env-design.md.
 """
 
 import math
 from copy import deepcopy
 
-# La symétrie G/D transformerait un spin à gauche en spin à droite : interdit ici.
+# L/R symmetry would turn a left spin into a right spin: forbidden here.
 ENABLE_SYMMETRY = False
 
-# DR — repris du roller env
+# DR — taken from the roller env
 ENABLE_COM_RANDOMIZATION             = True
 ENABLE_HEAD_COM_RANDOMIZATION        = True
 ENABLE_MASS_INERTIA_RANDOMIZATION    = True
@@ -44,8 +44,8 @@ VELOCITY_PUSH_RANGE              = (-0.2, 0.2)
 IMU_ORIENTATION_RANDOMIZATION_ANGLE = 6.0
 ENCODER_BIAS_RANGE               = (-0.015, 0.015)
 
-# Le bouton peut être pressé à l'arrêt OU en roulement lent : la policy apprend
-# à tuer l'élan résiduel avant/pendant le lancement de la rotation.
+# The button can be pressed at a standstill OR while rolling slowly: the policy
+# learns to kill the residual momentum before/during the rotation launch.
 ENTRY_VELOCITY_X = (0.0, 0.3)
 
 from mjlab.envs import ManagerBasedRlEnvCfg
@@ -71,7 +71,7 @@ from mjlab_microduck.tasks import mdp as microduck_mdp
 from mjlab_microduck.tasks.microduck_velocity_env_cfg import HEAD_BODY_NAMES
 from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg, SYMMETRY_CFG
 
-# Enveloppe de phase : constantes canoniques définies dans mdp.py.
+# Phase envelope: canonical constants defined in mdp.py.
 SPIN_PERIOD = microduck_mdp.SPIN_PERIOD
 _ENVELOPE = {
     "rate_max": microduck_mdp.SPIN_RATE_MAX,
@@ -79,13 +79,13 @@ _ENVELOPE = {
     "hold_end": microduck_mdp.SPIN_HOLD_END,
     "brake_end": microduck_mdp.SPIN_BRAKE_END,
 }
-# Nuque/tête tenues près du neutre SAUF head_yaw, laissé libre : il peut servir
-# de volant d'inertie pour lancer la rotation.
+# Neck/head held near neutral EXCEPT head_yaw, left free: it can act as a
+# flywheel to launch the rotation.
 NECK_PATTERN_NO_YAW = r"^(neck_pitch|head_pitch|head_roll)$"
 
 
 def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
-    """Env spin sur rollers, piloté par la phase du slot ground-pick."""
+    """Spin-on-rollers env, driven by the ground-pick slot's phase."""
 
     feet_ground_cfg = ContactSensorCfg(
         name="feet_ground_contact",
@@ -119,10 +119,10 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
     joint_pos_action.scale = 1.0
 
     # === REWARDS ===
-    # ⚠️ angular_momentum n'est PAS gardée : elle pénalise la norme 3D du moment
-    # angulaire, donc elle combattrait directement le spin. body_ang_vel, elle,
-    # ne pénalise que x/y (« Don't penalize z-angular velocity » dans mjlab) →
-    # gardée, elle mate le ballant roulis/tangage sans gêner la rotation.
+    # ⚠️ angular_momentum is NOT kept: it penalizes the 3D norm of angular
+    # momentum, so it would fight the spin head-on. body_ang_vel, on the other
+    # hand, only penalizes x/y ("Don't penalize z-angular velocity" in mjlab) →
+    # kept, it damps roll/pitch wobble without hindering the rotation.
     keep = {"upright", "body_ang_vel", "action_rate_l2"}
     for name in list(cfg.rewards.keys()):
         if name not in keep:
@@ -134,7 +134,7 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
     cfg.rewards["body_ang_vel"].weight = -0.05
     cfg.rewards["action_rate_l2"].weight = -1.0
 
-    # Objectif principal : suivre la vitesse de lacet cible ω*(φ) (trapèze).
+    # Main objective: track the target yaw rate ω*(φ) (trapezoidal).
     cfg.rewards["spin_rate_track"] = RewardTermCfg(
         func=microduck_mdp.spin_rate_track,
         weight=6.0,
@@ -146,14 +146,16 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
         weight=0.5,
         params={"command_name": "twist", **_ENVELOPE},
     )
-    # Tourner SUR PLACE, et tuer l'élan d'entrée. Renforcé -1.0 -> -3.0 : au run de
-    # calibrage à 500 it. le tronc translatait à ~0.35 m/s (~ω·demi-voie), signature
-    # d'un pivot sur un seul patin plutôt qu'un spin centré sur le corps — c'est le
-    # seul terme qui distingue un spin centré d'un pivot excentré.
-    # Atténué pendant la rampe de lancement [0, ACCEL_END) : c'est le moment où le
-    # robot doit pousser au sol pour s'injecter du moment angulaire, et où l'élan
-    # d'entrée (jusqu'à 0.3 m/s) doit être CONVERTI en rotation — le facturer plein
-    # tarif là s'opposerait au lancement. Plein tarif sur régime/freinage/repos.
+    # Spin IN PLACE, and kill the entry momentum. Strengthened -1.0 -> -3.0: in
+    # the calibration run at 500 it. the trunk was translating at ~0.35 m/s
+    # (~ω·half-track), the signature of a pivot on a single skate rather than a
+    # body-centered spin — this is the only term that tells a centered spin from
+    # an off-center pivot.
+    # Attenuated during the launch ramp [0, ACCEL_END): that is when the robot
+    # must push against the ground to inject angular momentum, and when the entry
+    # momentum (up to 0.3 m/s) must be CONVERTED into rotation — charging full
+    # price there would work against the launch. Full price on steady
+    # state/braking/rest.
     cfg.rewards["spin_stay_in_place"] = RewardTermCfg(
         func=microduck_mdp.spin_stay_in_place,
         weight=-3.0,
@@ -163,7 +165,7 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             "accel_end": microduck_mdp.SPIN_ACCEL_END,
         },
     )
-    # Amorce 1 : tourner EN ROULEMENT (patins en sens opposés), pas en patinage.
+    # Priming 1: spin BY ROLLING (skates in opposite directions), not by skidding.
     cfg.rewards["spin_wheel_differential"] = RewardTermCfg(
         func=microduck_mdp.spin_wheel_differential,
         weight=1.0,
@@ -173,7 +175,7 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             **_ENVELOPE,
         },
     )
-    # Amorce 2 : ciseau des jambes (décroît par curriculum, voir plus bas).
+    # Priming 2: leg scissor (decayed by curriculum, see below).
     cfg.rewards["leg_antisymmetry"] = RewardTermCfg(
         func=microduck_mdp.leg_antisymmetry,
         weight=1.0,
@@ -183,7 +185,7 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             **_ENVELOPE,
         },
     )
-    # Les deux lames au sol pendant le spin (pas de vrille en l'air).
+    # Both blades on the ground during the spin (no mid-air twist).
     cfg.rewards["spin_grounded"] = RewardTermCfg(
         func=microduck_mdp.spin_grounded,
         weight=0.5,
@@ -193,7 +195,7 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             **_ENVELOPE,
         },
     )
-    # Stabilité / sim2real
+    # Stability / sim2real
     cfg.rewards["feet_flat"] = RewardTermCfg(
         func=microduck_mdp.feet_flat_penalty,
         weight=-2.0,
@@ -242,10 +244,10 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
         )
 
     cfg.events["reset_base"].params["pose_range"]["z"] = (0.1335, 0.1435)
-    # Élan d'entrée : injecté via reset_root_state_uniform (état par défaut PROPRE
-    # + range), et NON via push_by_setting_velocity en mode reset, qui additionne à
-    # une vitesse racine potentiellement divergente et fait exploser le free-joint
-    # de la base -> NaN. Régression connue du roller_crouch.
+    # Entry momentum: injected through reset_root_state_uniform (CLEAN default
+    # state + range), and NOT through push_by_setting_velocity in reset mode,
+    # which adds to a potentially divergent root velocity and blows up the base
+    # free joint -> NaN. Known regression from roller_crouch.
     cfg.events["reset_base"].params["velocity_range"] = {"x": ENTRY_VELOCITY_X}
 
     if ENABLE_WHEEL_FRICTION_RANDOMIZATION:
@@ -371,13 +373,13 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             func=microduck_mdp.zero_command_padding, params={"dim": 6},
         )
 
-    # === COMMAND: phase (comme ground_pick / roller_crouch) ===
+    # === COMMAND: phase (like ground_pick / roller_crouch) ===
     command: UniformVelocityCommandCfg = cfg.commands["twist"]
     command.rel_standing_envs = 0.0
     command.rel_heading_envs = 0.0
-    # period=4.0 = défaut de --ground-pick-period (rien à passer au runtime) ;
-    # randomize_phase=False -> chaque épisode démarre debout à phase 0, comme le
-    # bouton au déploiement. Épisode 20 s = 5 cycles complets du geste.
+    # period=4.0 = the default of --ground-pick-period (nothing to pass at
+    # runtime); randomize_phase=False -> every episode starts standing at phase 0,
+    # like the button at deployment. A 20 s episode = 5 full cycles of the gesture.
     cfg.commands["twist"] = microduck_mdp.GroundPickPhaseCommandCfg(
         **{
             **vars(command),
@@ -404,8 +406,8 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             ],
         },
     )
-    # L'amorce ciseau s'efface : elle lance le bon mécanisme puis laisse la policy
-    # affiner son propre geste (fréquence de pompage libre).
+    # The scissor priming fades out: it launches the right mechanism, then lets
+    # the policy refine its own gesture (free pumping frequency).
     cfg.curriculum["leg_antisym_weight"] = CurriculumTermCfg(
         func=microduck_mdp.reward_weight,
         params={

--- a/src/mjlab_microduck/tasks/microduck_spin_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_spin_env_cfg.py
@@ -140,7 +140,7 @@ def make_microduck_spin_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
         weight=6.0,
         params={"command_name": "twist", "std": 1.5, **_ENVELOPE},
     )
-    # Bootstrap L1 : gradient constant quand la gaussienne sature loin de la cible.
+    # L1 bootstrap: constant gradient when the gaussian saturates far from the target.
     cfg.rewards["spin_rate_l1"] = RewardTermCfg(
         func=microduck_mdp.spin_rate_l1,
         weight=0.5,

--- a/src/mjlab_microduck/tasks/slope_terrain.py
+++ b/src/mjlab_microduck/tasks/slope_terrain.py
@@ -1,8 +1,8 @@
-"""Terrain custom « plat + rampe descendante » pour la tâche roller_slope.
+"""Custom "flat + downhill ramp" terrain for the roller_slope task.
 
-Le robot spawne sur une zone plate, reçoit une impulsion vers +x, roule
-jusqu'à la rampe et se laisse glisser. L'angle de la rampe est interpolé par
-la difficulté (curriculum) sur [RAMP_DEG_MIN, RAMP_DEG_MAX] degrés.
+The robot spawns on a flat area, gets an impulse toward +x, rolls to the ramp
+and lets itself glide. The ramp angle is interpolated by the difficulty
+(curriculum) over [RAMP_DEG_MIN, RAMP_DEG_MAX] degrees.
 """
 
 from __future__ import annotations
@@ -26,31 +26,31 @@ RAMP_DEG_MAX = 20.0
 def ramp_angle_by_difficulty(
     difficulty: float, deg_min: float = RAMP_DEG_MIN, deg_max: float = RAMP_DEG_MAX
 ) -> float:
-    """Angle de rampe (radians) interpolé linéairement par la difficulté [0,1]."""
+    """Ramp angle (radians), linearly interpolated by the difficulty [0,1]."""
     d = float(np.clip(difficulty, 0.0, 1.0))
     return math.radians(deg_min + d * (deg_max - deg_min))
 
 
 @dataclass(kw_only=True)
 class FlatRampTerrainCfg(SubTerrainCfg):
-    """Plat de départ → rampe descendante → plat de sortie.
+    """Starting flat → downhill ramp → flat runout.
 
-    Trois box alignés le long de +x :
-      1. plat de départ (surface à z=0) où le robot spawne ;
-      2. rampe descendante, angle interpolé par la difficulté, longueur
-         HORIZONTALE tirée au hasard dans ``ramp_length_range`` (une valeur par
-         tuile, fixée à la génération) ;
-      3. plat de sortie au niveau du bas de la rampe, pour que le robot
-         atterrisse sur du solide au lieu du vide.
+    Three boxes aligned along +x:
+      1. the starting flat (surface at z=0) where the robot spawns;
+      2. the downhill ramp, angle interpolated by the difficulty, HORIZONTAL
+         length drawn at random from ``ramp_length_range`` (one value per tile,
+         fixed at generation time);
+      3. the flat runout at the level of the bottom of the ramp, so the robot
+         lands on solid ground instead of the void.
     """
 
-    flat_length: float = 2.0                       # plat de départ (m)
-    ramp_length_range: tuple = (3.0, 8.0)          # longueur horizontale rampe (m), tirée au hasard
-    runout_length: float = 4.0                     # plat de sortie en bas (m)
-    spawn_on_ramp: float = 0.3                      # spawn ce nb de m SUR la rampe (gravité => roulement)
+    flat_length: float = 2.0                       # starting flat (m)
+    ramp_length_range: tuple = (3.0, 8.0)          # horizontal ramp length (m), drawn at random
+    runout_length: float = 4.0                     # flat runout at the bottom (m)
+    spawn_on_ramp: float = 0.3                      # spawn this many m ONTO the ramp (gravity => rolling)
     deg_min: float = RAMP_DEG_MIN
     deg_max: float = RAMP_DEG_MAX
-    thickness: float = 0.5                          # épaisseur des box (m)
+    thickness: float = 0.5                          # box thickness (m)
 
     def function(
         self, difficulty: float, spec: mujoco.MjSpec, rng
@@ -63,23 +63,23 @@ class FlatRampTerrainCfg(SubTerrainCfg):
         angle = ramp_angle_by_difficulty(difficulty, self.deg_min, self.deg_max)
         width = self.size[1]
         t = self.thickness
-        # Longueur de rampe tirée au hasard (déterministe pour un rng donné).
+        # Ramp length drawn at random (deterministic for a given rng).
         ramp_length = float(rng.uniform(self.ramp_length_range[0], self.ramp_length_range[1]))
-        drop = ramp_length * math.tan(angle)  # dénivelé (m), positif
+        drop = ramp_length * math.tan(angle)  # elevation drop (m), positive
 
-        # 1) Plat de départ : surface à z=0, x dans [0, flat_length].
+        # 1) Starting flat: surface at z=0, x in [0, flat_length].
         flat = body.add_geom(
             type=mujoco.mjtGeom.mjGEOM_BOX,
             size=(self.flat_length / 2.0, width / 2.0, t / 2.0),
             pos=(self.flat_length / 2.0, 0.0, -t / 2.0),
         )
 
-        # 2) Rampe : box tourné de +angle autour de +y (le bord +x descend).
-        # Décalage -(t/2)·sin(angle) en x : sans lui, le bord HAUT de la surface
-        # inclinée tombe à x=flat_length+(t/2)sin(a) -> petit trou entre la
-        # plateforme plate (finit à flat_length) et la rampe. Avec, le haut de la
-        # rampe touche pile le bord de la plateforme (raccord net), et le bas
-        # touche pile le plat de sortie.
+        # 2) Ramp: box rotated by +angle around +y (the +x edge goes down).
+        # The -(t/2)·sin(angle) offset in x: without it, the TOP edge of the
+        # tilted surface lands at x=flat_length+(t/2)sin(a) -> a small gap between
+        # the flat platform (which ends at flat_length) and the ramp. With it, the
+        # top of the ramp meets the platform edge exactly (clean joint), and the
+        # bottom meets the runout exactly.
         surf_len = ramp_length / math.cos(angle)
         ramp_cx = self.flat_length + ramp_length / 2.0 - (t / 2.0) * math.sin(angle)
         ramp_cz = -(drop / 2.0) - (t / 2.0) * math.cos(angle)
@@ -91,7 +91,7 @@ class FlatRampTerrainCfg(SubTerrainCfg):
             quat=(math.cos(half), 0.0, math.sin(half), 0.0),
         )
 
-        # 3) Plat de sortie : surface au niveau du bas de la rampe (z = -drop).
+        # 3) Flat runout: surface at the level of the bottom of the ramp (z = -drop).
         runout_cx = self.flat_length + ramp_length + self.runout_length / 2.0
         runout = body.add_geom(
             type=mujoco.mjtGeom.mjGEOM_BOX,
@@ -99,9 +99,9 @@ class FlatRampTerrainCfg(SubTerrainCfg):
             pos=(runout_cx, 0.0, -drop - t / 2.0),
         )
 
-        # Spawn un peu SUR la rampe : la gravité fait rouler les roues tout de
-        # suite (élan AUX ROUES, pas de poussée de base qui patinerait), et le
-        # robot est déjà sur la pente. z sur la surface inclinée à cette distance.
+        # Spawn slightly ONTO the ramp: gravity spins the wheels right away
+        # (momentum IN THE WHEELS, not a base push that would skid), and the robot
+        # is already on the slope. z on the tilted surface at that distance.
         spawn_x = self.flat_length + self.spawn_on_ramp
         spawn_z = -self.spawn_on_ramp * math.tan(angle)
         origin = np.array([spawn_x, 0.0, spawn_z])

--- a/tests/test_crouch_glide.py
+++ b/tests/test_crouch_glide.py
@@ -4,60 +4,60 @@ from mjlab_microduck.tasks import mdp
 
 
 def test_crouch_height_target_endpoints_are_high():
-    # phase 0 (début) et phase ~1 (fin) → hauteur haute (debout)
+    # phase 0 (start) and phase ~1 (end) → high stance (standing)
     phase = torch.tensor([0.0, 0.999])
     t = mdp.crouch_height_target(phase, height_low=0.075, height_high=0.11)
     assert torch.allclose(t, torch.tensor([0.11, 0.11]), atol=2e-3)
 
 
 def test_crouch_height_target_plateau_is_low():
-    # tout le palier [0.375, 0.625] → hauteur basse constante
+    # the whole plateau [0.375, 0.625] → constant low height
     phase = torch.tensor([0.375, 0.5, 0.624])
     t = mdp.crouch_height_target(phase, height_low=0.075, height_high=0.11)
     assert torch.allclose(t, torch.full((3,), 0.075), atol=1e-6)
 
 
 def test_crouch_height_target_descent_midpoint():
-    # milieu de la descente (phase = hold_lo/2 = 0.1875) → milieu des deux hauteurs
+    # midway through the descent (phase = hold_lo/2 = 0.1875) → midpoint of the two heights
     phase = torch.tensor([0.1875])
     t = mdp.crouch_height_target(phase, height_low=0.075, height_high=0.11)
     assert torch.allclose(t, torch.tensor([(0.11 + 0.075) / 2]), atol=1e-6)
 
 
 def test_crouch_height_target_rise_midpoint():
-    # milieu de la remontée (phase = 0.8125) → milieu des deux hauteurs
+    # midway through the rise (phase = 0.8125) → midpoint of the two heights
     phase = torch.tensor([0.8125])
     t = mdp.crouch_height_target(phase, height_low=0.075, height_high=0.11)
     assert torch.allclose(t, torch.tensor([(0.11 + 0.075) / 2]), atol=1e-6)
 
 
-# ── crouch_pose_blend : 4 segments (descente / bas / montée / debout) ─────────
-# breakpoints de test : descente [0,0.1), bas [0.1,0.5), montée [0.5,0.6),
-# debout [0.6,1.0).
+# ── crouch_pose_blend: 4 segments (descent / low / rise / standing) ──────────
+# test breakpoints: descent [0,0.1), low [0.1,0.5), rise [0.5,0.6),
+# standing [0.6,1.0).
 _BLEND = dict(descent_end=0.10, hold_end=0.50, rise_end=0.60)
 
 
 def test_blend_zero_standing_at_start_and_top_hold():
-    phase = torch.tensor([0.0, 0.6, 0.8, 0.999])  # début + palier haut
+    phase = torch.tensor([0.0, 0.6, 0.8, 0.999])  # start + high plateau
     b = mdp.crouch_pose_blend(phase, **_BLEND)
     assert torch.allclose(b, torch.zeros(4), atol=1e-6)
 
 
 def test_blend_one_on_low_hold():
-    phase = torch.tensor([0.10, 0.3, 0.499])  # palier bas
+    phase = torch.tensor([0.10, 0.3, 0.499])  # low plateau
     b = mdp.crouch_pose_blend(phase, **_BLEND)
     assert torch.allclose(b, torch.ones(3), atol=1e-6)
 
 
 def test_blend_descent_and_rise_midpoints():
-    # milieu descente (0.05 sur [0,0.1)) → 0.5 ; milieu montée (0.55 sur [0.5,0.6)) → 0.5
+    # descent midpoint (0.05 in [0,0.1)) → 0.5; rise midpoint (0.55 in [0.5,0.6)) → 0.5
     phase = torch.tensor([0.05, 0.55])
     b = mdp.crouch_pose_blend(phase, **_BLEND)
     assert torch.allclose(b, torch.tensor([0.5, 0.5]), atol=1e-6)
 
 
 def test_reward_is_one_when_height_matches_target():
-    # phase 0.5 (plein palier) → cible = height_low ; si com_height == height_low → reward 1
+    # phase 0.5 (full plateau) → target = height_low; if com_height == height_low → reward 1
     cmd_cos = torch.tensor([math.cos(2 * math.pi * 0.5)])  # -1
     cmd_sin = torch.tensor([math.sin(2 * math.pi * 0.5)])  # ~0
     com_height = torch.tensor([0.075])
@@ -68,7 +68,7 @@ def test_reward_is_one_when_height_matches_target():
 
 
 def test_reward_decays_when_off_by_one_std():
-    # à height_low + std de la cible → exp(-1) ≈ 0.368
+    # at height_low + std from the target → exp(-1) ≈ 0.368
     cmd_cos = torch.tensor([math.cos(2 * math.pi * 0.5)])
     cmd_sin = torch.tensor([math.sin(2 * math.pi * 0.5)])
     com_height = torch.tensor([0.075 + 0.02])
@@ -79,12 +79,12 @@ def test_reward_decays_when_off_by_one_std():
 
 
 def test_reward_at_phase_zero_expects_high_stance():
-    # phase 0 → cible = height_high ; rester debout est récompensé, être accroupi non
+    # phase 0 → target = height_high; staying upright is rewarded, crouching is not
     cmd_cos = torch.tensor([1.0, 1.0])   # cos(0)
     cmd_sin = torch.tensor([0.0, 0.0])   # sin(0)
-    com_height = torch.tensor([0.11, 0.075])  # debout vs accroupi
+    com_height = torch.tensor([0.11, 0.075])  # standing vs crouched
     r = mdp.crouch_glide_reward_from_values(
         com_height, cmd_cos, cmd_sin, height_low=0.075, height_high=0.11, std=0.02
     )
-    assert r[0] > 0.99          # debout à phase 0 → ~1
-    assert r[1] < 0.2           # accroupi à phase 0 → faible
+    assert r[0] > 0.99          # standing at phase 0 → ~1
+    assert r[1] < 0.2           # crouched at phase 0 → low

--- a/tests/test_descent_speed.py
+++ b/tests/test_descent_speed.py
@@ -1,5 +1,5 @@
-"""descent_speed_reward : récompense la vitesse d'avance vers le bas de la pente
-(monde +x), plafonnée à `cap`, nulle si le robot recule/remonte, NaN-safe.
+"""descent_speed_reward: rewards forward speed down the slope (world +x),
+capped at `cap`, zero if the robot backs up / climbs, NaN-safe.
 """
 
 import torch
@@ -10,7 +10,7 @@ from mjlab_microduck.tasks.mdp import descent_speed_reward
 class _Data:
     def __init__(self, vx):
         self.root_link_lin_vel_w = torch.tensor(vx, dtype=torch.float32).reshape(-1, 1).repeat(1, 3)
-        # seule la colonne 0 (x) est lue ; on met vx en x
+        # only column 0 (x) is read; we put vx in x
         self.root_link_lin_vel_w[:, 0] = torch.tensor(vx, dtype=torch.float32)
 
 

--- a/tests/test_ground_pick_cfg.py
+++ b/tests/test_ground_pick_cfg.py
@@ -5,35 +5,35 @@ from mjlab_microduck.tasks.mdp import GroundPickPhaseCommand
 
 
 def test_ground_pick_cfg_task_space_rewards():
-    """Objectif espace-tâche : bouche près du sol (sans toucher) + orientée."""
+    """Task-space objective: mouth close to the ground (without touching) + oriented."""
     cfg = make_microduck_ground_pick_env_cfg()
     r = cfg.rewards
-    # proximité bouche->sol (tire vers le bas)
+    # mouth->ground proximity (pulls downward)
     assert "mouth_ground_proximity" in r
     assert r["mouth_ground_proximity"].weight == 3.0
     assert r["mouth_ground_proximity"].params["target_height"] == 0.0
-    # orientation bouche vers le bas
+    # mouth oriented downward
     assert "mouth_perpendicular_to_ground" in r
     assert r["mouth_perpendicular_to_ground"].weight == 2.0
-    # no-touch : pénalité de contact forte + seuil bas
+    # no-touch: strong contact penalty + low threshold
     assert "head_impact_penalty" in r
     assert r["head_impact_penalty"].weight == -2.0
     assert r["head_impact_penalty"].params["threshold"] == 1.0
-    # pieds au sol ET à plat (anti-bascule sur la cheville)
+    # feet on the ground AND flat (anti-roll over the ankle)
     assert "feet_grounded" in r and r["feet_grounded"].weight == 3.0
     assert "feet_flat" in r and r["feet_flat"].weight == -2.0
-    # retour debout + aide au relever (upright gaté sur la remontée)
+    # return to standing + rise assist (upright gated on the rise)
     assert "ground_pick_return_pose_legs" in r
     assert "ground_pick_return_pose_neck" in r
     assert "return_upright" in r and r["return_upright"].weight == 4.0
-    # plus d'approche par pose interpolée
+    # no more interpolated-pose approach
     assert "phase_pose_track_head" not in r
     assert "phase_pose_track_legs" not in r
 
 
 def test_ground_pick_mouth_payload_wired():
     cfg = make_microduck_ground_pick_env_cfg()
-    # hook d'application (poids 0) + event de tirage du payload
+    # application hook (weight 0) + payload-sampling event
     assert "mouth_payload_force" in cfg.rewards
     assert cfg.rewards["mouth_payload_force"].weight == 0.0
     assert "sample_mouth_payload" in cfg.events

--- a/tests/test_ground_pick_pose.py
+++ b/tests/test_ground_pick_pose.py
@@ -32,7 +32,7 @@ class _FakeAsset:
         self.data = _FakeData(joint_pos, default_pos)
 
     def find_joints(self, query):
-        # mjlab renvoie (ids, names) ; on ne gère que la requête [name]
+        # mjlab returns (ids, names); we only handle the [name] query form
         (name,) = query
         return ([self._ids[name]], [name])
 
@@ -57,7 +57,7 @@ class _FakeEnv:
 
 NAMES = ["j0", "j1"]
 DOWN = {"j0": 1.0, "j1": -1.0}
-# HOME (STAND source) = 0 pour les deux joints
+# HOME (STAND source) = 0 for both joints
 HOME = torch.tensor([[0.0, 0.0]])
 
 
@@ -66,7 +66,7 @@ def _env(cur, phase):
 
 
 def test_phase_pose_track_perfect_at_down():
-    # phase 0.30 -> blend 1 -> cible = DOWN ; cur == DOWN -> gaussienne 1, l1 0
+    # phase 0.30 -> blend 1 -> target = DOWN; cur == DOWN -> gaussian 1, l1 0
     from mjlab.managers.scene_entity_config import SceneEntityCfg
     cfg = SceneEntityCfg("robot")
     env = _env([1.0, -1.0], phase=0.30)
@@ -78,7 +78,7 @@ def test_phase_pose_track_perfect_at_down():
 
 
 def test_phase_pose_track_l1_at_home_when_down_target():
-    # phase 0.30 -> cible DOWN=[1,-1] ; cur=HOME=[0,0] -> l1 = -mean(|1|,|1|) = -1
+    # phase 0.30 -> target DOWN=[1,-1]; cur=HOME=[0,0] -> l1 = -mean(|1|,|1|) = -1
     from mjlab.managers.scene_entity_config import SceneEntityCfg
     cfg = SceneEntityCfg("robot")
     env = _env([0.0, 0.0], phase=0.30)
@@ -87,7 +87,7 @@ def test_phase_pose_track_l1_at_home_when_down_target():
 
 
 def test_phase_pose_track_returns_to_stand():
-    # phase 0.80 -> blend 0 -> cible = HOME ; cur=HOME -> gaussienne 1
+    # phase 0.80 -> blend 0 -> target = HOME; cur=HOME -> gaussian 1
     from mjlab.managers.scene_entity_config import SceneEntityCfg
     cfg = SceneEntityCfg("robot")
     env = _env([0.0, 0.0], phase=0.80)
@@ -109,9 +109,9 @@ def test_phase_pose_track_affine_interpolation_nonzero_home():
 def test_ground_pick_cmd_cfg_has_randomize_phase_default_true():
     from mjlab_microduck.tasks.mdp import GroundPickPhaseCommandCfg
     from mjlab.tasks.velocity.mdp import UniformVelocityCommandCfg
-    # construit une cfg minimale en copiant une cfg velocity par défaut
-    # NOTE: adapté de `asset_name` (brief) -> `entity_name` (API locale de
-    # UniformVelocityCommandCfg, qui n'a pas de champ `asset_name`).
+    # build a minimal cfg by copying a default velocity cfg
+    # NOTE: adapted from `asset_name` (in the brief) -> `entity_name` (the local
+    # UniformVelocityCommandCfg API, which has no `asset_name` field).
     base = UniformVelocityCommandCfg(
         entity_name="robot", resampling_time_range=(10.0, 10.0),
         ranges=UniformVelocityCommandCfg.Ranges(

--- a/tests/test_nan_guard.py
+++ b/tests/test_nan_guard.py
@@ -1,7 +1,7 @@
-"""robot_state_is_nan doit attraper un état non-fini n'importe où (joints OU base
-OU roues), pas seulement dans joint_pos — sinon un free-joint qui diverge en NaN
-échappe au reset et corrompt l'obs critic (base_lin_vel/wheel_vel), ce qui tue
-l'entraînement via le check_nan global de rsl_rl.
+"""robot_state_is_nan must catch a non-finite state anywhere (joints OR base OR
+wheels), not just in joint_pos — otherwise a free joint that diverges to NaN
+escapes the reset and corrupts the critic obs (base_lin_vel/wheel_vel), which
+kills training through rsl_rl's global check_nan.
 """
 
 import torch
@@ -38,7 +38,7 @@ class _Env:
 
 
 def test_catches_base_linear_velocity_nan():
-    # env 1 : vitesse de base NaN (free-joint divergé) — joint_pos reste fini.
+    # env 1: NaN base velocity (diverged free joint) — joint_pos stays finite.
     d = _Data(3)
     d.root_link_lin_vel_w[1, 0] = float("nan")
     out = robot_state_is_nan(_Env(d))
@@ -46,7 +46,7 @@ def test_catches_base_linear_velocity_nan():
 
 
 def test_catches_base_velocity_inf():
-    # inf dans la vitesse angulaire de base (avant qu'il ne devienne NaN).
+    # inf in the base angular velocity (before it turns into NaN).
     d = _Data(2)
     d.root_link_ang_vel_w[0, 2] = float("inf")
     out = robot_state_is_nan(_Env(d))
@@ -54,7 +54,7 @@ def test_catches_base_velocity_inf():
 
 
 def test_still_catches_joint_pos_nan():
-    # comportement historique préservé.
+    # historical behavior preserved.
     d = _Data(2)
     d.joint_pos[0, 1] = float("nan")
     out = robot_state_is_nan(_Env(d))

--- a/tests/test_roller_crouch_cfg.py
+++ b/tests/test_roller_crouch_cfg.py
@@ -21,13 +21,13 @@ def test_cfg_has_crouch_and_forward_rewards():
     assert "crouch_glide_pose" in cfg.rewards
     assert "crouch_glide_pose_l1" in cfg.rewards
     assert "forward_speed" in cfg.rewards
-    # léger penché avant pendant l'accroupi (cible positive = vers l'avant)
+    # slight forward lean during the crouch (positive target = forward)
     assert "crouch_forward_lean" in cfg.rewards
     assert cfg.rewards["crouch_forward_lean"].params["target_pitch"] > 0.0
     # the crouch pose is carried by-name and includes the leg fold
     cp = cfg.rewards["crouch_glide_pose"].params["crouch_pose"]
     assert "left_knee" in cp and "right_knee" in cp
-    # rewards de patinage actif retirées (pas de stride pendant le trick)
+    # active skating rewards removed (no stride during the trick)
     for gone in ("braking", "skating_air_time", "single_support", "glide", "wheel_speed"):
         assert gone not in cfg.rewards
 

--- a/tests/test_roller_slope_cfg.py
+++ b/tests/test_roller_slope_cfg.py
@@ -24,9 +24,9 @@ def test_command_is_neutralised():
 
 
 def test_rolling_entry_no_base_push():
-    # élan donné en ROULEMENT (reset_rolling_entry), pas en poussée de base
-    # (base seule + roues immobiles = à-coup de patinage). Donc reset_base ne
-    # met aucune vitesse de base.
+    # momentum given as ROLLING (reset_rolling_entry), not as a base push (base
+    # alone + stationary wheels = skidding jolt). So reset_base sets no base
+    # velocity at all.
     cfg = make_microduck_roller_slope_env_cfg()
     assert cfg.events["reset_base"].params["velocity_range"] == {}
     assert "reset_rolling_entry" in cfg.events
@@ -35,15 +35,15 @@ def test_rolling_entry_no_base_push():
 
 
 def test_has_heading_hold_reward():
-    # aller droit : maintien du yaw de spawn
+    # go straight: hold the spawn yaw
     cfg = make_microduck_roller_slope_env_cfg()
     assert "heading_hold" in cfg.rewards
     assert cfg.rewards["heading_hold"].weight > 0.0
 
 
 def test_balance_rewards_no_fixed_pose():
-    # équilibre libre : upright/alive/glisse présents, mais PAS de pose fixe
-    # imposée (il doit pouvoir bouger son centre de gravité pour tenir la pente).
+    # free balance: upright/alive/glide present, but NO imposed fixed pose (it
+    # must be able to move its center of gravity to hold the slope).
     cfg = make_microduck_roller_slope_env_cfg()
     for name in ("upright", "alive", "feet_flat", "wheel_glide", "neck_joint_pos_l2"):
         assert name in cfg.rewards
@@ -52,8 +52,8 @@ def test_balance_rewards_no_fixed_pose():
 
 
 def test_has_wheel_glide_reward_not_base_speed():
-    # "se laisser glisser" = rouler (roues), pas récompenser la vitesse de base
-    # (qu'il atteignait en courant). wheel_glide présent, descent_speed absent.
+    # "letting itself glide" = rolling (wheels), not rewarding base speed (which
+    # it reached by running). wheel_glide present, descent_speed absent.
     cfg = make_microduck_roller_slope_env_cfg()
     assert "wheel_glide" in cfg.rewards
     assert cfg.rewards["wheel_glide"].weight > 0.0
@@ -61,15 +61,15 @@ def test_has_wheel_glide_reward_not_base_speed():
 
 
 def test_no_roller_skating_rewards_survive():
-    # les rewards de PATINAGE du roller ne doivent pas survivre (heading_hold est
-    # ré-ajouté volontairement pour aller droit, donc pas dans cette liste).
+    # the roller's SKATING rewards must not survive (heading_hold is deliberately
+    # re-added to go straight, hence not in this list).
     cfg = make_microduck_roller_slope_env_cfg()
     for name in ("wheel_speed", "braking", "skating_air_time", "glide", "forward_lean"):
         assert name not in cfg.rewards
 
 
 def test_spawn_yaw_faces_downhill():
-    # yaw fixe à 0 : toujours face au bas de la pente (+x), pas le -pi/+pi hérité
+    # yaw fixed at 0: always facing downhill (+x), not the inherited -pi/+pi
     cfg = make_microduck_roller_slope_env_cfg()
     assert cfg.events["reset_base"].params["pose_range"]["yaw"] == (0.0, 0.0)
 
@@ -78,27 +78,27 @@ def test_void_termination_present_no_edge_termination():
     cfg = make_microduck_roller_slope_env_cfg()
     assert "fell_into_void" in cfg.terminations
     assert "fell_over" in cfg.terminations
-    # plus de terminaison « bord de terrain » (remplacée par le plat de sortie)
+    # no more "terrain edge" termination (replaced by the flat runout)
     assert "reached_bottom" not in cfg.terminations
     assert "out_of_terrain_bounds" not in cfg.terminations
 
 
 def test_obs_nan_policy_sanitize():
-    # obs assainies : un NaN de contact rare ne doit pas tuer l'entraînement
+    # sanitized obs: a rare contact NaN must not kill training
     cfg = make_microduck_roller_slope_env_cfg()
     assert cfg.observations["actor"].nan_policy == "sanitize"
     assert cfg.observations["critic"].nan_policy == "sanitize"
 
 
 def test_curriculum_present_and_starts_gentle():
-    # curriculum doux->raide : démarre sur la rampe la plus douce, promotion active
-    cfg = make_microduck_roller_slope_env_cfg()  # play=False (entraînement)
+    # gentle->steep curriculum: starts on the gentlest ramp, promotion enabled
+    cfg = make_microduck_roller_slope_env_cfg()  # play=False (training)
     assert "terrain_levels" in cfg.curriculum
     assert cfg.scene.terrain.max_init_terrain_level == 0
 
 
 def test_terrain_tile_fits_geometry():
-    # la tuile doit contenir plat + rampe_max + sortie
+    # the tile must fit flat + ramp_max + runout
     cfg = make_microduck_roller_slope_env_cfg()
     gen = cfg.scene.terrain.terrain_generator
     st = next(iter(gen.sub_terrains.values()))

--- a/tests/test_roller_standup_cfg.py
+++ b/tests/test_roller_standup_cfg.py
@@ -8,7 +8,7 @@ from mjlab_microduck.tasks.microduck_velocity_rollers_env_cfg import (
     make_microduck_velocity_rollers_env_cfg,
 )
 
-# Récompenses de PATINAGE : elles ne doivent pas survivre dans un env de relevé.
+# SKATING rewards: they must not survive in a standup env.
 SKATING_REWARDS = (
     "wheel_speed",
     "braking",
@@ -32,7 +32,7 @@ def test_env_builds_train_and_play():
 
 
 def test_episode_is_short():
-    # Épisode court : monter puis stabiliser, comme standup (6 s).
+    # Short episode: rise then stabilize, like standup (6 s).
     cfg = make_microduck_roller_standup_env_cfg()
     assert cfg.episode_length_s == EPISODE_LENGTH_S == 6.0
 
@@ -40,12 +40,12 @@ def test_episode_is_short():
 def test_no_skating_rewards_survive():
     cfg = make_microduck_roller_standup_env_cfg()
     for name in SKATING_REWARDS:
-        assert name not in cfg.rewards, f"reward de patinage survivante : {name}"
+        assert name not in cfg.rewards, f"skating reward survived: {name}"
 
 
 def test_smoothness_regularisers_kept():
-    # Gardées de l'héritage roller : le relevé a besoin de douceur sim2real, mais
-    # body_ang_vel doit rester LÉGER (standup documente qu'à -0.15 il gelait).
+    # Kept from the roller inheritance: the standup needs sim2real smoothness, but
+    # body_ang_vel must stay LIGHT (standup documents that it froze at -0.15).
     cfg = make_microduck_roller_standup_env_cfg()
     for name in (
         "action_over_limit",
@@ -57,13 +57,13 @@ def test_smoothness_regularisers_kept():
         "neck_joint_pos_l2",
         "joint_torques_l2",
     ):
-        assert name in cfg.rewards, f"régularisateur perdu : {name}"
+        assert name in cfg.rewards, f"regularizer lost: {name}"
     assert cfg.rewards["body_ang_vel"].weight == -0.05
 
 
 def test_twist_command_is_neutralised():
-    # Pas de pilotage : la policy se déploie en --standing, où le runtime laisse
-    # le slot twist à zéro (cf. infer_policy.py:239).
+    # No steering: the policy deploys in --standing, where the runtime leaves the
+    # twist slot at zero (cf. infer_policy.py:239).
     cfg = make_microduck_roller_standup_env_cfg()
     cmd = cfg.commands["twist"]
     assert cmd.ranges.lin_vel_x == (-0.01, 0.01)
@@ -75,8 +75,8 @@ def test_twist_command_is_neutralised():
 
 
 def test_twist_command_is_not_heading_relative():
-    # L'env roller installe un RelativeHeadingVelocityCommandCfg (cmd[2] = erreur
-    # de cap, calculée en interne). Ici cmd[2] doit être un vrai zéro bruité.
+    # The roller env installs a RelativeHeadingVelocityCommandCfg (cmd[2] =
+    # heading error, computed internally). Here cmd[2] must be a real noisy zero.
     from mjlab_microduck.tasks import mdp as microduck_mdp
 
     cfg = make_microduck_roller_standup_env_cfg()
@@ -86,26 +86,26 @@ def test_twist_command_is_not_heading_relative():
 
 
 def test_obs_nan_policy_sanitize():
-    # Un contact rare fait diverger le free-joint en NaN : on assainit l'obs
-    # plutôt que de tuer l'entraînement (même choix que roller_slope).
+    # A rare contact makes the free joint diverge to NaN: we sanitize the obs
+    # rather than kill training (same choice as roller_slope).
     cfg = make_microduck_roller_standup_env_cfg()
     assert cfg.observations["actor"].nan_policy == "sanitize"
     assert cfg.observations["critic"].nan_policy == "sanitize"
 
 
 def test_obs_parity_with_roller_env():
-    # Parité 61D obligatoire : sinon l'ONNX ne se charge pas dans un slot runtime.
+    # 61D parity is mandatory: otherwise the ONNX will not load in a runtime slot.
     standup = make_microduck_roller_standup_env_cfg()
     roller = make_microduck_velocity_rollers_env_cfg()
     for grp in ("actor", "critic"):
         assert list(standup.observations[grp].terms.keys()) == list(
             roller.observations[grp].terms.keys()
-        ), f"layout d'observation divergent sur le groupe {grp}"
+        ), f"observation layout diverged on group {grp}"
 
 
 def test_terrain_is_plain_plane():
-    # Hérité de l'env roller : sol plat, pas de générateur. Pas de variante rough
-    # pour cette v1.
+    # Inherited from the roller env: flat ground, no generator. No rough variant
+    # for this v1.
     cfg = make_microduck_roller_standup_env_cfg()
     assert cfg.scene.terrain.terrain_type == "plane"
     assert cfg.scene.terrain.terrain_generator is None
@@ -114,17 +114,17 @@ def test_terrain_is_plain_plane():
 def test_task_is_registered():
     from mjlab.tasks.registry import list_tasks
 
-    import mjlab_microduck.tasks  # noqa: F401  (l'import déclenche l'enregistrement)
+    import mjlab_microduck.tasks  # noqa: F401  (the import triggers registration)
 
     assert "Mjlab-RollerStandUp-Flat-MicroDuck" in list_tasks()
 
 
 def test_joint_indices_match_actual_roller_model():
-    """Verrou : les roues passives sont intercalées dans l'ordre des joints.
+    """Lock-in: the passive wheels are interleaved in the joint ordering.
 
-    Réutiliser les indices du standup ([0-4, 9-13]) donnerait des récompenses
-    qui pointent sur des roues. Ce test compile le vrai MjSpec du robot rollers
-    et vérifie les noms aux indices utilisés. Pur CPU, pas de sim.
+    Reusing standup's indices ([0-4, 9-13]) would give rewards that point at
+    wheels. This test compiles the real MjSpec of the roller robot and checks the
+    names at the indices used. Pure CPU, no sim.
     """
     import mujoco
 
@@ -152,7 +152,7 @@ def test_joint_indices_match_actual_roller_model():
     assert [articulated[i] for i in _WHEEL_JOINTS] == [
         "passive_LF_wheel", "passive_LR_wheel", "passive_RF_wheel", "passive_RR_wheel",
     ]
-    # Aucun recouvrement, et les trois listes couvrent tous les joints.
+    # No overlap, and the three lists cover every joint.
     assert len(set(_LEG_JOINTS) | set(_NECK_JOINTS) | set(_WHEEL_JOINTS)) == len(articulated)
 
 
@@ -165,21 +165,21 @@ def test_recovery_rewards_present_with_expected_weights():
         "height_stand_sharp":   4.0,
         "height_stand_l1":     30.0,
         "com_upward_velocity":  3.0,
-        # gentle_rise : poids POSITIF. trunk_vertical_accel_penalty renvoie déjà
-        # -|a_z|, donc un poids négatif en faisait une RÉCOMPENSE de la violence
-        # (bug mesuré : Episode_Reward/gentle_rise loggée à +0.0118).
+        # gentle_rise: POSITIVE weight. trunk_vertical_accel_penalty already
+        # returns -|a_z|, so a negative weight turned it into a REWARD for
+        # violence (measured bug: Episode_Reward/gentle_rise logged at +0.0118).
         "gentle_rise":         +0.02,
         "upright_linear":       6.0,
         "upright_sharp":        6.0,
         "standing_composite":  15.0,
-        # -2e-3 ne contribuait que -0.0002/pas face à +41.6 de tâche : nul.
-        # -2.0 a mesuré -0.255/pas (run d8rnko6p) — pas le gel, mais on redescend
-        # à -0.2 pour dégager le budget d'amortissement pendant qu'on isole.
+        # -2e-3 contributed only -0.0002/step against +41.6 of task reward: nil.
+        # -2.0 measured -0.255/step (run d8rnko6p) — not the freeze, but we drop
+        # back to -0.2 to free up the damping budget while we isolate it.
         "joint_torque_rate_l2": -0.2,
     }
     for name, weight in expected.items():
-        assert name in cfg.rewards, f"récompense de relevé manquante : {name}"
-        assert cfg.rewards[name].weight == weight, f"poids inattendu sur {name}"
+        assert name in cfg.rewards, f"missing standup reward: {name}"
+        assert cfg.rewards[name].weight == weight, f"unexpected weight on {name}"
 
 
 def test_recovery_rewards_use_roller_heights_not_walker_heights():
@@ -189,14 +189,14 @@ def test_recovery_rewards_use_roller_heights_not_walker_heights():
     )
 
     cfg = make_microduck_roller_standup_env_cfg()
-    assert ROLLER_STAND_Z == 0.138  # PAS le 0.115 du modèle sans roues
+    assert ROLLER_STAND_Z == 0.138  # NOT the 0.115 of the model without wheels
     for name in ("height_stand", "height_stand_sharp", "height_stand_l1"):
         assert cfg.rewards[name].params["target_height"] == ROLLER_STAND_Z
     assert cfg.rewards["standing_composite"].params["target_height"] == ROLLER_STAND_Z
-    # com_upward_velocity se coupe juste AU-DESSUS de la cible (10 mm de marge),
-    # sinon la policy se gare à l'altitude de coupure sans finir la montée.
+    # com_upward_velocity cuts off just ABOVE the target (10 mm of margin),
+    # otherwise the policy parks at the cutoff altitude without finishing the rise.
     assert cfg.rewards["com_upward_velocity"].params["max_height"] == ROLLER_STAND_Z + 0.010
-    # upright_sharp est gatée entre le repos au sol et la station debout.
+    # upright_sharp is gated between the ground rest height and the standing height.
     assert cfg.rewards["upright_sharp"].params["height_low"] == ROLLER_PRONE_Z
     assert cfg.rewards["upright_sharp"].params["height_high"] == ROLLER_STAND_Z
 
@@ -207,13 +207,13 @@ def test_pose_rewards_target_legs_only_at_roller_indices():
     cfg = make_microduck_roller_standup_env_cfg()
     for name in ("pose_stand_legs", "pose_stand_l1", "standing_composite"):
         assert cfg.rewards[name].params["joint_indices"] == _LEG_JOINTS
-        # target_overrides=None → la cible est HOME (default_joint_pos).
+        # target_overrides=None → the target is HOME (default_joint_pos).
         assert cfg.rewards[name].params["target_overrides"] is None
 
 
 def test_trunk_asset_cfgs_are_distinct_objects():
-    """mjlab résout et MUTE les SceneEntityCfg en place : un objet partagé entre
-    plusieurs termes provoque des indices périmés. Chaque terme doit avoir le sien.
+    """mjlab resolves and MUTATES SceneEntityCfg in place: an object shared across
+    several terms causes stale indices. Each term must have its own.
     """
     cfg = make_microduck_roller_standup_env_cfg()
     names = (
@@ -222,13 +222,13 @@ def test_trunk_asset_cfgs_are_distinct_objects():
         "upright_sharp", "standing_composite",
     )
     seen = [id(cfg.rewards[n].params["asset_cfg"]) for n in names]
-    assert len(set(seen)) == len(seen), "asset_cfg partagé entre plusieurs termes"
+    assert len(set(seen)) == len(seen), "asset_cfg shared across several terms"
 
 
 def test_starts_from_ground_states():
-    # Ventre + dos + debout. Pas de bucket "assis" : il n'existait dans standup
-    # que pour le hand-off depuis la policy sit, dont il n'y a pas d'équivalent
-    # roller — et ses sitting_joint_overrides sont des indices du modèle SANS roues.
+    # Face down + face up + standing. No "sitting" bucket: in standup it existed
+    # only for the hand-off from the sit policy, which has no roller equivalent —
+    # and its sitting_joint_overrides are indices of the model WITHOUT wheels.
     cfg = make_microduck_roller_standup_env_cfg()
     assert "set_ground_state" in cfg.events
     params = cfg.events["set_ground_state"].params
@@ -236,30 +236,30 @@ def test_starts_from_ground_states():
     assert params["sitting_joint_overrides"] is None
     assert params["face_down_prob"] > 0.0
     assert params["standing_prob"] > 0.0
-    # face_up (le dos) démarre à 0 : introduit tard par le curriculum.
+    # face_up starts at 0: introduced late by the curriculum.
     assert params["face_up_prob"] == 0.0
 
 
 def test_ground_state_heights_are_roller_specific():
     cfg = make_microduck_roller_standup_env_cfg()
     params = cfg.events["set_ground_state"].params
-    # Ventre et dos partagent une seule plage de z, mais leurs contacts diffèrent :
-    # le ventre ne décolle du sol qu'à partir de 0.0752, le dos repose à 0.0475.
-    # prone_z_min = 0.076 pour éliminer toute interpénétration côté ventre.
+    # Face down and face up share a single z range, but their contacts differ:
+    # face down only clears the ground from 0.0752 up, face up rests at 0.0475.
+    # prone_z_min = 0.076 to eliminate any interpenetration on the face-down side.
     assert (params["prone_z_min"], params["prone_z_max"]) == (0.076, 0.09)
-    # Sous 0.0752 (contact mesuré, pose HOME), le départ ventre commence DANS le
-    # sol — un pushout de contact que la policy paierait via gentle_rise /
-    # joint_torque_rate_l2. prone_z_min doit rester au-dessus.
+    # Below 0.0752 (measured contact, HOME pose), a face-down start begins INSIDE
+    # the ground — a contact pushout the policy would pay for through gentle_rise /
+    # joint_torque_rate_l2. prone_z_min must stay above it.
     assert params["prone_z_min"] >= 0.0752
-    # Debout : hauteur ROLLER (+23 mm vs le modèle sans roues, qui est à 0.11–0.12).
+    # Standing: ROLLER height (+23 mm vs the model without wheels, at 0.11–0.12).
     assert params["standing_z_min"] == 0.134
     assert params["standing_z_max"] == 0.144
     assert params["standing_z_min"] < 0.138 < params["standing_z_max"]
 
 
 def test_ground_state_event_runs_after_base_reset():
-    # set_ground_state écrase la pose posée par reset_base / reset_robot_joints :
-    # l'ordre des événements suit l'ordre d'insertion, il doit donc venir APRÈS.
+    # set_ground_state overwrites the pose set by reset_base / reset_robot_joints:
+    # event order follows insertion order, so it must come AFTER them.
     cfg = make_microduck_roller_standup_env_cfg()
     order = list(cfg.events.keys())
     assert order.index("set_ground_state") > order.index("reset_base")
@@ -267,8 +267,8 @@ def test_ground_state_event_runs_after_base_reset():
 
 
 def test_no_fall_termination():
-    # Le robot DÉMARRE tombé : une terminaison sur inclinaison tuerait l'épisode
-    # au premier pas. nan_state (hérité) reste, lui.
+    # The robot STARTS fallen: a tilt termination would kill the episode on the
+    # first step. nan_state (inherited) does stay.
     cfg = make_microduck_roller_standup_env_cfg()
     assert "fell_over" not in cfg.terminations
     assert "nan_state" in cfg.terminations
@@ -279,16 +279,17 @@ def test_ground_state_curriculum_ramps_easy_to_hard():
     assert "ground_state_mix" in cfg.curriculum
     stages = cfg.curriculum["ground_state_mix"].params["param_stages"]
     assert cfg.curriculum["ground_state_mix"].params["event_name"] == "set_ground_state"
-    # Les steps sont croissants et démarrent à 0.
+    # The steps are increasing and start at 0.
     steps = [s["step"] for s in stages]
     assert steps[0] == 0 and steps == sorted(steps) and len(set(steps)) == len(steps)
-    # Le dos (face_up) est introduit tard puis croît de façon monotone.
+    # face_up is introduced late and then grows monotonically.
     face_up = [s["params"]["face_up_prob"] for s in stages]
     assert face_up[0] == 0.0
     assert face_up == sorted(face_up)
     assert face_up[-1] >= 0.35
-    # Chaque palier est une distribution valide, et le "déjà debout" ne disparaît
-    # jamais (sinon la policy se relève puis retombe faute d'apprendre à tenir).
+    # Every stage is a valid distribution, and "already standing" never
+    # disappears (otherwise the policy stands up then falls back, never learning
+    # to hold).
     for stage in stages:
         p = stage["params"]
         total = (
@@ -301,12 +302,12 @@ def test_ground_state_curriculum_ramps_easy_to_hard():
 
 
 def test_wheel_friction_curriculum_is_decreasing():
-    """La pièce nouvelle : roues FREINÉES → LIBRES.
+    """The new piece: BRAKED → FREE wheels.
 
-    Les roues roulent, donc il n'y a aucune adhérence longitudinale pour pousser
-    sur le sol. On bootstrappe avec des roulements quasi bloqués (le relevé se
-    fait comme avec des pieds) puis on rampe vers la vraie valeur. L'env roller,
-    lui, fait MONTER cette friction (0 → 0.0015) : le sens est bien inversé ici.
+    The wheels roll, so there is no longitudinal traction to push against the
+    ground. We bootstrap with near-locked bearings (the rise happens as if on
+    feet), then ramp toward the real value. The roller env, by contrast, ramps
+    this friction UP (0 → 0.0015): the direction really is reversed here.
     """
     cfg = make_microduck_roller_standup_env_cfg()
     stages = cfg.curriculum["wheel_friction"].params["ranges_stages"]
@@ -316,30 +317,29 @@ def test_wheel_friction_curriculum_is_decreasing():
     assert steps[0] == 0 and steps == sorted(steps) and len(set(steps)) == len(steps)
 
     lows = [s["ranges"][0] for s in stages]
-    assert lows == sorted(lows, reverse=True), "la friction doit DÉCROÎTRE"
-    assert lows[0] >= 0.02, "départ franchement freiné pour bootstrapper le geste"
-    # Arrivée sur la vraie valeur du roulement (celle de l'env roller).
+    assert lows == sorted(lows, reverse=True), "friction must DECREASE"
+    assert lows[0] >= 0.02, "start clearly braked to bootstrap the gesture"
+    # Ends at the real rolling value (the roller env's).
     assert stages[-1]["ranges"] == (0.0015, 0.0015)
     for stage in stages:
         assert stage["ranges"][0] == stage["ranges"][1]
 
 
 def test_wheel_friction_event_default_matches_stage_zero():
-    # Le curriculum manager tourne AVANT les événements de reset à chaque reset
-    # (y compris le tout premier), et wheel_friction_curriculum défaut lui-même
-    # sur le palier 0 : cette valeur par défaut de l'événement n'est donc jamais
-    # lue en pratique. On vérifie juste qu'elle reste cohérente avec le palier 0
-    # du curriculum — redondance défensive utile si le curriculum disparaît un
-    # jour en laissant l'événement en place.
+    # The curriculum manager runs BEFORE the reset events on every reset
+    # (including the very first), and wheel_friction_curriculum itself defaults to
+    # stage 0: this event default is therefore never read in practice. We just
+    # check it stays consistent with the curriculum's stage 0 — defensive
+    # redundancy, useful if the curriculum ever disappears while the event stays.
     cfg = make_microduck_roller_standup_env_cfg()
     stage0 = cfg.curriculum["wheel_friction"].params["ranges_stages"][0]["ranges"]
     assert cfg.events["randomize_wheel_friction"].params["ranges"] == stage0
 
 
 def test_action_rate_ramp_is_the_standup_one_not_the_roller_one():
-    # L'env roller monte à -2.0 (gait calme) : c'est un bloqueur de mouvement,
-    # il ralentit l'action rapide dont le relevé depuis le dos a besoin. On
-    # reprend la rampe du standup, qui plafonne à -1.0.
+    # The roller env ramps to -2.0 (calm gait): that is a motion blocker, it slows
+    # the fast action the rise from the back needs. We reuse standup's ramp, which
+    # tops out at -1.0.
     cfg = make_microduck_roller_standup_env_cfg()
     weights = [
         s["weight"] for s in cfg.curriculum["action_rate_weight"].params["weight_stages"]
@@ -349,8 +349,8 @@ def test_action_rate_ramp_is_the_standup_one_not_the_roller_one():
 
 
 def test_push_curriculum_ramps_from_zero():
-    # Poussées héritées (±0.2 m/s), mais rampées : une bourrade dès le pas 0
-    # parasite le bootstrap du relevé.
+    # Inherited pushes (±0.2 m/s), but ramped: a shove from step 0 disturbs the
+    # bootstrap of the rise.
     cfg = make_microduck_roller_standup_env_cfg()
     assert "push_robot" in cfg.events
     stages = cfg.curriculum["push_magnitude"].params["push_stages"]
@@ -358,14 +358,14 @@ def test_push_curriculum_ramps_from_zero():
     assert stages[0]["velocity_range"]["x"] == (0.0, 0.0)
     assert stages[-1]["velocity_range"]["x"] == (-0.2, 0.2)
     highs = [s["velocity_range"]["x"][1] for s in stages]
-    assert highs == sorted(highs), "la poussée doit CROÎTRE"
+    assert highs == sorted(highs), "the push must GROW"
 
 
 def test_inherited_dr_curricula_survive():
-    # La DR héritée de l'env roller ne doit pas avoir été perdue en chemin.
+    # The DR inherited from the roller env must not have been lost along the way.
     cfg = make_microduck_roller_standup_env_cfg()
     for name in ("com_range", "head_com_range"):
-        assert name in cfg.curriculum, f"curriculum de DR perdu : {name}"
+        assert name in cfg.curriculum, f"DR curriculum lost: {name}"
     for name in (
         "randomize_com",
         "randomize_head_com",
@@ -375,15 +375,15 @@ def test_inherited_dr_curricula_survive():
         "randomize_wheel_friction",
         "encoder_bias",
     ):
-        assert name in cfg.events, f"événement de DR perdu : {name}"
+        assert name in cfg.events, f"DR event lost: {name}"
 
 
-# ── Override de play : forcer les départs sur le dos ──────────────────────────
-# Sans override, un play ne montre JAMAIS de départ sur le dos : l'env de play est
-# reconstruit à neuf, donc common_step_counter repart à 0 et le curriculum applique
-# son palier 0, où face_up_prob = 0. Or c'est justement le cas le plus dur, celui
-# qu'on veut inspecter à l'œil. STANDUP_PLAY_FACE_UP force le mélange, sur le
-# modèle de SLOPE_PLAY_DIFFICULTY dans roller_slope.
+# ── Play override: force face-up starts ──────────────────────────────────────
+# Without an override, a play run NEVER shows a face-up start: the play env is
+# rebuilt from scratch, so common_step_counter restarts at 0 and the curriculum
+# applies its stage 0, where face_up_prob = 0. Yet that is precisely the hardest
+# case, the one we want to eyeball. STANDUP_PLAY_FACE_UP forces the mix, modeled
+# on SLOPE_PLAY_DIFFICULTY in roller_slope.
 
 
 def test_play_face_up_override_forces_back_starts(monkeypatch):
@@ -393,14 +393,14 @@ def test_play_face_up_override_forces_back_starts(monkeypatch):
     assert params["face_up_prob"] == 1.0
     assert params["face_down_prob"] == 0.0
     assert params["standing_prob"] == 0.0
-    # Sans ça, le curriculum réécrirait les probabilités dès le premier reset
-    # (event_param_curriculum tourne AVANT les événements de reset).
+    # Without this, the curriculum would rewrite the probabilities on the very
+    # first reset (event_param_curriculum runs BEFORE the reset events).
     assert "ground_state_mix" not in cfg.curriculum
 
 
 def test_play_face_up_override_splits_remainder_like_final_stage(monkeypatch):
-    # 0.4 doit reproduire le DERNIER palier du curriculum (0.40 ventre / 0.20
-    # debout / 0.40 dos) : le reste est réparti dans le rapport 2:1 de ce palier.
+    # 0.4 must reproduce the curriculum's LAST stage (0.40 face down / 0.20
+    # standing / 0.40 face up): the remainder is split in that stage's 2:1 ratio.
     monkeypatch.setenv("STANDUP_PLAY_FACE_UP", "0.4")
     params = make_microduck_roller_standup_env_cfg(play=True).events["set_ground_state"].params
     assert params["face_up_prob"] == pytest.approx(0.40)
@@ -417,8 +417,8 @@ def test_play_face_up_override_is_clamped(monkeypatch):
 
 
 def test_play_face_up_override_ignored_during_training(monkeypatch):
-    # Garde-fou : la variable ne doit JAMAIS toucher l'entraînement, sinon on
-    # casserait le curriculum easy->hard sans s'en apercevoir.
+    # Guard rail: the variable must NEVER touch training, otherwise we would
+    # break the easy->hard curriculum without noticing.
     monkeypatch.setenv("STANDUP_PLAY_FACE_UP", "1.0")
     cfg = make_microduck_roller_standup_env_cfg(play=False)
     assert cfg.events["set_ground_state"].params["face_up_prob"] == 0.00
@@ -426,7 +426,7 @@ def test_play_face_up_override_ignored_during_training(monkeypatch):
 
 
 def test_play_without_override_keeps_curriculum_mix(monkeypatch):
-    # Comportement par défaut inchangé : palier 0, pas de départ sur le dos.
+    # Default behavior unchanged: stage 0, no face-up start.
     monkeypatch.delenv("STANDUP_PLAY_FACE_UP", raising=False)
     cfg = make_microduck_roller_standup_env_cfg(play=True)
     assert cfg.events["set_ground_state"].params["face_up_prob"] == 0.00
@@ -447,51 +447,50 @@ def test_play_face_up_override_none_keyword_disables(monkeypatch):
     assert "ground_state_mix" in cfg.curriculum
 
 
-# ── Anti-violence : corrections après test sur le robot ───────────────────────
-# Symptômes observés (checkpoint 4000+, EN SIMU AUSSI donc pas du sim2real) :
-# mouvements très brusques, la tête tape le sol, échec du relevé depuis le dos
-# sur le vrai robot. Diagnostic mesuré dans wandb (run vweolw91, iter 7500).
+# ── Anti-violence: fixes after testing on the robot ──────────────────────────
+# Symptoms observed (checkpoint 4000+, IN SIM TOO, so not a sim2real issue):
+# very abrupt motions, the head banging the ground, failure to rise from the back
+# on the real robot. Diagnosis measured in wandb (run vweolw91, iter 7500).
 
 
 def test_already_negative_penalties_use_positive_weights():
-    """Verrou sur la classe de bug qui rendait la policy violente.
+    """Lock-in against the class of bug that made the policy violent.
 
-    mdp.py mélange DEUX conventions de signe : certaines fonctions de pénalité
-    renvoient une magnitude positive (à multiplier par un poids négatif), d'autres
-    renvoient déjà une valeur négative (à multiplier par un poids POSITIF).
-    trunk_vertical_accel_penalty renvoie -|a_z| : avec le poids -0.02 hérité du
-    standup, le double négatif RÉCOMPENSAIT l'accélération verticale — mesuré à
-    Episode_Reward/gentle_rise = +0.0118, seul terme de pénalité loggé positif.
+    mdp.py mixes TWO sign conventions: some penalty functions return a positive
+    magnitude (to be multiplied by a negative weight), others already return a
+    negative value (to be multiplied by a POSITIVE weight).
+    trunk_vertical_accel_penalty returns -|a_z|: with the -0.02 weight inherited
+    from standup, the double negative REWARDED vertical acceleration — measured at
+    Episode_Reward/gentle_rise = +0.0118, the only penalty term logged positive.
     """
     cfg = make_microduck_roller_standup_env_cfg()
-    # Ces trois termes appellent des fonctions qui renvoient déjà du négatif
+    # These three terms call functions that already return negative values
     # (height_l1_penalty, pose_l1_penalty, trunk_vertical_accel_penalty).
     for name in ("height_stand_l1", "pose_stand_l1", "gentle_rise"):
         assert cfg.rewards[name].weight > 0, (
-            f"{name} appelle une fonction qui renvoie déjà du négatif : "
-            f"un poids négatif en ferait une récompense"
+            f"{name} calls a function that already returns a negative value: "
+            f"a negative weight would turn it into a reward"
         )
-    # Et ces termes renvoient une magnitude positive → poids négatif.
+    # And these terms return a positive magnitude → negative weight.
     for name in ("joint_torques_l2", "joint_torque_rate_l2", "action_rate_l2"):
-        assert cfg.rewards[name].weight < 0, f"{name} attend un poids négatif"
+        assert cfg.rewards[name].weight < 0, f"{name} expects a negative weight"
 
 
 def test_no_ungated_head_impact_penalty():
-    """PAS de pénalité d'impact tête non gatée — elle gelait la policy.
+    """NO ungated head-impact penalty — it froze the policy.
 
-    Essayée à -1.0 (valeurs de velstand) : la policy a convergé vers rester
-    couchée, inerte. Mesuré sur le run d8rnko6p : head_impact_penalty -1.01/pas,
-    le plus gros terme négatif, pendant que standing_composite s'effondrait de
-    +14.3 à +3.3.
+    Tried at -1.0 (velstand's values): the policy converged to lying down, inert.
+    Measured on run d8rnko6p: head_impact_penalty -1.01/step, the largest negative
+    term, while standing_composite collapsed from +14.3 to +3.3.
 
-    L'erreur de raisonnement était de croire qu'une pénalité « ciblée » ne bride
-    pas le mouvement. Faux ici : pour se relever du dos, ce robot PIVOTE sur sa
-    tête et ses épaules. La tête est le point d'appui du retournement, pas un
-    dégât collatéral — la pénaliser, c'est pénaliser le seul mécanisme disponible.
+    The reasoning error was believing that a "targeted" penalty does not restrict
+    motion. False here: to get up from its back, this robot PIVOTS on its head and
+    shoulders. The head is the fulcrum of the roll-over, not collateral damage —
+    penalizing it means penalizing the only available mechanism.
 
-    Si le slam revient une fois le signe de gentle_rise corrigé, la reprise doit
-    être une pénalité GATÉE EN HAUTEUR (comme upright_sharp l'est), qui épargne la
-    phase de retournement au sol. Pas celle-ci.
+    If the slam comes back once the gentle_rise sign is fixed, the reintroduction
+    must be a HEIGHT-GATED penalty (as upright_sharp is), which spares the ground
+    roll-over phase. Not this one.
     """
     cfg = make_microduck_roller_standup_env_cfg()
     assert "head_impact_penalty" not in cfg.rewards
@@ -499,8 +498,8 @@ def test_no_ungated_head_impact_penalty():
 
 
 def test_inherited_sensors_intact():
-    # Les capteurs hérités de l'env roller sont utilisés par des récompenses
-    # gardées (self_collisions) et par les observations.
+    # The sensors inherited from the roller env are used by kept rewards
+    # (self_collisions) and by the observations.
     cfg = make_microduck_roller_standup_env_cfg()
     names = [s.name for s in cfg.scene.sensors]
     assert "feet_ground_contact" in names
@@ -508,13 +507,13 @@ def test_inherited_sensors_intact():
 
 
 def test_lazy_prone_optimum_is_documented_risk():
-    """Le gel vient d'un optimum paresseux : couché, jambes à HOME, ça paye.
+    """The freeze comes from a lazy optimum: lying down, legs at HOME, still pays.
 
-    pose_stand_legs restait à +7.72 sur 8 alors que le robot était allongé — les
-    jambes sont à HOME en position couchée, donc la récompense de pose est encaissée
-    quasi gratuitement. C'est le contrepoids qui rend « ne rien faire » viable dès
-    qu'on ajoute un coût au mouvement. height_stand_l1 (poids +30) est le terme
-    censé rendre « rester au sol » net négatif : il doit rester fort.
+    pose_stand_legs stayed at +7.72 out of 8 while the robot was lying flat — the
+    legs are at HOME in a prone position, so the pose reward is collected almost
+    for free. That is the counterweight that makes "do nothing" viable as soon as
+    a cost on motion is added. height_stand_l1 (weight +30) is the term meant to
+    make "stay on the ground" net negative: it must stay strong.
     """
     cfg = make_microduck_roller_standup_env_cfg()
     assert cfg.rewards["height_stand_l1"].weight >= 30.0
@@ -522,18 +521,17 @@ def test_lazy_prone_optimum_is_documented_risk():
 
 
 def test_damping_terms_are_not_numerically_negligible():
-    """Les amortisseurs dédiés ne pesaient littéralement rien.
+    """The dedicated dampers weighed literally nothing.
 
-    Mesuré à convergence : joint_torque_rate_l2 -0.0002/pas et joint_torques_l2
-    -0.0001/pas, face à ~+41.6 de récompense de tâche (rapport ~35:1 pour tous
-    les amortisseurs réunis). joint_torque_rate_l2 est le levier SÛR à remonter :
-    il pénalise la VARIATION de couple, pas le mouvement, donc il n'agit pas comme
-    bloqueur de mouvement — le standup documente que body_ang_vel et action_rate,
-    eux, gelaient le relevé depuis le dos.
+    Measured at convergence: joint_torque_rate_l2 -0.0002/step and joint_torques_l2
+    -0.0001/step, against ~+41.6 of task reward (a ~35:1 ratio for all the dampers
+    combined). joint_torque_rate_l2 is the SAFE lever to turn up: it penalizes
+    torque RATE, not motion, so it does not act as a motion blocker — standup
+    documents that body_ang_vel and action_rate did freeze the rise from the back.
     """
     cfg = make_microduck_roller_standup_env_cfg()
     assert abs(cfg.rewards["joint_torque_rate_l2"].weight) >= 0.1
-    # Les bloqueurs de mouvement restent à leurs valeurs « se relève de partout ».
+    # The motion blockers stay at their "gets up from anywhere" values.
     assert cfg.rewards["body_ang_vel"].weight == -0.05
     weights = [s["weight"] for s in cfg.curriculum["action_rate_weight"].params["weight_stages"]]
-    assert min(weights) >= -1.0, "action_rate au-delà de -1.0 gelait le relevé (standup)"
+    assert min(weights) >= -1.0, "action_rate beyond -1.0 froze the rise (standup)"

--- a/tests/test_slope_curriculum.py
+++ b/tests/test_slope_curriculum.py
@@ -3,7 +3,7 @@ from mjlab_microduck.tasks.mdp import slope_move_masks
 
 
 def test_move_up_when_reached_bottom():
-    # distance > size_x*0.4 (=3.2) → monte en difficulté
+    # distance > size_x*0.4 (=3.2) → promote to a harder slope
     dist = torch.tensor([5.0, 4.1])
     up, down = slope_move_masks(dist, size_x=8.0)
     assert bool(up[0]) and bool(up[1])
@@ -11,7 +11,7 @@ def test_move_up_when_reached_bottom():
 
 
 def test_move_down_when_stuck_early():
-    # distance < size_x*0.2 (=1.6) → descend en difficulté
+    # distance < size_x*0.2 (=1.6) → demote to an easier slope
     dist = torch.tensor([0.5, 1.0])
     up, down = slope_move_masks(dist, size_x=8.0)
     assert not bool(up[0]) and not bool(up[1])
@@ -19,21 +19,21 @@ def test_move_down_when_stuck_early():
 
 
 def test_stay_in_middle_band():
-    # entre 1.6 et 3.2 → ni haut ni bas
+    # between 1.6 and 3.2 → neither up nor down
     dist = torch.tensor([2.5])
     up, down = slope_move_masks(dist, size_x=8.0)
     assert not bool(up[0]) and not bool(down[0])
 
 
 def test_move_up_boundary_at_04():
-    # promotion dès qu'on a descendu > 0.4*size_x (le robot a parcouru une bonne
-    # partie de la rampe avant d'atteindre le plat de sortie).
+    # promotion as soon as it has descended > 0.4*size_x (the robot covered a
+    # good part of the ramp before reaching the flat runout).
     dist = torch.tensor([3.3])
     up, down = slope_move_masks(dist, size_x=8.0)
     assert bool(up[0])
     assert not bool(down[0])
 
-    # 3.0 reste dans la bande médiane (3.0 < 3.2 et 3.0 > 1.6)
+    # 3.0 stays in the middle band (3.0 < 3.2 and 3.0 > 1.6)
     dist_mid = torch.tensor([3.0])
     up_mid, down_mid = slope_move_masks(dist_mid, size_x=8.0)
     assert not bool(up_mid[0]) and not bool(down_mid[0])

--- a/tests/test_slope_terrain.py
+++ b/tests/test_slope_terrain.py
@@ -34,33 +34,33 @@ def _empty_terrain_spec():
 
 def test_flat_ramp_builds_geoms_and_origin_on_flat():
     cfg = FlatRampTerrainCfg(flat_length=2.0)
-    cfg.size = (15.0, 4.0)  # posé normalement par le générateur
+    cfg.size = (15.0, 4.0)  # normally set by the generator
     spec = _empty_terrain_spec()
     out = cfg.function(difficulty=0.5, spec=spec, rng=np.random.default_rng(0))
-    # trois géométries : plat de départ + rampe + plat de sortie
+    # three geoms: starting flat + ramp + flat runout
     assert len(out.geometries) == 3
-    # origine SUR la rampe (au-delà du plat), donc x > flat_length et z < 0
+    # origin ON the ramp (past the flat), hence x > flat_length and z < 0
     assert out.origin[0] == cfg.flat_length + cfg.spawn_on_ramp
     assert out.origin[2] < 0.0
-    # z = surface inclinée à spawn_on_ramp du bord (drop = d * tan(angle))
+    # z = the tilted surface at spawn_on_ramp from the edge (drop = d * tan(angle))
     angle = ramp_angle_by_difficulty(0.5, cfg.deg_min, cfg.deg_max)
     assert abs(out.origin[2] - (-cfg.spawn_on_ramp * math.tan(angle))) < 1e-9
 
 
 def test_flat_ramp_steeper_at_higher_difficulty():
-    # à difficulté plus haute, le bout de rampe descend plus bas
+    # at higher difficulty the end of the ramp goes lower
     cfg = FlatRampTerrainCfg()
     cfg.size = (15.0, 4.0)
     easy = cfg.function(0.0, _empty_terrain_spec(), np.random.default_rng(0))
     hard = cfg.function(1.0, _empty_terrain_spec(), np.random.default_rng(0))
-    # la rampe (2e géométrie) est plus basse (centre z plus négatif) en difficile
-    # (même rng -> même longueur tirée -> seule la pente change)
+    # the ramp (2nd geom) sits lower (more negative center z) at high difficulty
+    # (same rng -> same drawn length -> only the slope changes)
     assert hard.geometries[1].geom.pos[2] < easy.geometries[1].geom.pos[2]
 
 
 def test_ramp_joins_flat_platform_no_gap():
-    # le haut de la rampe doit toucher le bord de la plateforme plate (x=flat_length) :
-    # centre rampe décalé de -(t/2)*sin(angle) en x.
+    # the top of the ramp must meet the flat platform's edge (x=flat_length):
+    # the ramp center is offset by -(t/2)*sin(angle) in x.
     cfg = FlatRampTerrainCfg()
     cfg.size = (15.0, 4.0)
     out = cfg.function(0.5, _empty_terrain_spec(), np.random.default_rng(0))
@@ -73,22 +73,22 @@ def test_ramp_joins_flat_platform_no_gap():
 
 
 def test_flat_ramp_runout_at_ramp_bottom():
-    # le plat de sortie (3e géométrie) est au niveau du bas de la rampe (z<0),
-    # et sa surface est plate (box non tourné : quat identité).
+    # the flat runout (3rd geom) is at the level of the bottom of the ramp (z<0),
+    # and its surface is flat (unrotated box: identity quat).
     cfg = FlatRampTerrainCfg()
     cfg.size = (15.0, 4.0)
     out = cfg.function(1.0, _empty_terrain_spec(), np.random.default_rng(0))
     runout = out.geometries[2].geom
-    assert runout.pos[2] < 0.0  # descendu sous le plat de départ
-    # quaternion identité (plat, pas incliné)
+    assert runout.pos[2] < 0.0  # dropped below the starting flat
+    # identity quaternion (flat, not tilted)
     assert math.isclose(runout.quat[0], 1.0, abs_tol=1e-9)
 
 
 def test_ramp_length_within_range():
     cfg = FlatRampTerrainCfg(ramp_length_range=(3.0, 8.0))
     cfg.size = (15.0, 4.0)
-    # surface de rampe = ramp_length / cos(angle) ; à difficulté 0, angle=2°,
-    # donc surf_len ~= ramp_length. On vérifie sur plusieurs tirages.
+    # ramp surface = ramp_length / cos(angle); at difficulty 0, angle=2°, so
+    # surf_len ~= ramp_length. We check across several draws.
     for seed in range(20):
         out = cfg.function(0.0, _empty_terrain_spec(), np.random.default_rng(seed))
         surf_half = out.geometries[1].geom.size[0]

--- a/tests/test_spin.py
+++ b/tests/test_spin.py
@@ -4,13 +4,14 @@ import torch
 
 from mjlab_microduck.tasks import mdp
 
-# Enveloppe du spec : accel 0.5s / régime 1.6s / freinage 0.5s / repos 1.4s sur 4s.
+# Envelope from the spec: accel 0.5s / steady 1.6s / brake 0.5s / rest 1.4s over 4s.
 _ENV = dict(rate_max=6.0, accel_end=0.125, hold_end=0.525, brake_end=0.650)
 
 
 def test_spin_rate_segment_boundaries():
-    # bornes des 4 segments : 0 au départ, plein régime sur [accel_end, hold_end],
-    # encore plein régime au tout début du freinage, 0 dès le segment de repos.
+    # boundaries of the 4 segments: 0 at the start, full rate over
+    # [accel_end, hold_end], still full rate at the very start of braking, 0 from
+    # the rest segment onward.
     phase = torch.tensor([0.0, 0.125, 0.30, 0.525, 0.650, 0.80, 0.999])
     w = mdp.spin_rate_by_phase(phase, **_ENV)
     expected = torch.tensor([0.0, 6.0, 6.0, 6.0, 0.0, 0.0, 0.0])
@@ -21,7 +22,7 @@ def test_spin_rate_accel_ramp_is_increasing():
     phase = torch.linspace(0.0, 0.125, 20)
     w = mdp.spin_rate_by_phase(phase, **_ENV)
     assert torch.all(w[1:] >= w[:-1])
-    # milieu de la rampe de lancement -> moitié de la cible
+    # midway through the launch ramp -> half the target
     mid = mdp.spin_rate_by_phase(torch.tensor([0.0625]), **_ENV)
     assert torch.allclose(mid, torch.tensor([3.0]), atol=1e-6)
 
@@ -30,16 +31,17 @@ def test_spin_rate_brake_ramp_is_decreasing():
     phase = torch.linspace(0.525, 0.6499, 20)
     w = mdp.spin_rate_by_phase(phase, **_ENV)
     assert torch.all(w[1:] <= w[:-1])
-    # milieu du freinage -> moitié de la cible
+    # midway through the braking -> half the target
     mid = mdp.spin_rate_by_phase(torch.tensor([0.5875]), **_ENV)
     assert torch.allclose(mid, torch.tensor([3.0]), atol=1e-6)
 
 
 def test_spin_rate_integral_matches_trapezoid_shape_at_rate_max_6():
-    # Ce test protège la FORME du trapèze (2.1 * rate_max rad par cycle), pas la
-    # cible réellement expédiée : à rate_max=6.0 (hypothétique, cf. _ENV ci-dessus)
-    # ça vaut ~4*pi rad = 2 tours. Enveloppe exacte = 12.6 rad, 4*pi = 12.566 ->
-    # tolérance 1 %. La cible EN VIGUEUR est couverte par le test suivant.
+    # This test protects the SHAPE of the trapezoid (2.1 * rate_max rad per
+    # cycle), not the target actually shipped: at rate_max=6.0 (hypothetical, cf.
+    # _ENV above) that is ~4*pi rad = 2 turns. Exact envelope = 12.6 rad,
+    # 4*pi = 12.566 -> 1% tolerance. The SHIPPED target is covered by the next
+    # test.
     n = 100_000
     phase = (torch.arange(n, dtype=torch.float64) + 0.5) / n
     w = mdp.spin_rate_by_phase(phase, **_ENV)
@@ -48,13 +50,13 @@ def test_spin_rate_integral_matches_trapezoid_shape_at_rate_max_6():
 
 
 def test_spin_rate_max_integrates_to_2_1_times_itself_per_cycle():
-    # LE test qui protège la cible EXPÉDIÉE (mdp.SPIN_RATE_MAX), par opposition au
-    # test ci-dessus qui ne teste que la forme à rate_max=6.0. L'aire sous
-    # l'enveloppe sur un cycle vaut 2.1 * rate_max rad, quel que soit rate_max
-    # (0.25 + 1.6 + 0.25 = 2.1, cf. le commentaire au-dessus des constantes dans
-    # mdp.py). Avec le réglage actuel (SPIN_RATE_MAX = 3.0) ça donne 6.3 rad,
-    # soit ~1 tour -- pas 2. Ce test échoue bruyamment si quelqu'un change la
-    # cible sans réfléchir au nombre de tours que ça implique.
+    # THE test that protects the SHIPPED target (mdp.SPIN_RATE_MAX), as opposed
+    # to the test above which only checks the shape at rate_max=6.0. The area
+    # under the envelope over one cycle is 2.1 * rate_max rad, whatever rate_max
+    # is (0.25 + 1.6 + 0.25 = 2.1, cf. the comment above the constants in
+    # mdp.py). With the current setting (SPIN_RATE_MAX = 3.0) that gives 6.3 rad,
+    # i.e. ~1 turn -- not 2. This test fails loudly if someone changes the target
+    # without thinking about how many turns it implies.
     n = 100_000
     phase = (torch.arange(n, dtype=torch.float64) + 0.5) / n
     w = mdp.spin_rate_by_phase(
@@ -78,14 +80,14 @@ def test_spin_gate_is_normalized_rate():
 
 
 def test_spin_gate_is_zero_over_the_whole_rest_segment():
-    # pendant le repos aucune amorce ne doit pousser au ciseau -> porte nulle,
-    # c'est ce qui donne une sortie de trick propre vers la policy roller.
+    # during the rest segment no priming term should push toward the scissor ->
+    # zero gate, which is what gives a clean trick exit back to the roller policy.
     phase = torch.linspace(0.650, 0.999, 50)
     gate = mdp.spin_gate_by_phase(phase, **_ENV)
     assert torch.allclose(gate, torch.zeros_like(gate), atol=1e-6)
 
 
-# ── faux env minimal : permet de tester les wrappers de reward sans MuJoCo ────
+# ── minimal fake env: lets us test the reward wrappers without MuJoCo ────────
 class _FakeData:
     def __init__(self, ang_vel_b=None, lin_vel_b=None, joint_pos=None, joint_vel=None):
         self.root_link_ang_vel_b = ang_vel_b
@@ -95,7 +97,7 @@ class _FakeData:
 
 
 class _FakeEntity:
-    """Entity minimale : find_joints() résout par nom depuis un dict {nom: index}."""
+    """Minimal Entity: find_joints() resolves by name from a {name: index} dict."""
 
     def __init__(self, data, joint_ids=None):
         self.data = data
@@ -109,7 +111,7 @@ class _FakeEntity:
             matched = [n for n in names if n in pattern]
         else:
             matched = [n for n in names if re.fullmatch(pattern, n)]
-        assert matched, f"aucun joint ne matche {pattern!r} parmi {names}"
+        assert matched, f"no joint matches {pattern!r} among {names}"
         return [self._joint_ids[n] for n in matched], matched
 
 
@@ -139,7 +141,7 @@ class _FakeEnv:
 
 
 def _phase_cmd(phases):
-    """Commande du slot telle que la voit la policy : [cos(2*pi*phi), sin(...), 0]."""
+    """The slot command as the policy sees it: [cos(2*pi*phi), sin(...), 0]."""
     p = torch.as_tensor(phases, dtype=torch.float32)
     return torch.stack(
         [torch.cos(2 * math.pi * p), torch.sin(2 * math.pi * p), torch.zeros_like(p)],
@@ -159,15 +161,15 @@ def test_spin_rate_reward_peaks_on_exact_match():
     w = torch.tensor([6.0, 6.0])
     target = torch.tensor([6.0, 4.5])
     r = mdp.spin_rate_reward_from_values(w, target, std=1.5)
-    # erreur nulle -> 1.0 ; erreur = 1 std -> exp(-1)
+    # zero error -> 1.0; error = 1 std -> exp(-1)
     assert torch.allclose(r, torch.tensor([1.0, math.exp(-1.0)]), atol=1e-6)
 
 
 def test_spin_rate_track_uses_yaw_and_phase():
-    # phase 0.30 = plein régime -> cible SPIN_RATE_MAX (3.0 rad/s, défaut appelé
-    # ici implicitement). Un robot qui tourne à la cible doit toucher 1.0 ; un
-    # robot immobile doit être largement en dessous (exp(-(3/1.5)^2) = 0.018 au
-    # réglage courant : std=1.5 reste bien calibré à cette cible, cf. mdp.py).
+    # phase 0.30 = full rate -> target SPIN_RATE_MAX (3.0 rad/s, the default
+    # implicitly used here). A robot spinning at the target must hit 1.0; a
+    # motionless robot must be well below it (exp(-(3/1.5)^2) = 0.018 at the
+    # current setting: std=1.5 stays well calibrated to that target, cf. mdp.py).
     ang = torch.tensor([[0.0, 0.0, mdp.SPIN_RATE_MAX], [0.0, 0.0, 0.0]])
     env = _FakeEnv(
         _FakeEntity(_FakeData(ang_vel_b=ang)), cmd=_phase_cmd([0.30, 0.30])
@@ -178,7 +180,7 @@ def test_spin_rate_track_uses_yaw_and_phase():
 
 
 def test_spin_rate_track_wants_stillness_during_rest():
-    # phase 0.80 = repos -> cible 0 : tourner encore est puni, être immobile payé.
+    # phase 0.80 = rest -> target 0: still spinning is punished, being still pays.
     ang = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 6.0]])
     env = _FakeEnv(
         _FakeEntity(_FakeData(ang_vel_b=ang)), cmd=_phase_cmd([0.80, 0.80])
@@ -189,8 +191,8 @@ def test_spin_rate_track_wants_stillness_during_rest():
 
 
 def test_spin_rate_track_penalizes_wrong_direction():
-    # tourner à -SPIN_RATE_MAX (horaire) quand on demande +SPIN_RATE_MAX doit
-    # être pire qu'immobile.
+    # spinning at -SPIN_RATE_MAX (clockwise) when +SPIN_RATE_MAX is requested must
+    # be worse than standing still.
     ang = torch.tensor([[0.0, 0.0, -mdp.SPIN_RATE_MAX], [0.0, 0.0, 0.0]])
     env = _FakeEnv(
         _FakeEntity(_FakeData(ang_vel_b=ang)), cmd=_phase_cmd([0.30, 0.30])
@@ -201,7 +203,7 @@ def test_spin_rate_track_penalizes_wrong_direction():
 
 # ── spin_rate_l1 ─────────────────────────────────────────────────────────────
 def test_spin_rate_l1_is_negative_absolute_error():
-    # phase 0.30 = plein régime -> cible SPIN_RATE_MAX (3.0 rad/s, défaut).
+    # phase 0.30 = full rate -> target SPIN_RATE_MAX (3.0 rad/s, the default).
     ang = torch.tensor([[0.0, 0.0, mdp.SPIN_RATE_MAX], [0.0, 0.0, 1.0]])
     env = _FakeEnv(
         _FakeEntity(_FakeData(ang_vel_b=ang)), cmd=_phase_cmd([0.30, 0.30])
@@ -213,20 +215,20 @@ def test_spin_rate_l1_is_negative_absolute_error():
 
 # ── spin_stay_in_place ───────────────────────────────────────────────────────
 def test_spin_stay_in_place_is_squared_planar_speed():
-    # phase 0.30 = plein régime -> coût plein tarif
+    # phase 0.30 = full rate -> full-price cost
     lin = torch.tensor([[0.0, 0.0, 0.0], [0.3, 0.4, 9.0]])
     env = _FakeEnv(
         _FakeEntity(_FakeData(lin_vel_b=lin)), cmd=_phase_cmd([0.30, 0.30])
     )
     c = mdp.spin_stay_in_place(env)
-    # 0.3^2 + 0.4^2 = 0.25 ; la composante z est ignorée
+    # 0.3^2 + 0.4^2 = 0.25; the z component is ignored
     assert torch.allclose(c, torch.tensor([0.0, 0.25]), atol=1e-6)
 
 
 def test_spin_stay_in_place_is_attenuated_during_the_launch_ramp():
-    # Même vitesse, deux phases : dans la rampe de lancement (0.05 < accel_end) le
-    # coût est multiplié par launch_scale, en régime (0.30) il est plein tarif.
-    # C'est ce qui empêche ce terme de s'opposer à l'injection de moment angulaire.
+    # Same velocity, two phases: in the launch ramp (0.05 < accel_end) the cost is
+    # multiplied by launch_scale, at full rate (0.30) it is full price. That is
+    # what keeps this term from opposing the injection of angular momentum.
     lin = torch.tensor([[0.3, 0.4, 0.0], [0.3, 0.4, 0.0]])
     env = _FakeEnv(
         _FakeEntity(_FakeData(lin_vel_b=lin)), cmd=_phase_cmd([0.05, 0.30])
@@ -238,8 +240,9 @@ def test_spin_stay_in_place_is_attenuated_during_the_launch_ramp():
 
 
 def test_spin_stay_in_place_is_full_price_during_rest():
-    # Pendant le repos on veut le robot IMMOBILE : ce terme ne doit PAS être éteint,
-    # contrairement aux amorces (spin_wheel_differential, spin_grounded, ciseau).
+    # During the rest segment we want the robot MOTIONLESS: this term must NOT be
+    # switched off, unlike the priming terms (spin_wheel_differential,
+    # spin_grounded, scissor).
     lin = torch.tensor([[0.3, 0.4, 0.0]])
     env = _FakeEnv(_FakeEntity(_FakeData(lin_vel_b=lin)), cmd=_phase_cmd([0.80]))
     c = mdp.spin_stay_in_place(env)
@@ -262,13 +265,13 @@ def _wheel_env(vel_rows, phases):
 
 
 def test_wheel_differential_rewards_counter_rolling_wheels():
-    # anti-horaire : roues GAUCHE négatives (patin part en arrière), DROITE
-    # positives -> omega_D - omega_G > 0 -> récompensé.
+    # counter-clockwise: LEFT wheels negative (that skate goes backward), RIGHT
+    # positive -> omega_R - omega_L > 0 -> rewarded.
     env = _wheel_env(
         [
-            [-10.0, -10.0, 10.0, 10.0],  # bon différentiel
-            [10.0, 10.0, 10.0, 10.0],    # tout droit : différentiel nul
-            [10.0, 10.0, -10.0, -10.0],  # différentiel inversé (horaire)
+            [-10.0, -10.0, 10.0, 10.0],  # correct differential
+            [10.0, 10.0, 10.0, 10.0],    # straight ahead: zero differential
+            [10.0, 10.0, -10.0, -10.0],  # reversed differential (clockwise)
         ],
         [0.30, 0.30, 0.30],
     )
@@ -279,14 +282,14 @@ def test_wheel_differential_rewards_counter_rolling_wheels():
 
 
 def test_wheel_differential_is_gated_off_during_rest():
-    # même bon différentiel, mais en phase de repos -> porte nulle -> pas payé.
+    # same correct differential, but in the rest phase -> zero gate -> unpaid.
     env = _wheel_env([[-10.0, -10.0, 10.0, 10.0]], [0.80])
     r = mdp.spin_wheel_differential(env, omega_scale=20.0)
     assert torch.allclose(r, torch.zeros(1), atol=1e-6)
 
 
 def test_wheel_differential_saturates():
-    # tanh : au-delà de omega_scale la reward sature, pas de course à la vitesse.
+    # tanh: beyond omega_scale the reward saturates, no race to maximum speed.
     env = _wheel_env(
         [[-10.0, -10.0, 10.0, 10.0], [-100.0, -100.0, 100.0, 100.0]], [0.30, 0.30]
     )
@@ -313,8 +316,8 @@ def test_spin_grounded_rewards_both_blades_down_and_is_gated():
         sensors={"feet_ground_contact": _FakeSensor(contact)},
     )
     r = mdp.spin_grounded(env, sensor_name="feet_ground_contact")
-    # deux lames au sol en régime -> porte 1.0 ; une seule ou zéro -> 0 ;
-    # deux lames au sol mais en repos -> porte 0.
+    # both blades down at full rate -> gate 1.0; one or none -> 0;
+    # both blades down but in the rest phase -> gate 0.
     assert torch.allclose(r, torch.tensor([1.0, 0.0, 0.0, 0.0]), atol=1e-6)
 
 
@@ -334,12 +337,12 @@ def _leg_env(pos_rows, phases):
 
 
 def test_leg_antisymmetry_prefers_scissor_over_mirror():
-    # convention miroir : q_G = -q_D est une pose SYMÉTRIQUE (mauvais ici),
-    # q_G = q_D est le CISEAU (bon ici). Valeur = -mean|q_G - q_D|, donc <= 0.
+    # mirror convention: q_L = -q_R is a SYMMETRIC pose (bad here), q_L = q_R is
+    # the SCISSOR (good here). Value = -mean|q_L - q_R|, hence <= 0.
     env = _leg_env(
         [
-            [0.4, 0.3, 0.4, 0.3],    # ciseau parfait : q_G == q_D -> 0.0
-            [0.4, 0.3, -0.4, -0.3],  # miroir : écart 0.8 et 0.6 -> -0.7
+            [0.4, 0.3, 0.4, 0.3],    # perfect scissor: q_L == q_R -> 0.0
+            [0.4, 0.3, -0.4, -0.3],  # mirror: gaps of 0.8 and 0.6 -> -0.7
         ],
         [0.30, 0.30],
     )
@@ -349,13 +352,14 @@ def test_leg_antisymmetry_prefers_scissor_over_mirror():
 
 
 def test_leg_antisymmetry_is_gated_off_during_rest():
-    # en repos la porte est nulle : rien ne pousse au ciseau, station neutre libre.
+    # at rest the gate is zero: nothing pushes toward the scissor, the neutral
+    # stance is free.
     env = _leg_env([[0.4, 0.3, -0.4, -0.3]], [0.80])
     r = mdp.leg_antisymmetry(env)
     assert torch.allclose(r, torch.zeros(1), atol=1e-6)
 
 
-# ── neck_joint_pos_l2 : paramètre pattern ────────────────────────────────────
+# ── neck_joint_pos_l2: the pattern parameter ─────────────────────────────────
 _NECK_IDS = {
     "neck_pitch": 0,
     "head_pitch": 1,
@@ -370,16 +374,16 @@ def test_neck_joint_pos_l2_pattern_can_exclude_head_yaw():
             super().__init__(joint_pos=joint_pos)
             self.default_joint_pos = default_joint_pos
 
-    pos = torch.tensor([[0.0, 0.0, 0.0, 1.0]])  # seul head_yaw dévie, de 1 rad
+    pos = torch.tensor([[0.0, 0.0, 0.0, 1.0]])  # only head_yaw deviates, by 1 rad
     default = torch.zeros(1, 4)
     entity = _FakeEntity(_NeckData(pos, default), joint_ids=_NECK_IDS)
     env = _FakeEnv(entity)
 
-    # motif par défaut : head_yaw compté -> coût 1.0
+    # default pattern: head_yaw counted -> cost 1.0
     assert torch.allclose(
         mdp.neck_joint_pos_l2(env), torch.tensor([1.0]), atol=1e-6
     )
-    # motif du spin : head_yaw exclu -> coût 0.0 (tête libre en lacet)
+    # spin pattern: head_yaw excluded -> cost 0.0 (head free in yaw)
     assert torch.allclose(
         mdp.neck_joint_pos_l2(env, pattern=r"^(neck_pitch|head_pitch|head_roll)$"),
         torch.tensor([0.0]),

--- a/tests/test_spin_cfg.py
+++ b/tests/test_spin_cfg.py
@@ -9,9 +9,9 @@ def test_cfg_uses_phase_command_with_runtime_default_period():
     cfg = make_microduck_spin_env_cfg()
     cmd = cfg.commands["twist"]
     assert isinstance(cmd, microduck_mdp.GroundPickPhaseCommandCfg)
-    # 4.0 s = le défaut de --ground-pick-period : rien à passer au runtime
+    # 4.0 s = the default of --ground-pick-period: nothing to pass at runtime
     assert cmd.period == 4.0
-    # chaque épisode démarre à phase 0 (debout), comme le bouton au déploiement
+    # every episode starts at phase 0 (standing), like the button at deployment
     assert cmd.randomize_phase is False
 
 
@@ -26,29 +26,30 @@ def test_cfg_has_the_spin_rewards():
         "leg_antisymmetry",
     ):
         assert name in cfg.rewards, name
-    # objectif principal avec un poids dominant
+    # main objective with a dominant weight
     assert cfg.rewards["spin_rate_track"].weight == 6.0
-    # sur-place est un COÛT
+    # staying in place is a COST
     assert cfg.rewards["spin_stay_in_place"].weight < 0.0
 
 
 def test_stay_in_place_is_attenuated_during_the_launch_ramp():
-    # Renforcé à -3.0, ce terme s'opposerait à l'injection de moment angulaire s'il
-    # était plein tarif pendant la rampe de lancement : il doit y être atténué.
+    # Strengthened to -3.0, this term would oppose the injection of angular
+    # momentum if it were full price during the launch ramp: it must be attenuated
+    # there.
     cfg = make_microduck_spin_env_cfg()
     params = cfg.rewards["spin_stay_in_place"].params
     assert 0.0 < params["launch_scale"] < 1.0
     assert params["accel_end"] == microduck_mdp.SPIN_ACCEL_END
-    # cible positive = anti-horaire (le sens est porté par l'enveloppe)
+    # positive target = counter-clockwise (the direction is carried by the envelope)
     assert microduck_mdp.SPIN_RATE_MAX > 0.0
 
 
 def test_angular_momentum_reward_is_removed():
-    # Régression : angular_momentum_penalty pénalise la NORME 3D du moment
-    # angulaire, elle combattrait directement le spin. Elle doit être absente.
+    # Regression: angular_momentum_penalty penalizes the 3D NORM of angular
+    # momentum, so it would fight the spin head-on. It must be absent.
     cfg = make_microduck_spin_env_cfg()
     assert "angular_momentum" not in cfg.rewards
-    # body_ang_vel ne pénalise que x/y -> elle reste, elle mate le ballant
+    # body_ang_vel only penalizes x/y -> it stays, it damps the wobble
     assert "body_ang_vel" in cfg.rewards
 
 
@@ -60,14 +61,14 @@ def test_head_yaw_is_free_to_act_as_a_flywheel():
 
 def test_entry_velocity_allows_standstill_and_slow_roll():
     cfg = make_microduck_spin_env_cfg()
-    # jamais via un push en mode reset (régression NaN du crouch)
+    # never through a reset-mode push (the crouch's NaN regression)
     assert "entry_velocity" not in cfg.events
     lo, hi = cfg.events["reset_base"].params["velocity_range"]["x"]
     assert lo == 0.0 and hi > 0.0
 
 
 def test_symmetry_augmentation_is_disabled():
-    # la symétrie G/D transformerait un spin à gauche en spin à droite
+    # L/R symmetry would turn a left spin into a right spin
     assert MicroduckSpinRlCfg.algorithm.symmetry_cfg is None
 
 
@@ -81,9 +82,9 @@ def test_leg_antisymmetry_shaping_decays():
 
 
 def test_actor_observation_keeps_the_61d_slot_layout():
-    # condition pour que l'ONNX charge dans le slot du runtime. L'égalité exacte
-    # des dimensions avec le crouch est vérifiée par test_obs_parity_with_roller_crouch
-    # ci-dessous ; ici on vérifie la structure.
+    # required for the ONNX to load in the runtime slot. Exact dimensional
+    # equality with the crouch is checked by test_obs_parity_with_roller_crouch
+    # below; here we check the structure.
     cfg = make_microduck_spin_env_cfg()
     terms = cfg.observations["actor"].terms
     assert "base_lin_vel" not in terms
@@ -95,9 +96,9 @@ def test_actor_observation_keeps_the_61d_slot_layout():
 
 
 def test_obs_parity_with_roller_crouch():
-    # Parité de layout obligatoire : sinon l'ONNX exporté ne charge pas dans le
-    # slot du runtime. Contrairement au test de structure ci-dessus, celui-ci
-    # compare l'ordre EXACT des termes, groupe par groupe.
+    # Layout parity is mandatory: otherwise the exported ONNX will not load in the
+    # runtime slot. Unlike the structural test above, this one compares the EXACT
+    # ordering of the terms, group by group.
     from mjlab_microduck.tasks.microduck_roller_crouch_env_cfg import (
         make_microduck_roller_crouch_env_cfg,
     )
@@ -107,4 +108,4 @@ def test_obs_parity_with_roller_crouch():
     for grp in ("actor", "critic"):
         assert list(spin.observations[grp].terms.keys()) == list(
             crouch.observations[grp].terms.keys()
-        ), f"layout d'observation divergent sur le groupe {grp}"
+        ), f"observation layout diverged on group {grp}"

--- a/tests/test_wheel_glide.py
+++ b/tests/test_wheel_glide.py
@@ -1,6 +1,6 @@
-"""wheel_glide_reward : récompense le ROULEMENT des roues vers l'avant (glisse
-par gravité), plafonné à cap_speed, nul si les roues reculent, NaN-safe.
-Indépendant de toute commande (la tâche pente a une commande nulle).
+"""wheel_glide_reward: rewards forward WHEEL ROLLING (gravity-driven glide),
+capped at cap_speed, zero if the wheels roll backward, NaN-safe.
+Independent of any command (the slope task has a zero command).
 """
 
 import re
@@ -15,7 +15,7 @@ _WHEELS = {"passive_LF_wheel": 0, "passive_LR_wheel": 1, "passive_RF_wheel": 2, 
 
 class _Data:
     def __init__(self, omegas):
-        # 4 roues, colonnes 0..3 dans l'ordre LF,LR,RF,RR
+        # 4 wheels, columns 0..3 in the order LF,LR,RF,RR
         self.joint_vel = torch.tensor([omegas], dtype=torch.float32)
 
 
@@ -44,13 +44,13 @@ class _Env:
 
 
 def test_rewards_forward_roll_below_cap():
-    # omega=10 rad/s sur les 4 -> vitesse = 10*0.0175 = 0.175 m/s (< cap 0.35)
+    # omega=10 rad/s on all 4 -> speed = 10*0.0175 = 0.175 m/s (< cap 0.35)
     out = wheel_glide_reward(_Env([10.0, 10.0, 10.0, 10.0]), cap_speed=0.35)
     assert abs(float(out[0]) - 0.175) < 1e-6
 
 
 def test_caps_fast_roll():
-    # omega=40 -> 0.7 m/s -> plafonné à 0.35
+    # omega=40 -> 0.7 m/s -> capped at 0.35
     out = wheel_glide_reward(_Env([40.0, 40.0, 40.0, 40.0]), cap_speed=0.35)
     assert abs(float(out[0]) - 0.35) < 1e-6
 


### PR DESCRIPTION
Translates the remaining French comments, docstrings and plan/spec docs to English. Comments-only — no behavior change.

`uv run --with pytest pytest tests/ -q` → 149 passed.