### PR TITLE
Add play-dead task: stand, flop onto the back, and hold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ wheels/
 wandb
 logs
 agents
+clips/
 
 *.pch
 nohup.out

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ instead of locally (see [scripts/hf/README.md](scripts/hf/README.md)).
 | `Mjlab-GroundPick-{Flat,Rough}-MicroDuck` | flat/rough | Crouch and touch the ground with the mouth tip, return to stand |
 | `Mjlab-BallKick-Flat-MicroDuck` | flat | Kick a 70 mm / 15 g ball forward (actor is ball-blind) |
 | `Mjlab-Roulade-Flat-MicroDuck` | flat | Forward roll over the head, land back on the feet |
+| `Mjlab-PlayDead-{Flat,Rough}-MicroDuck` | flat/rough | Stand → flop onto the back and **hold** (opposite of standup) |
 | `Mjlab-Velocity-Flat-MicroDuck-Rollers` | flat | Roller-skate velocity tracking (passive wheels under the feet) |
 | `Mjlab-Velocity-Swizzle-MicroDuck` | flat | Classic symmetric swizzle skating |
 | `Mjlab-RollerCrouch-Flat-MicroDuck` | flat | Crouch while gliding on rollers |
@@ -84,11 +85,14 @@ over the robot at any moment. `scripts/infer_policy.py` rehearses exactly that:
 
 ```bash
 uv run scripts/infer_policy.py --walking walk.onnx --standing stand.onnx \
-    --sitstand sitstand.onnx --roulade roulade.onnx --new-cmd-obs
+    --sitstand sitstand.onnx --roulade roulade.onnx --playdead playdead.onnx \
+    --new-cmd-obs
 ```
 
 Keyboard-driven (velocity commands, `G` ground pick, `Y` sit/stand, `R` roulade,
-`K`/`L` kicks); `--debug`, `--save-csv`, `--record` support sim2real comparisons.
+`K`/`L` kicks, `D` play-dead); `--debug`, `--save-csv`, `--record` support
+sim2real comparisons. Play-dead holds until `D` again — swap standup/sitstand
+to revive; handing walk back from a dead pose is a fall.
 
 ### Backlash variants
 

--- a/scripts/infer_policy.py
+++ b/scripts/infer_policy.py
@@ -13,6 +13,11 @@ import termios
 import threading
 import time
 import tty
+
+# EGL must be selected before libmujoco creates a GL context (headless clips).
+if any(a == "--headless" for a in sys.argv):
+    os.environ.setdefault("MUJOCO_GL", "egl")
+
 import numpy as np
 import mujoco
 import mujoco.viewer
@@ -263,8 +268,16 @@ class PolicyInference:
 
         # Validate at least one policy loaded. A sitstand policy can run alone
         # (it holds the stand at flag=0), unlike the old one-way sit policy.
-        if not self.walking_session and not self.standing_session and not self.is_sitstand:
-            raise ValueError("At least one of --walking, --standing or --sitstand must be provided")
+        # Play-dead-only is allowed for clip recording (hold HOME, then flop).
+        if (
+            not self.walking_session
+            and not self.standing_session
+            and not self.is_sitstand
+            and "playdead" not in self.behavior_sessions
+        ):
+            raise ValueError(
+                "At least one of --walking, --standing, --sitstand or --playdead must be provided"
+            )
 
         # Determine initial active session and policy
         if self.walking_session:
@@ -273,10 +286,15 @@ class PolicyInference:
         elif self.standing_session:
             self.current_policy = "standing"
             self.ort_session = self.standing_session
-        else:
+        elif self.is_sitstand:
             # sitstand-only: start standing (posture flag 0).
             self.current_policy = "sit"
             self.ort_session = self.sit_session
+        else:
+            self.current_policy = "playdead"
+            self.ort_session = self.behavior_sessions["playdead"]
+            self.behavior_mode = "playdead"
+            self.behavior_time_left = float("inf")
 
         # Get input/output names from active session
         self.input_name = self.ort_session.get_inputs()[0].name
@@ -839,6 +857,12 @@ def main():
     parser.add_argument("--debug", action="store_true", help="Print observations and actions")
     parser.add_argument("--save-csv", type=str, default=None, help="Save observations and actions to CSV file")
     parser.add_argument("--record", type=str, default=None, help="Enable recording mode: save observations to pickle file on Ctrl+C")
+    parser.add_argument("--video", type=str, default=None, help="Write an mp4 (offscreen EGL renderer). Headless if --headless, else alongside the viewer.")
+    parser.add_argument("--video-seconds", type=float, default=6.0, help="Clip length when --headless (default 6.0). Ignored with the live viewer (record until Q).")
+    parser.add_argument("--video-width", type=int, default=1280)
+    parser.add_argument("--video-height", type=int, default=720)
+    parser.add_argument("--headless", action="store_true", help="No viewer — render --video and exit. For X clips.")
+    parser.add_argument("--auto-playdead", action="store_true", help="Hold the stand for 0.5s then trigger play-dead (clip mode).")
     parser.add_argument("--switch-threshold", type=float, default=0.05, help="Vel command magnitude threshold for walking/standing switch (default: 0.05)")
     parser.add_argument("--ground-pick-period", type=float, default=4.0, help="Ground pick phase period in seconds (default: 4.0)")
     parser.add_argument("--new-cmd-obs", action="store_true",
@@ -859,8 +883,12 @@ def main():
                              "compliant PU sole. e.g. --foot-solref 0.04")
     args = parser.parse_args()
 
-    if not args.walking and not args.standing and not args.sitstand:
-        parser.error("At least one of --walking, --standing or --sitstand must be provided")
+    if not args.walking and not args.standing and not args.sitstand and not args.playdead:
+        parser.error("At least one of --walking, --standing, --sitstand or --playdead must be provided")
+    if args.headless and not args.video:
+        parser.error("--headless requires --video PATH.mp4")
+    if args.auto_playdead and not args.playdead:
+        parser.error("--auto-playdead requires --playdead")
     if args.sitstand and not args.new_cmd_obs:
         parser.error("--sitstand policies use the unified 13D command obs (61D); add --new-cmd-obs")
     if (args.kick_left or args.kick_right or args.roulade or args.playdead) and not args.new_cmd_obs:
@@ -895,6 +923,9 @@ def main():
     print(f"Loading MuJoCo model from: {xml_path}")
     model = mujoco.MjModel.from_xml_path(xml_path)
     model.opt.timestep = 0.005
+    if args.video:
+        model.vis.global_.offwidth = max(model.vis.global_.offwidth, args.video_width)
+        model.vis.global_.offheight = max(model.vis.global_.offheight, args.video_height)
     data = mujoco.MjData(model)
 
     # XL330 firmware current limit. The motors saturate current at ~1.75 A; since
@@ -1052,11 +1083,34 @@ def main():
 
     csv_data = [] if args.save_csv else None
     recorded_observations = [] if args.record else None
-    policy_enabled = not args.record
+    policy_enabled = not args.record and not args.auto_playdead
     policy_enable_time = None
     original_kp = None
+    auto_playdead_fired = not args.auto_playdead
     if args.record:
         original_kp = model.actuator_gainprm[:, 0].copy()
+
+    video_writer = None
+    renderer = None
+    clip_cam = None
+    if args.video:
+        import imageio
+        renderer = mujoco.Renderer(model, height=args.video_height, width=args.video_width)
+        clip_cam = mujoco.MjvCamera()
+        mujoco.mjv_defaultFreeCamera(model, clip_cam)
+        clip_cam.azimuth = 150.0
+        clip_cam.elevation = -20.0
+        clip_cam.distance = 0.62
+        os.makedirs(os.path.dirname(os.path.abspath(args.video)) or ".", exist_ok=True)
+        video_writer = imageio.get_writer(
+            args.video,
+            fps=int(round(1.0 / control_dt)),
+            format="FFMPEG",
+            mode="I",
+            codec="libx264",
+            ffmpeg_params=["-pix_fmt", "yuv420p", "-crf", "18"],
+        )
+        print(f"Recording mp4 → {args.video} ({args.video_width}x{args.video_height} @ {int(round(1.0 / control_dt))} fps)")
 
     # Cache the trunk freejoint qvel address so the push handler can write to
     # the trunk's world-frame linear velocity directly (qvel[0..3]).
@@ -1222,6 +1276,10 @@ def main():
     print("  L:                kick with RIGHT foot (requires --kick-right)")
     print("  R:                roulade / forward roll (requires --roulade)")
     print("  D:                play dead (requires --playdead; D again to revive)")
+    if args.headless:
+        print(f"Headless clip: {args.video_seconds:.1f}s → {args.video}")
+        if args.auto_playdead:
+            print("  auto-playdead at t=0.5s")
     print(f"  P:                random push (trunk vel = {PUSH_MAX:.1f} m/s in random direction)")
     print("  Q:                quit")
     print("  [ Body pose mode — press B to toggle ]")
@@ -1238,8 +1296,32 @@ def main():
     print("  A / E:            head_roll ±step")
     print("  SPACE:            reset head offset to zero")
 
-    with TerminalInput() as term, \
-         mujoco.viewer.launch_passive(model, data, show_left_ui=False, show_right_ui=False) as viewer:
+    class _NullTerm:
+        def get_keys(self):
+            return []
+        def __enter__(self):
+            return self
+        def __exit__(self, *exc):
+            return False
+
+    class _HeadlessViewer:
+        def is_running(self):
+            return True
+        def sync(self):
+            return None
+        def __enter__(self):
+            return self
+        def __exit__(self, *exc):
+            return False
+
+    term_ctx = _NullTerm() if args.headless else TerminalInput()
+    viewer_ctx = (
+        _HeadlessViewer()
+        if args.headless
+        else mujoco.viewer.launch_passive(model, data, show_left_ui=False, show_right_ui=False)
+    )
+
+    with term_ctx as term, viewer_ctx as viewer:
         viewer.sync()
         start_time = time.time()
 
@@ -1270,6 +1352,16 @@ def main():
                                 model.actuator_biasprm[i, 1] = -kp
                             print("Policy inference enabled (after 1s standby)")
                             print(f"  Restored original kp gains (range: [{original_kp.min():.2f}, {original_kp.max():.2f}])")
+
+                sim_t = control_step_count * control_dt
+                if args.auto_playdead and not auto_playdead_fired and sim_t >= 0.5:
+                    policy_enabled = True
+                    if policy.behavior_mode != "playdead":
+                        policy.trigger_behavior("playdead")
+                    auto_playdead_fired = True
+                    print("auto-playdead: triggered")
+                if args.headless and sim_t >= args.video_seconds:
+                    quit_requested = True
 
                 actual_dt = step_start - prev_step_time
                 prev_step_time = step_start
@@ -1367,17 +1459,28 @@ def main():
                 for _ in range(decimation):
                     mujoco.mj_step(model, data)
 
+                if renderer is not None and video_writer is not None and clip_cam is not None:
+                    clip_cam.lookat[:] = data.qpos[qpos_adr:qpos_adr + 3]
+                    clip_cam.lookat[2] += 0.02
+                    renderer.update_scene(data, camera=clip_cam)
+                    video_writer.append_data(np.asarray(renderer.render()))
+
                 viewer.sync()
 
                 elapsed = time.time() - step_start
-                sleep_time = control_dt - elapsed
-                if sleep_time > 0:
-                    time.sleep(sleep_time)
+                if not args.headless:
+                    sleep_time = control_dt - elapsed
+                    if sleep_time > 0:
+                        time.sleep(sleep_time)
 
         except KeyboardInterrupt:
             print("\n\nKeyboardInterrupt received (Ctrl+C). Saving data...")
 
     print("\nInference stopped.")
+
+    if video_writer is not None:
+        video_writer.close()
+        print(f"Wrote clip: {args.video}")
 
     if csv_data is not None and len(csv_data) > 0:
         print(f"\nSaving {len(csv_data)} steps to: {args.save_csv}")

--- a/scripts/infer_policy.py
+++ b/scripts/infer_policy.py
@@ -137,8 +137,8 @@ class PolicyInference:
                  sit_onnx_path=None, new_cmd_obs=False, slope_onnx_path=None,
                  sitstand_onnx_path=None,
                  kick_left_onnx_path=None, kick_right_onnx_path=None,
-                 roulade_onnx_path=None,
-                 kick_duration=3.0, roulade_duration=2.0):
+                 roulade_onnx_path=None, playdead_onnx_path=None,
+                 kick_duration=3.0, roulade_duration=2.0, playdead_duration=0.0):
         self.model = model
         self.data = data
         self.action_scale = action_scale
@@ -231,11 +231,12 @@ class PolicyInference:
             sl_input_shape = self.slope_session.get_inputs()[0].shape
             print(f"Slope policy input shape: {sl_input_shape}")
 
-        # Episodic behavior policies (kick left/right, roulade). All three use
-        # the unified 61D obs layout with an ALL-ZERO 13D command (twist forced
-        # ~0 in training, head/body slots zero-padded), so triggering one is a
-        # plain session swap; after `duration` seconds control hands back to
-        # walking/standing (the behavior policies end standing on their own).
+        # Episodic behavior policies (kick left/right, roulade, play-dead). All
+        # use the unified 61D obs layout with an ALL-ZERO 13D command (twist
+        # forced ~0 in training, head/body slots zero-padded), so triggering
+        # one is a plain session swap. Kick/roulade end standing and auto-return
+        # after `duration`. Play-dead HOLDS: duration 0 means stay dead until
+        # D is pressed again (handing back to walk from a dead pose is a fall).
         self.behavior_sessions = {}
         self.behavior_durations = {}
         self.behavior_mode = None       # name of the running behavior, or None
@@ -244,6 +245,7 @@ class PolicyInference:
             ("kick_left", kick_left_onnx_path, kick_duration),
             ("kick_right", kick_right_onnx_path, kick_duration),
             ("roulade", roulade_onnx_path, roulade_duration),
+            ("playdead", playdead_onnx_path, playdead_duration),
         ):
             if not path:
                 continue
@@ -255,8 +257,9 @@ class PolicyInference:
             print(f"\nLoading {name} policy from: {path}")
             self.behavior_sessions[name] = ort.InferenceSession(path)
             self.behavior_durations[name] = duration
+            hold = "hold until D again" if duration <= 0.0 else f"auto-return after {duration:.1f}s"
             print(f"{name} policy input shape: {self.behavior_sessions[name].get_inputs()[0].shape}"
-                  f"  (auto-return after {duration:.1f}s)")
+                  f"  ({hold})")
 
         # Validate at least one policy loaded. A sitstand policy can run alone
         # (it holds the stand at flag=0), unlike the old one-way sit policy.
@@ -649,15 +652,19 @@ class PolicyInference:
         self.command[2] = 0.0
 
     def trigger_behavior(self, name):
-        """Start an episodic behavior (kick_left / kick_right / roulade).
+        """Start an episodic behavior (kick_left / kick_right / roulade / playdead).
 
-        The behavior policies were trained to run from a standing start with an
-        all-zero command and end standing, so triggering is a session swap; a
-        timer hands control back to walking/standing afterwards.
+        Kick/roulade were trained to run from a standing start with an all-zero
+        command and end standing, so triggering is a session swap; a timer hands
+        control back to walking/standing afterwards. Play-dead does NOT end
+        standing: press D again to hand back (or pass --playdead-duration > 0).
         """
         session = self.behavior_sessions.get(name)
         if session is None:
             print(f"{name} unavailable: no --{name.replace('_', '-')} policy loaded")
+            return
+        if name == "playdead" and self.behavior_mode == "playdead":
+            self._end_behavior()
             return
         if self.behavior_mode is not None:
             print(f"Cannot start {name}: {self.behavior_mode} already in progress")
@@ -674,12 +681,16 @@ class PolicyInference:
         if name in ("kick_left", "kick_right"):
             self._place_ball(name)
         self.behavior_mode = name
-        self.behavior_time_left = self.behavior_durations[name]
+        duration = self.behavior_durations[name]
+        self.behavior_time_left = float("inf") if duration <= 0.0 else duration
         self.vel_cmd = np.zeros(3, dtype=np.float32)
         self.current_policy = name
         self.ort_session = session
         self._update_command()
-        print(f"{name}: started (auto-return in {self.behavior_time_left:.1f}s)")
+        if duration <= 0.0:
+            print(f"{name}: started (hold until D again)")
+        else:
+            print(f"{name}: started (auto-return in {self.behavior_time_left:.1f}s)")
 
     def _place_ball(self, behavior):
         """Teleport the ball in front of the kicking foot, matching training's
@@ -702,6 +713,8 @@ class PolicyInference:
     def update_behavior(self, dt: float):
         """Advance the behavior timer; hand back to walking/standing when done."""
         if self.behavior_mode is None:
+            return
+        if self.behavior_time_left == float("inf"):
             return
         self.behavior_time_left -= dt
         if self.behavior_time_left <= 0.0:
@@ -813,8 +826,10 @@ def main():
     parser.add_argument("--kick-left", type=str, default=None, help="Path to LEFT-foot ball kick policy ONNX (press K to trigger). Requires --new-cmd-obs. Loads a scene with a ball.")
     parser.add_argument("--kick-right", type=str, default=None, help="Path to RIGHT-foot ball kick policy ONNX (press L to trigger). Requires --new-cmd-obs. Loads a scene with a ball.")
     parser.add_argument("--roulade", type=str, default=None, help="Path to roulade (forward roll) policy ONNX (press R to trigger). Requires --new-cmd-obs.")
+    parser.add_argument("--playdead", type=str, default=None, help="Path to play-dead policy ONNX (press D to trigger). Stand → flop and hold. Requires --new-cmd-obs.")
     parser.add_argument("--kick-duration", type=float, default=3.0, help="Seconds a kick policy stays active before handing back to standing/walking (default: 3.0)")
     parser.add_argument("--roulade-duration", type=float, default=2.0, help="Seconds the roulade policy stays active before handing back to standing/walking (default: 2.0, ~the roll itself; the standing/walking policy takes over for the settle)")
+    parser.add_argument("--playdead-duration", type=float, default=0.0, help="Seconds the play-dead policy stays active before handing back. 0 (default) = hold until D again — play-dead does not end standing.")
     parser.add_argument("--lin-vel-x", type=float, default=0.0, help="Initial linear velocity X command (m/s)")
     parser.add_argument("--lin-vel-y", type=float, default=0.0, help="Initial linear velocity Y command (m/s)")
     parser.add_argument("--ang-vel-z", type=float, default=0.0, help="Initial angular velocity Z command (rad/s)")
@@ -848,10 +863,10 @@ def main():
         parser.error("At least one of --walking, --standing or --sitstand must be provided")
     if args.sitstand and not args.new_cmd_obs:
         parser.error("--sitstand policies use the unified 13D command obs (61D); add --new-cmd-obs")
-    if (args.kick_left or args.kick_right or args.roulade) and not args.new_cmd_obs:
-        parser.error("--kick-left/--kick-right/--roulade policies use the unified 13D command obs (61D); add --new-cmd-obs")
-    if (args.kick_left or args.kick_right or args.roulade) and args.roller:
-        parser.error("kick/roulade policies are trained on the walking robot, not the roller model")
+    if (args.kick_left or args.kick_right or args.roulade or args.playdead) and not args.new_cmd_obs:
+        parser.error("--kick-left/--kick-right/--roulade/--playdead policies use the unified 13D command obs (61D); add --new-cmd-obs")
+    if (args.kick_left or args.kick_right or args.roulade or args.playdead) and args.roller:
+        parser.error("kick/roulade/playdead policies are trained on the walking robot, not the roller model")
 
     # Parse delay arguments
     delay_min_lag = 0
@@ -936,8 +951,10 @@ def main():
         kick_left_onnx_path=args.kick_left,
         kick_right_onnx_path=args.kick_right,
         roulade_onnx_path=args.roulade,
+        playdead_onnx_path=args.playdead,
         kick_duration=args.kick_duration,
         roulade_duration=args.roulade_duration,
+        playdead_duration=args.playdead_duration,
     )
     policy.set_vel_cmd(args.lin_vel_x, args.lin_vel_y, args.ang_vel_z)
 
@@ -1015,7 +1032,7 @@ def main():
         print(f"{kind} policy: loaded  (press Y to toggle)")
     if policy.slope_session:
         print(f"Slope policy: loaded  (press Y to toggle, passive descent)")
-    _behavior_keys = {"kick_left": "K", "kick_right": "L", "roulade": "R"}
+    _behavior_keys = {"kick_left": "K", "kick_right": "L", "roulade": "R", "playdead": "D"}
     for _name in policy.behavior_sessions:
         print(f"{_name} policy: loaded  (press {_behavior_keys[_name]}, "
               f"auto-return after {policy.behavior_durations[_name]:.1f}s)")
@@ -1135,6 +1152,8 @@ def main():
                 policy.trigger_behavior("kick_right")
             elif key == "r":
                 policy.trigger_behavior("roulade")
+            elif key == "d":
+                policy.trigger_behavior("playdead")
             elif key == "q":
                 quit_requested = True
                 print("Quit requested")
@@ -1202,6 +1221,7 @@ def main():
     print("  K:                kick with LEFT foot (requires --kick-left)")
     print("  L:                kick with RIGHT foot (requires --kick-right)")
     print("  R:                roulade / forward roll (requires --roulade)")
+    print("  D:                play dead (requires --playdead; D again to revive)")
     print(f"  P:                random push (trunk vel = {PUSH_MAX:.1f} m/s in random direction)")
     print("  Q:                quit")
     print("  [ Body pose mode — press B to toggle ]")

--- a/src/mjlab_microduck/tasks/__init__.py
+++ b/src/mjlab_microduck/tasks/__init__.py
@@ -67,6 +67,10 @@ from .microduck_roulade_env_cfg import (
     make_microduck_roulade_env_cfg,
     MicroduckRouladeRlCfg,
 )
+from .microduck_playdead_env_cfg import (
+    make_microduck_playdead_env_cfg,
+    MicroduckPlayDeadRlCfg,
+)
 from .backlash import make_backlash_variant
 
 # Standard velocity task
@@ -225,6 +229,23 @@ register_mjlab_task(
     runner_cls=MicroduckOnPolicyRunner,
 )
 
+# Play-dead — stand → flop onto the back and HOLD (opposite of standup).
+register_mjlab_task(
+    task_id="Mjlab-PlayDead-Flat-MicroDuck",
+    env_cfg=make_microduck_playdead_env_cfg(),
+    play_env_cfg=make_microduck_playdead_env_cfg(play=True),
+    rl_cfg=MicroduckPlayDeadRlCfg,
+    runner_cls=MicroduckOnPolicyRunner,
+)
+
+register_mjlab_task(
+    task_id="Mjlab-PlayDead-Rough-MicroDuck",
+    env_cfg=make_microduck_playdead_env_cfg(rough=True),
+    play_env_cfg=make_microduck_playdead_env_cfg(play=True, rough=True),
+    rl_cfg=MicroduckPlayDeadRlCfg,
+    runner_cls=MicroduckOnPolicyRunner,
+)
+
 # Backlash variants — ±1° serial gear play per servo + encoder-through-backlash
 # actuator feedback and joint obs (see tasks/backlash.py). Each family keeps its
 # base task's collision model: Velocity → robot_walk_backlash.xml,
@@ -255,6 +276,8 @@ _BACKLASH_TASKS = (
     ("Mjlab-GroundPick-Flat-Backlash-MicroDuck", make_microduck_ground_pick_env_cfg, {}, MicroduckGroundPickRlCfg, _BL_ALLCOL),
     ("Mjlab-GroundPick-Rough-Backlash-MicroDuck", make_microduck_ground_pick_env_cfg, {"rough": True}, MicroduckGroundPickRlCfg, _BL_ALLCOL),
     ("Mjlab-BallKick-Flat-Backlash-MicroDuck", make_microduck_ball_kick_env_cfg, {}, MicroduckBallKickRlCfg, _BL_ALLCOL),
+    ("Mjlab-PlayDead-Flat-Backlash-MicroDuck", make_microduck_playdead_env_cfg, {}, MicroduckPlayDeadRlCfg, _BL_ALLCOL),
+    ("Mjlab-PlayDead-Rough-Backlash-MicroDuck", make_microduck_playdead_env_cfg, {"rough": True}, MicroduckPlayDeadRlCfg, _BL_ALLCOL),
     ("Mjlab-Velocity-Flat-Backlash-MicroDuck-Rollers", make_microduck_velocity_rollers_env_cfg, {}, MicroduckRollersRlCfg, _BL_ROLLERS),
     ("Mjlab-Velocity-Swizzle-Backlash-MicroDuck", make_microduck_velocity_swizzle_env_cfg, {}, MicroduckSwizzleRlCfg, _BL_ROLLERS),
     ("Mjlab-RollerCrouch-Flat-Backlash-MicroDuck", make_microduck_roller_crouch_env_cfg, {}, MicroduckRollerCrouchRlCfg, _BL_ROLLERS),

--- a/src/mjlab_microduck/tasks/mdp.py
+++ b/src/mjlab_microduck/tasks/mdp.py
@@ -5192,6 +5192,179 @@ def head_pose_tracking(
     return per_joint.mean(dim=-1)
 
 
+def body_supine_cos_from_quat(quat: torch.Tensor) -> torch.Tensor:
+    """World-z of body +X: +1 supine (belly up), −1 prone, 0 standing.
+
+    Play-dead is ON THE BACK. ``body_upright_linear`` / upright_cos cannot
+    tell that from a face-plant or a headstand: all three can look "inverted".
+    Face-up spawn is −90° pitch, which leaves body X pointing at the sky
+    (see ``set_random_ground_state``). R[2, 0] = 2 (xz − wy) for [w, x, y, z].
+    """
+    w, x, y, z = quat[:, 0], quat[:, 1], quat[:, 2], quat[:, 3]
+    return torch.nan_to_num(2.0 * (x * z - w * y), nan=0.0)
+
+
+def _supine_cos(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    asset: Entity = env.scene[asset_cfg.name]
+    return body_supine_cos_from_quat(asset.data.root_link_quat_w)
+
+
+def _trunk_z(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    asset: Entity = env.scene[asset_cfg.name]
+    return torch.nan_to_num(
+        asset.data.root_link_pos_w[:, 2] - env.scene.terrain.env_origins[:, 2], nan=0.0
+    )
+
+
+def _trunk_ang_norm(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    asset: Entity = env.scene[asset_cfg.name]
+    return torch.linalg.norm(
+        torch.nan_to_num(asset.data.root_link_ang_vel_w, nan=0.0), dim=-1
+    )
+
+
+def body_supine_linear(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> torch.Tensor:
+    """+1 fully supine (play-dead), 0 standing, −1 face-down.
+
+    Linear in pitch around standing, so a back-lean has gradient from t=0.
+    Face-down is the opposite sign — the policy is punished for a face-plant.
+    """
+    return _supine_cos(env, asset_cfg)
+
+
+def supine_gaussian(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    std: float = 0.45,
+) -> torch.Tensor:
+    """Sharp peak at fully supine (``supine_cos`` = +1)."""
+    err = 1.0 - _supine_cos(env, asset_cfg)
+    return torch.exp(-(err / std) ** 2)
+
+
+def playdead_height_gaussian(
+    env: ManagerBasedRlEnv,
+    target_height: float,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    std: float = 0.04,
+) -> torch.Tensor:
+    """Height Gaussian toward the dead rest, gated to the back side of horizontal.
+
+    Ungated, sitting (z ≈ 0.060 vs DEAD_Z ≈ 0.050) scores ~0.94 of the peak
+    while staying upright — the sit basin AGENTS.md warns about. Multiplying
+    by ``clamp(supine_cos, 0, 1)`` makes the peak available only on the back.
+    """
+    gate = torch.clamp(_supine_cos(env, asset_cfg), min=0.0)
+    z = _trunk_z(env, asset_cfg)
+    return gate * torch.exp(-((z - target_height) / std) ** 2)
+
+
+def playdead_height_l1(
+    env: ManagerBasedRlEnv,
+    target_height: float,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> torch.Tensor:
+    """Gated L1 companion to ``playdead_height_gaussian`` (already ≤ 0)."""
+    gate = torch.clamp(_supine_cos(env, asset_cfg), min=0.0)
+    z = _trunk_z(env, asset_cfg)
+    return gate * (-torch.abs(z - target_height))
+
+
+def com_downward_velocity(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    min_height: float = 0.07,
+    max_vz: float = 0.25,
+    min_supine: float = 0.0,
+) -> torch.Tensor:
+    """Reward downward CoM velocity while still high AND already on the back side.
+
+    Zero below ``min_height`` so a dead duck cannot farm bounce-and-drop.
+    Zero at ``supine_cos <= min_supine`` so a polite sit cannot farm the drop.
+    ``max_vz`` caps the jackpot (explosive launch onto the back).
+    """
+    asset: Entity = env.scene[asset_cfg.name]
+    com_z = _trunk_z(env, asset_cfg)
+    vz = torch.nan_to_num(asset.data.root_link_lin_vel_w[:, 2], nan=0.0)
+    above = (com_z > min_height).float()
+    on_back = (_supine_cos(env, asset_cfg) > min_supine).float()
+    return torch.clamp(-vz, min=0.0, max=max_vz) * above * on_back
+
+
+def playdead_hold(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    height_high: float = 0.08,
+    min_supine: float = 0.2,
+    vel_std: float = 0.4,
+) -> torch.Tensor:
+    """Stillness bonus only when already supine and low — the hold, not the fall."""
+    z = _trunk_z(env, asset_cfg)
+    dead = (z < height_high).float() * (_supine_cos(env, asset_cfg) > min_supine).float()
+    return dead * torch.exp(-(_trunk_ang_norm(env, asset_cfg) / vel_std) ** 2)
+
+
+def trunk_grounded_supine(
+    env: ManagerBasedRlEnv,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    min_supine: float = 0.2,
+) -> torch.Tensor:
+    """Trunk-terrain contact while supine (play-dead, not a polite sit)."""
+    if sensor_name not in env.scene.sensors:
+        return torch.zeros(env.num_envs, device=env.device)
+    sensor = env.scene.sensors[sensor_name]
+    found = sensor.data.found
+    if found.dim() > 1:
+        found = found.sum(dim=-1)
+    has_contact = (found > 0).float()
+    on_back = (_supine_cos(env, asset_cfg) >= min_supine).float()
+    return has_contact * on_back
+
+
+def playdead_composite_from_values(
+    supine_cos: torch.Tensor,
+    z: torch.Tensor,
+    ang_norm: torch.Tensor,
+    target_height: float,
+    height_std: float = 0.04,
+    supine_std: float = 0.45,
+    vel_std: float = 0.4,
+) -> torch.Tensor:
+    """Product of Gaussians: height × supine × stillness.
+
+    Sitting / standing / face-down / side all collapse on at least one factor.
+    Broad stds so a nearly-dead pose still scores visibly (~0.2+).
+    """
+    height = torch.exp(-((z - target_height) / height_std) ** 2)
+    supine = torch.exp(-((1.0 - supine_cos) / supine_std) ** 2)
+    still = torch.exp(-(ang_norm / vel_std) ** 2)
+    return height * supine * still
+
+
+def playdead_composite(
+    env: ManagerBasedRlEnv,
+    target_height: float,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    height_std: float = 0.04,
+    supine_std: float = 0.45,
+    vel_std: float = 0.4,
+) -> torch.Tensor:
+    """Multiplicative goal-state score for play-dead (see ``playdead_composite_from_values``)."""
+    return playdead_composite_from_values(
+        _supine_cos(env, asset_cfg),
+        _trunk_z(env, asset_cfg),
+        _trunk_ang_norm(env, asset_cfg),
+        target_height=target_height,
+        height_std=height_std,
+        supine_std=supine_std,
+        vel_std=vel_std,
+    )
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # NaN-safe wrappers for the sensor-derived critic observations.
 #

--- a/src/mjlab_microduck/tasks/microduck_playdead_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_playdead_env_cfg.py
@@ -1,0 +1,510 @@
+"""Microduck play-dead task — stand → flop onto the BACK and HOLD.
+
+Episodic hot-swap trick (same 61D contract as roulade / kick). Deployment:
+swap ONNX in, duck goes down and stays; swap sitstand/standup to revive.
+
+Why this env exists: sit is a polite sit, roulade lands on its feet, standup
+starts already down. Nothing in the pad means "die and stay dead."
+
+Play-dead is SUPINE (belly up, −90° pitch), not "inverted". upright_cos = −1
+is a headstand AND a face-plant — the policy will farm whichever is cheaper.
+The orientation signal is world-z of body +X (see body_supine_cos_from_quat).
+
+Reward (standup recipe, flipped): two-layer supine + gated height toward
+DEAD_Z + hold-still once down. Height terms are gated on supine_cos > 0 so
+sitting (z ≈ 0.060, upright) cannot collect the dead-height peak. |a_z| and
+too-fast descent are light taxes so it doesn't slam. No joint pose target —
+the fall path is RL's job.
+
+Reset mix: mostly standing (learn the flop) + a slice already supine (learn
+the hold). Reverse curriculum later raises the already-dead fraction.
+Face-down stays at 0 — rolling from belly to back is a different trick.
+"""
+
+from __future__ import annotations
+
+import math
+from copy import deepcopy
+
+ENABLE_SYMMETRY = True  # sagittal flop; mirror loss fights sideways collapse
+
+ENABLE_COM_RANDOMIZATION = True
+ENABLE_HEAD_COM_RANDOMIZATION = True
+ENABLE_KP_RANDOMIZATION = False
+ENABLE_KD_RANDOMIZATION = False
+ENABLE_MASS_INERTIA_RANDOMIZATION = True
+ENABLE_JOINT_FRICTION_RANDOMIZATION = True
+ENABLE_ARMATURE_RANDOMIZATION = True
+ENABLE_VELOCITY_PUSHES = False  # a shove mid-flop is incoherent
+ENABLE_IMU_ORIENTATION_RANDOMIZATION = True
+ENABLE_ENCODER_BIAS = True
+
+COM_RANDOMIZATION_RANGE = 0.003
+HEAD_COM_RANDOMIZATION_RANGE = 0.003
+MASS_INERTIA_RANDOMIZATION_RANGE = (0.95, 1.05)
+ARMATURE_RANDOMIZATION_RANGE = (0.9, 1.1)
+JOINT_FRICTION_RANDOMIZATION_RANGE = (0.9, 1.1)
+ENCODER_BIAS_RANGE = (-0.015, 0.015)
+IMU_ORIENTATION_RANDOMIZATION_ANGLE = 6.0
+
+EPISODE_LENGTH_S = 4.0
+STAND_Z = 0.115
+DEAD_Z = 0.050  # measured face-up trunk rest ~0.044; sit is 0.060
+
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.envs.mdp import dr
+from mjlab.envs.mdp.actions import JointPositionActionCfg
+from mjlab.managers import (
+    CurriculumTermCfg,
+    EventTermCfg,
+    ObservationTermCfg,
+    RewardTermCfg,
+    TerminationTermCfg,
+)
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.rl import RslRlOnPolicyRunnerCfg, RslRlModelCfg
+from mjlab.sensor import ContactMatch, ContactSensorCfg
+from mjlab.tasks.velocity import mdp
+from mjlab.tasks.velocity.velocity_env_cfg import make_velocity_env_cfg
+from mjlab.utils.noise import UniformNoiseCfg as Unoise
+
+from mjlab_microduck.robot.microduck_constants import MICRODUCK_STANDUP_ROBOT_CFG
+from mjlab_microduck.tasks import mdp as microduck_mdp
+from mjlab_microduck.tasks.microduck_velocity_env_cfg import (
+    HEAD_BODY_NAMES,
+    MICRODUCK_ROUGH_TERRAINS_CFG,
+)
+from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg, SYMMETRY_CFG
+
+
+def make_microduck_playdead_env_cfg(
+    play: bool = False,
+    rough: bool = False,
+) -> ManagerBasedRlEnvCfg:
+    feet_ground_cfg = ContactSensorCfg(
+        name="feet_ground_contact",
+        primary=ContactMatch(
+            mode="geom",
+            pattern=r"^(left_foot_collision|right_foot_collision)$",
+            entity="robot",
+        ),
+        secondary=ContactMatch(mode="body", pattern="terrain"),
+        fields=("found", "force"),
+        reduce="netforce",
+        num_slots=1,
+        track_air_time=True,
+    )
+    self_collision_cfg = ContactSensorCfg(
+        name="self_collision",
+        primary=ContactMatch(mode="subtree", pattern="trunk_base", entity="robot"),
+        secondary=ContactMatch(mode="subtree", pattern="trunk_base", entity="robot"),
+        fields=("found",),
+        reduce="none",
+        num_slots=1,
+    )
+    trunk_ground_cfg = ContactSensorCfg(
+        name="trunk_ground_contact",
+        primary=ContactMatch(mode="body", pattern="trunk_base", entity="robot"),
+        secondary=ContactMatch(mode="body", pattern="terrain"),
+        fields=("found", "force"),
+        reduce="netforce",
+        num_slots=1,
+    )
+
+    cfg = make_velocity_env_cfg()
+    cfg.scene.entities = {"robot": MICRODUCK_STANDUP_ROBOT_CFG}
+    cfg.scene.sensors = (feet_ground_cfg, self_collision_cfg, trunk_ground_cfg)
+    cfg.viewer.body_name = "trunk_base"
+    cfg.episode_length_s = EPISODE_LENGTH_S
+
+    joint_pos_action = cfg.actions["joint_pos"]
+    assert isinstance(joint_pos_action, JointPositionActionCfg)
+    joint_pos_action.scale = 1.0
+
+    for name in [
+        "track_linear_velocity",
+        "track_angular_velocity",
+        "air_time",
+        "foot_clearance",
+        "foot_swing_height",
+        "foot_slip",
+        "pose",
+        "upright",
+    ]:
+        if name in cfg.rewards:
+            del cfg.rewards[name]
+
+    # Two-layer supine. Linear has gradient from standing (back-lean);
+    # Gaussian peaks once on the back. Face-down is the opposite sign.
+    cfg.rewards["supine_linear"] = RewardTermCfg(
+        func=microduck_mdp.body_supine_linear,
+        weight=1.5,
+        params={"asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",))},
+    )
+    cfg.rewards["supine_sharp"] = RewardTermCfg(
+        func=microduck_mdp.supine_gaussian,
+        weight=1.5,
+        params={
+            "std": 0.45,
+            "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+        },
+    )
+    # Height peak is GATED on supine_cos > 0 so sitting cannot collect it.
+    cfg.rewards["height_dead"] = RewardTermCfg(
+        func=microduck_mdp.playdead_height_gaussian,
+        weight=1.0,
+        params={
+            "std": 0.04,
+            "target_height": DEAD_Z,
+            "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+        },
+    )
+    cfg.rewards["height_dead_l1"] = RewardTermCfg(
+        func=microduck_mdp.playdead_height_l1,
+        weight=5.0,
+        params={
+            "target_height": DEAD_Z,
+            "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+        },
+    )
+    cfg.rewards["com_downward_velocity"] = RewardTermCfg(
+        func=microduck_mdp.com_downward_velocity,
+        weight=0.75,
+        params={
+            "min_height": DEAD_Z + 0.02,
+            "max_vz": 0.25,
+            "min_supine": 0.0,
+            "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+        },
+    )
+    # Self-negating penalties → POSITIVE weight (AGENTS.md sign rule).
+    cfg.rewards["gentle_impact"] = RewardTermCfg(
+        func=microduck_mdp.trunk_vertical_accel_penalty,
+        weight=0.005,
+        params={"asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",))},
+    )
+    cfg.rewards["too_fast_drop"] = RewardTermCfg(
+        func=microduck_mdp.trunk_downward_velocity_penalty,
+        weight=0.5,
+        params={
+            "max_down_vel": 0.35,
+            "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+        },
+    )
+    cfg.rewards["playdead_hold"] = RewardTermCfg(
+        func=microduck_mdp.playdead_hold,
+        weight=2.0,
+        params={
+            "height_high": 0.08,
+            "min_supine": 0.2,
+            "vel_std": 0.4,
+            "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+        },
+    )
+    cfg.rewards["trunk_grounded_supine"] = RewardTermCfg(
+        func=microduck_mdp.trunk_grounded_supine,
+        weight=2.0,
+        params={
+            "sensor_name": trunk_ground_cfg.name,
+            "min_supine": 0.2,
+            "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+        },
+    )
+    # Product of Gaussians — sitting/standing/face-down/side all collapse.
+    # Not a binary per-step jackpot (those buy violence to arrive early).
+    cfg.rewards["playdead_composite"] = RewardTermCfg(
+        func=microduck_mdp.playdead_composite,
+        weight=3.0,
+        params={
+            "target_height": DEAD_Z,
+            "height_std": 0.04,
+            "supine_std": 0.45,
+            "vel_std": 0.4,
+            "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+        },
+    )
+
+    cfg.rewards["action_rate_l2"] = RewardTermCfg(func=mdp.action_rate_l2, weight=-0.1)
+    cfg.rewards["body_ang_vel"].params["asset_cfg"].body_names = ("trunk_base",)
+    cfg.rewards["body_ang_vel"].weight = -0.02  # light: flop needs rotation
+    cfg.rewards["angular_momentum"].weight = -0.01
+    cfg.rewards.pop("soft_landing", None)
+    cfg.rewards["self_collisions"] = RewardTermCfg(
+        func=mdp.self_collision_cost,
+        weight=-1.0,
+        params={"sensor_name": self_collision_cfg.name},
+    )
+
+    # ── Observations (61D: 48 proprio + twist3 + head4 + body6 pad) ────────
+    del cfg.observations["actor"].terms["base_lin_vel"]
+    cfg.observations["critic"].terms["base_lin_vel"] = ObservationTermCfg(
+        func=mdp.base_lin_vel, scale=1.0,
+    )
+    del cfg.observations["critic"].terms["foot_height"]
+    del cfg.observations["actor"].terms["height_scan"]
+    del cfg.observations["critic"].terms["height_scan"]
+    for _term, _safe in (
+        ("foot_contact_forces", microduck_mdp.foot_contact_forces_safe),
+        ("foot_air_time", microduck_mdp.foot_air_time_safe),
+    ):
+        if _term in cfg.observations["critic"].terms:
+            cfg.observations["critic"].terms[_term].func = _safe
+
+    gravity_term_name = "projected_gravity"
+    cfg.observations["actor"].terms[gravity_term_name] = deepcopy(
+        cfg.observations["actor"].terms[gravity_term_name]
+    )
+    cfg.observations["actor"].terms["base_ang_vel"] = deepcopy(
+        cfg.observations["actor"].terms["base_ang_vel"]
+    )
+    cfg.observations["actor"].terms["base_ang_vel"].delay_min_lag = 0
+    cfg.observations["actor"].terms["base_ang_vel"].delay_max_lag = 1
+    cfg.observations["actor"].terms["base_ang_vel"].delay_update_period = 64
+    cfg.observations["actor"].terms[gravity_term_name].delay_min_lag = 0
+    cfg.observations["actor"].terms[gravity_term_name].delay_max_lag = 1
+    cfg.observations["actor"].terms[gravity_term_name].delay_update_period = 64
+    cfg.observations["actor"].terms["base_ang_vel"].noise = Unoise(n_min=-0.03, n_max=0.03)
+    cfg.observations["actor"].terms[gravity_term_name].noise = Unoise(n_min=-0.01, n_max=0.01)
+    cfg.observations["actor"].terms["joint_pos"].noise = Unoise(n_min=-0.001, n_max=0.001)
+    cfg.observations["actor"].terms["joint_vel"].noise = Unoise(n_min=-0.25, n_max=0.25)
+
+    if ENABLE_IMU_ORIENTATION_RANDOMIZATION:
+        av = cfg.observations["actor"].terms["base_ang_vel"]
+        av.func = microduck_mdp.base_ang_vel_imu_misaligned
+        av.params = {"max_angle_deg": IMU_ORIENTATION_RANDOMIZATION_ANGLE}
+        g = cfg.observations["actor"].terms[gravity_term_name]
+        g.func = microduck_mdp.projected_gravity_imu_misaligned
+        g.params = {"max_angle_deg": IMU_ORIENTATION_RANDOMIZATION_ANGLE}
+
+    cfg.observations["actor"].terms["joint_vel"] = deepcopy(
+        cfg.observations["actor"].terms["joint_vel"]
+    )
+    cfg.observations["actor"].terms["joint_vel"].delay_min_lag = 1
+    cfg.observations["actor"].terms["joint_vel"].delay_max_lag = 1
+    cfg.observations["actor"].terms["joint_vel"].delay_update_period = 0
+
+    passive_excluded = SceneEntityCfg("robot", joint_names=(r"^(?!passive_).*",))
+    for grp in ("actor", "critic"):
+        for term in ("joint_pos", "joint_vel"):
+            cfg.observations[grp].terms[term] = deepcopy(cfg.observations[grp].terms[term])
+            cfg.observations[grp].terms[term].params["asset_cfg"] = deepcopy(passive_excluded)
+
+    if ENABLE_ENCODER_BIAS:
+        cfg.events["encoder_bias"].params["bias_range"] = ENCODER_BIAS_RANGE
+        cfg.observations["actor"].terms["joint_pos"].params["biased"] = True
+        cfg.observations["critic"].terms["joint_pos"].params["biased"] = False
+    else:
+        cfg.events.pop("encoder_bias", None)
+
+    # Command obs slots: zero padding for BOTH head (4) and body (6). The flop
+    # does not track a head/body command, but the 61D layout stays hot-swappable
+    # (runtime sends zeros). Same pattern as roulade.
+    for group in ("actor", "critic"):
+        cfg.observations[group].terms["head_command"] = ObservationTermCfg(
+            func=microduck_mdp.zero_command_padding, params={"dim": 4},
+        )
+        cfg.observations[group].terms["body_command"] = ObservationTermCfg(
+            func=microduck_mdp.zero_command_padding, params={"dim": 6},
+        )
+
+    command = cfg.commands["twist"]
+    command.rel_standing_envs = 0.0
+    command.rel_heading_envs = 0.0
+    command.heading_command = False
+    command.ranges.heading = None
+    command.resampling_time_range = (EPISODE_LENGTH_S, EPISODE_LENGTH_S * 2)
+    command.debug_vis = False
+    command.ranges.lin_vel_x = (-0.01, 0.01)
+    command.ranges.lin_vel_y = (-0.01, 0.01)
+    command.ranges.ang_vel_z = (-0.05, 0.05)
+    cfg.commands["twist"] = microduck_mdp.VelocityCommandCommandOnlyCfg(**vars(command))
+
+    if "fell_over" in cfg.terminations:
+        del cfg.terminations["fell_over"]
+    cfg.terminations["nan_state"] = TerminationTermCfg(
+        func=microduck_mdp.robot_state_is_nan,
+        time_out=False,
+        params={"sensor_names": ("feet_ground_contact", "trunk_ground_contact")},
+    )
+
+    cfg.events["expand_bam_friction_fields"] = EventTermCfg(
+        func=microduck_mdp.expand_bam_friction_fields,
+        mode="startup",
+    )
+    cfg.events["reset_action_history"] = EventTermCfg(
+        func=microduck_mdp.reset_action_history,
+        mode="reset",
+    )
+    foot_frictions_geom_names = ("left_foot_collision", "right_foot_collision")
+    cfg.events["foot_friction"].params["asset_cfg"].geom_names = foot_frictions_geom_names
+    cfg.events["foot_friction"].params["ranges"] = (0.7, 1.3)
+    if "push_robot" in cfg.events:
+        del cfg.events["push_robot"]
+
+    cfg.events["set_ground_state"] = EventTermCfg(
+        func=microduck_mdp.set_random_ground_state,
+        mode="reset",
+        params={
+            "face_down_prob": 0.00,
+            "face_up_prob": 0.25,  # already dead — train the hold
+            "sitting_prob": 0.00,
+            "standing_prob": 0.75,  # learn the flop
+            "prone_z_min": 0.05,
+            "prone_z_max": 0.09,
+            "face_up_roll_max": math.radians(40),
+            "standing_z_min": 0.11,
+            "standing_z_max": 0.12,
+        },
+    )
+
+    if ENABLE_COM_RANDOMIZATION:
+        cfg.events["randomize_com"] = EventTermCfg(
+            func=dr.body_ipos,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+                "operation": "add",
+                "ranges": (-COM_RANDOMIZATION_RANGE, COM_RANDOMIZATION_RANGE),
+            },
+        )
+    if ENABLE_HEAD_COM_RANDOMIZATION:
+        cfg.events["randomize_head_com"] = EventTermCfg(
+            func=dr.body_ipos,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg("robot", body_names=HEAD_BODY_NAMES),
+                "operation": "add",
+                "ranges": (-HEAD_COM_RANDOMIZATION_RANGE, HEAD_COM_RANDOMIZATION_RANGE),
+            },
+        )
+    if ENABLE_ARMATURE_RANDOMIZATION:
+        cfg.events["randomize_armature"] = EventTermCfg(
+            func=dr.joint_armature,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg("robot", joint_names=(r".*",)),
+                "operation": "scale",
+                "ranges": ARMATURE_RANDOMIZATION_RANGE,
+            },
+        )
+    if ENABLE_MASS_INERTIA_RANDOMIZATION:
+        _mi_lo, _mi_hi = MASS_INERTIA_RANDOMIZATION_RANGE
+        cfg.events["randomize_mass_inertia"] = EventTermCfg(
+            func=dr.pseudo_inertia,
+            mode="startup",
+            params={
+                "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+                "alpha_range": (math.log(_mi_lo) / 2.0, math.log(_mi_hi) / 2.0),
+            },
+        )
+    if ENABLE_JOINT_FRICTION_RANDOMIZATION:
+        cfg.events["randomize_joint_friction"] = EventTermCfg(
+            func=microduck_mdp.randomize_bam_friction,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg("robot"),
+                "scale_range": JOINT_FRICTION_RANDOMIZATION_RANGE,
+            },
+        )
+
+    if not rough:
+        cfg.scene.terrain.terrain_type = "plane"
+        cfg.scene.terrain.terrain_generator = None
+    else:
+        cfg.scene.terrain.terrain_type = "generator"
+        cfg.scene.terrain.terrain_generator = MICRODUCK_ROUGH_TERRAINS_CFG
+        if play:
+            cfg.scene.terrain.terrain_generator.curriculum = False
+            cfg.scene.terrain.terrain_generator.num_cols = 5
+            cfg.scene.terrain.terrain_generator.num_rows = 5
+
+    if not rough:
+        del cfg.curriculum["terrain_levels"]
+    del cfg.curriculum["command_vel"]
+
+    cfg.curriculum["ground_state_mix"] = CurriculumTermCfg(
+        func=microduck_mdp.event_param_curriculum,
+        params={
+            "event_name": "set_ground_state",
+            "param_stages": [
+                {"step": 0, "params": {"standing_prob": 0.75, "sitting_prob": 0.0, "face_down_prob": 0.0, "face_up_prob": 0.25}},
+                {"step": 400 * 24, "params": {"standing_prob": 0.55, "sitting_prob": 0.0, "face_down_prob": 0.0, "face_up_prob": 0.45}},
+                {"step": 1000 * 24, "params": {"standing_prob": 0.40, "sitting_prob": 0.0, "face_down_prob": 0.0, "face_up_prob": 0.60}},
+            ],
+        },
+    )
+    cfg.curriculum["action_rate_weight"] = CurriculumTermCfg(
+        func=microduck_mdp.reward_weight,
+        params={
+            "reward_name": "action_rate_l2",
+            "weight_stages": [
+                {"step": 0, "weight": -0.1},
+                {"step": 500 * 24, "weight": -0.3},
+                {"step": 1000 * 24, "weight": -0.6},
+            ],
+        },
+    )
+    if ENABLE_COM_RANDOMIZATION:
+        cfg.curriculum["com_range"] = CurriculumTermCfg(
+            func=microduck_mdp.com_range_curriculum,
+            params={
+                "event_name": "randomize_com",
+                "range_stages": [
+                    {"step": 0, "range": 0.003},
+                    {"step": 500 * 24, "range": 0.008},
+                    {"step": 1000 * 24, "range": 0.015},
+                ],
+            },
+        )
+
+    if play:
+        # Viewer should show both the flop (standing spawn) and the hold
+        # (already-dead spawn). Drop the mix curriculum or it overwrites this
+        # on the first reset (common_step_counter restarts at 0).
+        p = cfg.events["set_ground_state"].params
+        p["standing_prob"] = 0.5
+        p["face_up_prob"] = 0.5
+        p["sitting_prob"] = 0.0
+        p["face_down_prob"] = 0.0
+        cfg.curriculum.pop("ground_state_mix", None)
+    return cfg
+
+
+MicroduckPlayDeadRlCfg = RslRlOnPolicyRunnerCfg(
+    actor=RslRlModelCfg(
+        hidden_dims=(512, 256, 128),
+        activation="elu",
+        obs_normalization=True,
+        distribution_cfg={
+            "class_name": "GaussianDistribution",
+            "init_std": 1.0,
+            "std_type": "scalar",
+        },
+    ),
+    critic=RslRlModelCfg(
+        hidden_dims=(512, 256, 128),
+        activation="elu",
+        obs_normalization=True,
+    ),
+    algorithm=PpoWithSymmetryCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.01,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+        symmetry_cfg=SYMMETRY_CFG if ENABLE_SYMMETRY else None,
+    ),
+    wandb_project="mjlab_microduck",
+    experiment_name="microduck_playdead",
+    run_name="microduck_playdead",
+    save_interval=250,
+    num_steps_per_env=24,
+    max_iterations=2_000,  # simple episodic trick; 4k if the hold never settles
+)

--- a/tests/test_playdead_cfg.py
+++ b/tests/test_playdead_cfg.py
@@ -1,0 +1,273 @@
+"""Cfg invariants for Mjlab-PlayDead-*-MicroDuck.
+
+CPU only — no GPU, no env construction. Locks the 61D contract, the supine
+(not inverted) orientation signal, reward signs, and the sit-basin audit.
+"""
+
+import math
+
+import torch
+
+from mjlab_microduck.robot.microduck_constants import MICRODUCK_STANDUP_ROBOT_CFG
+from mjlab_microduck.tasks import mdp as microduck_mdp
+from mjlab_microduck.tasks.microduck_playdead_env_cfg import (
+    DEAD_Z,
+    STAND_Z,
+    MicroduckPlayDeadRlCfg,
+    make_microduck_playdead_env_cfg,
+)
+from mjlab_microduck.tasks.mdp import (
+    body_supine_cos_from_quat,
+    body_supine_linear,
+    com_downward_velocity,
+    playdead_composite,
+    playdead_composite_from_values,
+    playdead_height_gaussian,
+    playdead_height_l1,
+    playdead_hold,
+    supine_gaussian,
+    trunk_grounded_supine,
+    trunk_downward_velocity_penalty,
+    trunk_vertical_accel_penalty,
+)
+
+
+# Sit env's measured seated rest. Play-dead must not treat this as success.
+_SIT_Z = 0.060
+
+
+def test_playdead_task_rewards():
+    cfg = make_microduck_playdead_env_cfg()
+    r = cfg.rewards
+    assert r["supine_linear"].weight == 1.5
+    assert r["supine_linear"].func is body_supine_linear
+    assert r["supine_sharp"].func is supine_gaussian
+    assert r["height_dead"].func is playdead_height_gaussian
+    assert r["height_dead"].params["target_height"] == DEAD_Z
+    assert r["height_dead_l1"].func is playdead_height_l1
+    assert DEAD_Z < _SIT_Z < STAND_Z
+    assert r["com_downward_velocity"].func is com_downward_velocity
+    assert r["com_downward_velocity"].params["min_height"] > DEAD_Z
+    assert r["com_downward_velocity"].params["min_supine"] == 0.0
+    assert r["playdead_hold"].func is playdead_hold
+    assert r["trunk_grounded_supine"].func is trunk_grounded_supine
+    assert r["playdead_composite"].func is playdead_composite
+    assert r["playdead_composite"].params["target_height"] == DEAD_Z
+    # No binary per-step jackpot (arriving early then collecting an annuity).
+    assert "playdead_success" not in r
+    assert "inverted_linear" not in r
+    # Walking terms must be gone — upright would fight the flop.
+    for name in (
+        "track_linear_velocity",
+        "track_angular_velocity",
+        "air_time",
+        "foot_clearance",
+        "foot_swing_height",
+        "foot_slip",
+        "pose",
+        "upright",
+    ):
+        assert name not in r, name
+
+
+def test_self_negating_penalties_use_positive_weights():
+    cfg = make_microduck_playdead_env_cfg()
+    r = cfg.rewards
+    assert r["gentle_impact"].func is trunk_vertical_accel_penalty
+    assert r["too_fast_drop"].func is trunk_downward_velocity_penalty
+    assert r["height_dead_l1"].func is playdead_height_l1
+    for name in ("gentle_impact", "too_fast_drop", "height_dead_l1"):
+        assert r[name].weight > 0, name
+    for name in ("action_rate_l2", "body_ang_vel", "angular_momentum", "self_collisions"):
+        assert r[name].weight < 0, name
+
+
+def test_playdead_obs_slots_padded():
+    cfg = make_microduck_playdead_env_cfg()
+    for grp in ("actor", "critic"):
+        terms = cfg.observations[grp].terms
+        assert "command" in terms  # twist (3)
+        assert "head_command" in terms
+        assert "body_command" in terms
+        assert terms["head_command"].params["dim"] == 4
+        assert terms["body_command"].params["dim"] == 6
+        assert terms["head_command"].func is microduck_mdp.zero_command_padding
+        assert terms["body_command"].func is microduck_mdp.zero_command_padding
+
+
+def test_twist_command_is_neutralised():
+    cfg = make_microduck_playdead_env_cfg()
+    cmd = cfg.commands["twist"]
+    assert isinstance(cmd, microduck_mdp.VelocityCommandCommandOnlyCfg)
+    assert cmd.ranges.lin_vel_x == (-0.01, 0.01)
+    assert cmd.ranges.lin_vel_y == (-0.01, 0.01)
+    assert cmd.ranges.ang_vel_z == (-0.05, 0.05)
+    assert cmd.heading_command is False
+    assert cmd.ranges.heading is None
+    assert cmd.rel_standing_envs == 0.0
+
+
+def test_playdead_reset_mix():
+    cfg = make_microduck_playdead_env_cfg()
+    p = cfg.events["set_ground_state"].params
+    assert p["standing_prob"] == 0.75
+    assert p["face_up_prob"] == 0.25
+    assert p["sitting_prob"] == 0.0
+    assert p["face_down_prob"] == 0.0
+    assert abs(
+        p["standing_prob"] + p["face_up_prob"] + p["sitting_prob"] + p["face_down_prob"] - 1.0
+    ) < 1e-6
+
+
+def test_ground_state_event_runs_after_base_reset():
+    cfg = make_microduck_playdead_env_cfg()
+    order = list(cfg.events.keys())
+    assert order.index("set_ground_state") > order.index("reset_base")
+    assert order.index("set_ground_state") > order.index("reset_robot_joints")
+
+
+def test_no_fall_termination_and_no_push():
+    cfg = make_microduck_playdead_env_cfg()
+    assert "fell_over" not in cfg.terminations
+    assert "nan_state" in cfg.terminations
+    assert "push_robot" not in cfg.events
+    assert "expand_bam_friction_fields" in cfg.events
+
+
+def test_uses_allcollisions_robot():
+    cfg = make_microduck_playdead_env_cfg()
+    assert cfg.scene.entities["robot"] is MICRODUCK_STANDUP_ROBOT_CFG
+    names = [s.name for s in cfg.scene.sensors]
+    assert "feet_ground_contact" in names
+    assert "self_collision" in names
+    assert "trunk_ground_contact" in names
+
+
+def test_playdead_variants_build():
+    play = make_microduck_playdead_env_cfg(play=True)
+    assert play.episode_length_s == 4.0
+    p = play.events["set_ground_state"].params
+    assert p["standing_prob"] == 0.5
+    assert p["face_up_prob"] == 0.5
+    assert "ground_state_mix" not in play.curriculum
+    rough = make_microduck_playdead_env_cfg(rough=True)
+    assert rough.scene.terrain.terrain_type == "generator"
+    train = make_microduck_playdead_env_cfg()
+    assert "ground_state_mix" in train.curriculum
+
+
+def test_ground_state_curriculum_stays_on_back():
+    cfg = make_microduck_playdead_env_cfg()
+    stages = cfg.curriculum["ground_state_mix"].params["param_stages"]
+    steps = [s["step"] for s in stages]
+    assert steps[0] == 0 and steps == sorted(steps) and len(set(steps)) == len(steps)
+    face_up = [s["params"]["face_up_prob"] for s in stages]
+    assert face_up == sorted(face_up)
+    for stage in stages:
+        p = stage["params"]
+        total = p["standing_prob"] + p["sitting_prob"] + p["face_down_prob"] + p["face_up_prob"]
+        assert abs(total - 1.0) < 1e-9
+        assert p["sitting_prob"] == 0.0
+        assert p["face_down_prob"] == 0.0
+        assert p["standing_prob"] > 0.0
+
+
+def test_task_is_registered_with_backlash_twins():
+    from mjlab.tasks.registry import list_tasks
+
+    import mjlab_microduck.tasks  # noqa: F401
+
+    tasks = list_tasks()
+    for task_id in (
+        "Mjlab-PlayDead-Flat-MicroDuck",
+        "Mjlab-PlayDead-Rough-MicroDuck",
+        "Mjlab-PlayDead-Flat-Backlash-MicroDuck",
+        "Mjlab-PlayDead-Rough-Backlash-MicroDuck",
+    ):
+        assert task_id in tasks, task_id
+
+
+def test_runner_cfg():
+    assert MicroduckPlayDeadRlCfg.experiment_name == "microduck_playdead"
+    assert MicroduckPlayDeadRlCfg.algorithm.symmetry_cfg is not None
+    assert MicroduckPlayDeadRlCfg.actor.obs_normalization is True
+
+
+def test_trunk_asset_cfgs_are_distinct_objects():
+    cfg = make_microduck_playdead_env_cfg()
+    names = (
+        "supine_linear",
+        "supine_sharp",
+        "height_dead",
+        "height_dead_l1",
+        "com_downward_velocity",
+        "gentle_impact",
+        "too_fast_drop",
+        "playdead_hold",
+        "trunk_grounded_supine",
+        "playdead_composite",
+    )
+    seen = [id(cfg.rewards[n].params["asset_cfg"]) for n in names]
+    assert len(set(seen)) == len(seen), "asset_cfg shared across terms"
+
+
+def test_supine_cos_distinguishes_back_from_face_and_headstand():
+    s = 0.5**0.5
+    identity = torch.tensor([[1.0, 0.0, 0.0, 0.0]])
+    face_up = torch.tensor([[s, 0.0, -s, 0.0]])    # −90° pitch, belly up
+    face_down = torch.tensor([[s, 0.0, s, 0.0]])   # +90° pitch, belly down
+    headstand = torch.tensor([[0.0, 0.0, 1.0, 0.0]])  # 180° pitch
+    assert torch.allclose(body_supine_cos_from_quat(identity), torch.tensor([0.0]), atol=1e-5)
+    assert torch.allclose(body_supine_cos_from_quat(face_up), torch.tensor([1.0]), atol=1e-5)
+    assert torch.allclose(body_supine_cos_from_quat(face_down), torch.tensor([-1.0]), atol=1e-5)
+    # Headstand is inverted but NOT play-dead — this is the bug inverted_linear had.
+    assert torch.allclose(body_supine_cos_from_quat(headstand), torch.tensor([0.0]), atol=1e-5)
+
+
+def test_playdead_composite_sit_basin_is_dead():
+    """Sitting / standing / face-down must not score the goal product."""
+    dead = playdead_composite_from_values(
+        supine_cos=torch.tensor([1.0]),
+        z=torch.tensor([DEAD_Z]),
+        ang_norm=torch.tensor([0.0]),
+        target_height=DEAD_Z,
+    )
+    sit = playdead_composite_from_values(
+        supine_cos=torch.tensor([0.0]),
+        z=torch.tensor([_SIT_Z]),
+        ang_norm=torch.tensor([0.0]),
+        target_height=DEAD_Z,
+    )
+    stand = playdead_composite_from_values(
+        supine_cos=torch.tensor([0.0]),
+        z=torch.tensor([STAND_Z]),
+        ang_norm=torch.tensor([0.0]),
+        target_height=DEAD_Z,
+    )
+    face = playdead_composite_from_values(
+        supine_cos=torch.tensor([-1.0]),
+        z=torch.tensor([DEAD_Z]),
+        ang_norm=torch.tensor([0.0]),
+        target_height=DEAD_Z,
+    )
+    side = playdead_composite_from_values(
+        supine_cos=torch.tensor([0.0]),
+        z=torch.tensor([DEAD_Z]),
+        ang_norm=torch.tensor([0.0]),
+        target_height=DEAD_Z,
+    )
+    assert float(dead) > 0.99
+    assert float(sit) < 0.05
+    assert float(stand) < 0.05
+    assert float(face) < 0.05
+    assert float(side) < 0.05
+    assert float(dead) > 10.0 * float(sit)
+
+
+def test_yawed_face_up_stays_supine():
+    # set_random_ground_state face_up at yaw=π/2: [s*cy, s*sy, -s*cy, s*sy]
+    s = 0.5**0.5
+    yaw = math.pi / 2
+    cy, sy = math.cos(yaw * 0.5), math.sin(yaw * 0.5)
+    q = torch.tensor([[s * cy, s * sy, -s * cy, s * sy]])
+    assert torch.allclose(body_supine_cos_from_quat(q), torch.tensor([1.0]), atol=1e-4)


### PR DESCRIPTION
## Why

Sit is a polite sit. Roulade lands on its feet. Standup starts already down. Nothing in the pad means **die and stay dead** — swap the ONNX in, the duck goes down and holds; swap sitstand/standup to revive.

Play-dead is **supine** (belly up, −90° pitch), not “inverted”. `upright_cos = −1` is a headstand **and** a face-plant; a policy will farm whichever is cheaper. The orientation signal is world-z of body +X (`body_supine_cos_from_quat`). Height rewards are gated on `supine_cos > 0` so sitting (`z ≈ 0.060`) cannot collect the dead-height peak.

## What

- New env family `Mjlab-PlayDead-{Flat,Rough}-MicroDuck` (+ backlash twins on the allcollisions model)
- 61D actor obs: 48 proprio + twist(3) + head(4) pad + body(6) pad — hot-swappable with walk/stand/roulade
- Reset mix: 75% standing (learn the flop) / 25% already face-up (learn the hold); reverse curriculum raises the dead fraction; face-down stays at 0
- `scripts/infer_policy.py --playdead` (key **D**). Default is hold-until-D-again — play-dead does not end standing
- CPU cfg tests lock the contract, signs, sit-basin audit, and registration

## AGENTS.md bar

```bash
uv run --with pytest pytest tests/test_playdead_cfg.py
uv run train Mjlab-PlayDead-Flat-MicroDuck --env.scene.num-envs 64 --agent.max_iterations 5
```

Ran on a Spark (GB10): 16 play-dead tests + full CPU suite (171) green. Smoke 64 envs × 5 iters: actor obs **(61,)**, every reward term computed, `Episode_Termination/nan_state = 0`, self-negating penalties logged **≤ 0**, ONNX export **61 → 14**.

This is the env, not a converged policy. A real run is `~1000–2000` iters at 4096 envs (`experiment_name=microduck_playdead`), then `scripts/export.py` (bakes the normalizer — mandatory).

## Deploy rehearsal

```bash
uv run scripts/infer_policy.py --walking walk.onnx --standing stand.onnx \
    --playdead playdead.onnx --new-cmd-obs
```

`D` plays dead and holds; `D` again hands back. Revive with standup/sitstand, not walk.