### PR TITLE
roller-standup: fix joint indices to servo space (env crashed on first step)

### DIFF
--- a/docs/roller_standup_policy_summary.md
+++ b/docs/roller_standup_policy_summary.md
@@ -24,7 +24,15 @@ Les hauteurs de repos au sol sont identiques aux deux modèles : c'est la coque 
 0-4   jambe gauche      5-6   roues gauches
 7-10  cou / tête       11-15  jambe droite      16-17  roues droites
 ```
-`_LEG_JOINTS = [0-4, 11-15]`. Les indices du `standup` (`[0-4, 9-13]`) valent pour le modèle **sans** roues et pointeraient sur des roues ici. Verrouillé par `tests/test_roller_standup_cfg.py::test_joint_indices_match_actual_roller_model`.
+Cet ordre est celui du tableau de joints d'**entité**. Mais les récompenses de pose ne l'indexent pas : `pose_target_match` / `pose_l1_penalty` passent par `_servo_joint_pos()`, qui applique déjà `find_joints("^(?!passive_).*")` et rend une vue à **14 colonnes sans les roues**. Dans cette vue le décalage disparaît et la disposition redevient celle du modèle sans roues :
+
+```
+0-4  jambe gauche      5-8  cou / tête      9-13  jambe droite
+```
+
+D'où `_LEG_JOINTS = [0-4, 9-13]` et `_NECK_JOINTS = [5-8]` — les mêmes que `standup` et `sitstand`. Écrire ici les indices d'entité (`[0-4, 11-15]`) déborde la vue servo : 14 et 15 sont hors bornes et l'env meurt au premier calcul de récompense (`IndexError` sur CPU, device-side assert CUDA sur GPU). C'est ce qui est arrivé entre le 11/08 et le correctif : la migration vers la vue servo (`fa1b2ac`) et cet env ont été développés sur des branches parallèles, et leur fusion a laissé le cfg en indices d'entité.
+
+Verrouillé par `tests/test_roller_standup_cfg.py::test_joint_indices_are_servo_space` (les noms, pour cet env) et `tests/test_joint_index_bounds.py` (les bornes, pour tous les envs).
 
 ## Reset — départ au sol
 

--- a/src/mjlab_microduck/tasks/mdp.py
+++ b/src/mjlab_microduck/tasks/mdp.py
@@ -3882,8 +3882,10 @@ def joint_vel_l2_when_standing(
     total_speed = torch.norm(command[:, :2], dim=1) + torch.abs(command[:, 2])
     is_standing_cmd = (total_speed < command_threshold).float()
 
+    # Leg joints (left hip-ankle: 0-4, right hip-ankle: 9-13).
+    # Servo view: passive_* joints (backlash, wheels) don't shift the indices.
     leg_indices = list(range(0, 5)) + list(range(9, 14))
-    joint_vel = asset.data.joint_vel[:, leg_indices]
+    joint_vel = _servo_joint_vel(env, asset)[:, leg_indices]
     vel_sq = torch.sum(joint_vel ** 2, dim=-1)
 
     return is_standing_cmd * vel_sq
@@ -4190,9 +4192,10 @@ def set_random_ground_state(
                                     HOME (whatever ``reset_robot_joints`` set).
 
     Args:
-        sitting_joint_overrides: ``{qpos_joint_index: angle_rad}`` to write into
-            ``qpos[7+idx]`` for envs sampled into the sitting bucket. ``None``
-            keeps joints at whatever ``reset_robot_joints`` already set.
+        sitting_joint_overrides: ``{servo_joint_index: angle_rad}`` to write into
+            ``qpos[7 + servo_ids[idx]]`` for envs sampled into the sitting
+            bucket — servo indices, so passive_* joints don't shift them.
+            ``None`` keeps joints at whatever ``reset_robot_joints`` already set.
     """
     if env_ids is None or len(env_ids) == 0:
         return

--- a/src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_roller_standup_env_cfg.py
@@ -9,9 +9,10 @@ quel le robot rollers, les capteurs, toute la DR et l'observation 61D, donc
 interchangeable au runtime (--new-cmd-obs). C'est le pattern de roller_slope.
 
 Deux différences structurelles avec `standup` :
-  - les roues passives sont INTERCALÉES dans l'ordre des joints → indices
-    remappés (_LEG_JOINTS ci-dessous), verrouillés par
-    tests/test_roller_standup_cfg.py ;
+  - les roues passives sont INTERCALÉES dans l'ordre des joints d'entité, mais
+    les récompenses de pose indexent la vue SERVO (_servo_joint_pos les a déjà
+    retirées) : _LEG_JOINTS reste donc identique à celui du standup. Verrouillé
+    par tests/test_roller_standup_cfg.py ;
   - pas de commande head_pose : les slots head/body restent zero-paddés
     (convention de la famille roller) et la tête est tenue droite par
     neck_joint_pos_l2, qui résout par NOM.
@@ -91,24 +92,33 @@ def _resolve_play_face_up():
         print(f"[roller_standup] STANDUP_PLAY_FACE_UP='{raw}' invalide -> défaut {PLAY_FACE_UP}")
         return PLAY_FACE_UP
 
-# ── Indices de joints — les roues passives sont INTERCALÉES ───────────────────
-# Ordre réel du modèle rollers (18 joints après le free-joint), vérifié dans
-# MuJoCo via get_walk_rollers_spec().compile() :
+# ── Indices de joints — espace SERVO, pas l'espace entité ─────────────────────
+# Ordre réel du modèle rollers (18 joints d'entité après le free-joint), vérifié
+# dans MuJoCo via get_walk_rollers_spec().compile() :
 #   0-4   left_hip_yaw, left_hip_roll, left_hip_pitch, left_knee, left_ankle
 #   5-6   passive_LF_wheel, passive_LR_wheel
 #   7-10  neck_pitch, head_pitch, head_yaw, head_roll
 #   11-15 right_hip_yaw, right_hip_roll, right_hip_pitch, right_knee, right_ankle
 #   16-17 passive_RF_wheel, passive_RR_wheel
-# Le standup utilise [0-4, 9-13] / [5-8] : ce sont les indices du modèle SANS
-# roues, ils ne valent PAS ici. Verrouillé par tests/test_roller_standup_cfg.py.
 #
-# Seul _LEG_JOINTS est consommé (par les récompenses de pose). _NECK_JOINTS et
-# _WHEEL_JOINTS servent à la documentation et au test d'indices : le cou est
-# résolu par NOM (neck_joint_pos_l2 appelle find_joints(r".*(neck|head).*") à
-# chaque pas) et les roues par la regex ^passive_.*.
-_LEG_JOINTS   = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]
-_NECK_JOINTS  = [7, 8, 9, 10]
-_WHEEL_JOINTS = [5, 6, 16, 17]
+# MAIS les récompenses de pose n'indexent PAS ce tableau-là. pose_target_match /
+# pose_l1_penalty passent par _servo_joint_pos(), qui applique déjà
+# find_joints(r"^(?!passive_).*") : elles reçoivent une vue à 14 colonnes d'où
+# les roues ont DISPARU. Dans cette vue le décalage des roues n'existe plus, et
+# la disposition redevient exactement celle du modèle sans roues — donc les
+# mêmes indices que standup / sitstand.
+#
+# Utiliser ici les indices d'entité ([0-4, 11-15]) déborde la vue servo à
+# 14 colonnes : 14 et 15 sont hors bornes et déclenchent un device-side assert
+# CUDA au premier calcul de récompense. Verrouillé par
+# tests/test_roller_standup_cfg.py::test_joint_indices_are_servo_space.
+#
+# Seul _LEG_JOINTS est consommé (par les récompenses de pose). _NECK_JOINTS sert
+# à la documentation et au test d'indices : le cou est résolu par NOM
+# (neck_joint_pos_l2 appelle find_joints(r".*(neck|head).*") à chaque pas) et les
+# roues par la regex ^passive_.* — elles n'ont, elles, aucun indice servo.
+_LEG_JOINTS  = [0, 1, 2, 3, 4, 9, 10, 11, 12, 13]
+_NECK_JOINTS = [5, 6, 7, 8]
 
 # Récompenses de PATINAGE de l'env roller : aucun sens quand on est par terre.
 # feet_flat : les lames ne sont PAS à plat pendant la montée → combattrait le geste.

--- a/tests/test_joint_index_bounds.py
+++ b/tests/test_joint_index_bounds.py
@@ -1,0 +1,138 @@
+"""Verrou transverse : tout indice de joint d'un cfg vit dans l'espace SERVO.
+
+Les fonctions de mdp.py qui prennent des indices (``joint_indices``,
+``target_overrides``, ``sitting_joint_overrides``, ``sit_overrides``,
+``tuck_overrides`` — cf. _INDEX_*_PARAMS) passent toutes par
+``_servo_joint_pos`` / ``_servo_default_joint_pos``, qui appliquent déjà
+``find_joints(r"^(?!passive_).*")``. Elles reçoivent donc une vue à 14 colonnes
+— la disposition canonique des 14 servos — quel que soit le modèle.
+
+Sur les modèles à joints passifs (rollers, backlash), le tableau de joints de
+l'ENTITÉ est plus large et intercalé. Écrire les indices dans cet espace-là
+donne, selon la valeur :
+
+  - un IndexError / device-side assert CUDA si l'indice dépasse 14 (c'est le bug
+    qu'a eu roller_standup : _LEG_JOINTS en indices d'entité, donc 14 et 15 hors
+    bornes, l'env plantait au premier calcul de récompense) ;
+  - pire, une récompense SILENCIEUSEMENT appliquée au mauvais joint si l'indice
+    reste sous 14.
+
+CE test ne couvre que le PREMIER cas : c'est une vérification de bornes, elle ne
+peut pas savoir quel joint un terme VOULAIT viser. Le second cas se vérifie par
+NOM, et donc par env — cf. test_joint_indices_are_servo_space dans
+tests/test_roller_standup_cfg.py, qui compare les noms de joints attendus.
+"""
+
+import pytest
+
+from mjlab_microduck.tasks import (
+    make_microduck_ball_kick_env_cfg,
+    make_microduck_ground_pick_env_cfg,
+    make_microduck_roller_crouch_env_cfg,
+    make_microduck_roller_slope_env_cfg,
+    make_microduck_roller_standup_env_cfg,
+    make_microduck_roulade_env_cfg,
+    make_microduck_sitstand_env_cfg,
+    make_microduck_spin_env_cfg,
+    make_microduck_standup_env_cfg,
+    make_microduck_velocity_env_cfg,
+    make_microduck_velocity_rollers_env_cfg,
+    make_microduck_velocity_swizzle_env_cfg,
+    make_microduck_velstand_env_cfg,
+)
+
+# La disposition canonique : 14 servos, cf. AGENTS.md (« Joint layout »).
+N_SERVO = 14
+
+# Les paramètres de terme qui portent des indices de joints dans l'espace servo.
+_INDEX_LIST_PARAMS = ("joint_indices",)
+_INDEX_DICT_PARAMS = (
+    "target_overrides",
+    "sitting_joint_overrides",
+    "sit_overrides",
+    "tuck_overrides",
+)
+
+_FACTORIES = {
+    "ball_kick": make_microduck_ball_kick_env_cfg,
+    "ground_pick": make_microduck_ground_pick_env_cfg,
+    "roller_crouch": make_microduck_roller_crouch_env_cfg,
+    "roller_slope": make_microduck_roller_slope_env_cfg,
+    "roller_standup": make_microduck_roller_standup_env_cfg,
+    "roulade": make_microduck_roulade_env_cfg,
+    "sitstand": make_microduck_sitstand_env_cfg,
+    "spin": make_microduck_spin_env_cfg,
+    "standup": make_microduck_standup_env_cfg,
+    "velocity": make_microduck_velocity_env_cfg,
+    "velocity_rollers": make_microduck_velocity_rollers_env_cfg,
+    "velocity_swizzle": make_microduck_velocity_swizzle_env_cfg,
+    "velstand": make_microduck_velstand_env_cfg,
+}
+
+
+def _indices_in(params):
+    """(nom du paramètre, indices) pour chaque paramètre porteur d'indices."""
+    if not params:
+        return
+    for key in _INDEX_LIST_PARAMS:
+        value = params.get(key)
+        if value:
+            yield key, list(value)
+    for key in _INDEX_DICT_PARAMS:
+        value = params.get(key)
+        if value:
+            yield key, list(value.keys())
+
+
+def _terms_of(cfg):
+    """(famille, nom du terme, params) sur récompenses ET événements."""
+    for family in ("rewards", "events"):
+        container = getattr(cfg, family, None)
+        if container is None:
+            continue
+        for name, term in container.items():
+            yield family, name, getattr(term, "params", None)
+
+
+@pytest.mark.parametrize("task", sorted(_FACTORIES))
+def test_joint_indices_stay_in_servo_space(task):
+    cfg = _FACTORIES[task]()
+    for family, name, params in _terms_of(cfg):
+        for key, indices in _indices_in(params):
+            assert min(indices) >= 0, f"{task}.{family}.{name}.{key}: indice négatif {indices}"
+            assert max(indices) < N_SERVO, (
+                f"{task}.{family}.{name}.{key} = {indices} sort de la vue servo "
+                f"({N_SERVO} colonnes). Les fonctions de mdp.py indexent "
+                f"_servo_joint_pos(), d'où les joints passive_* sont DÉJÀ retirés : "
+                f"les indices d'entité (roues/backlash intercalés) n'y valent pas."
+            )
+
+
+# Nombre de paramètres d'indices que le scan trouve aujourd'hui, par nom. C'est
+# un PLANCHER anti-régression, pas une spec : en ajouter fait monter le chiffre
+# (à mettre à jour), en perdre veut dire que le scan est devenu muet — c'est le
+# cas qu'on veut attraper. Un simple "total > 0" ne suffit pas : renommer
+# joint_indices en laisserait passer 6 tout en vidant 15 assertions.
+_EXPECTED_MIN_PARAMS = {
+    "joint_indices": 15,
+    "sit_overrides": 3,
+    "sitting_joint_overrides": 2,
+    "tuck_overrides": 1,
+}
+
+
+def test_the_scan_actually_finds_indices():
+    """Garde-fou : sans lui, test_joint_indices_stay_in_servo_space peut passer
+    au vert en n'ayant rien vérifié du tout (paramètres renommés côté cfg)."""
+    seen = {}
+    for _task, factory in _FACTORIES.items():
+        cfg = factory()
+        for _family, _name, params in _terms_of(cfg):
+            for key, _indices in _indices_in(params):
+                seen[key] = seen.get(key, 0) + 1
+    for key, expected in _EXPECTED_MIN_PARAMS.items():
+        assert seen.get(key, 0) >= expected, (
+            f"le scan ne trouve plus que {seen.get(key, 0)} '{key}' au lieu de "
+            f"{expected} : paramètre renommé ? Le verrou de bornes est devenu "
+            f"muet pour d'autant de termes."
+        )

--- a/tests/test_roller_standup_cfg.py
+++ b/tests/test_roller_standup_cfg.py
@@ -119,21 +119,15 @@ def test_task_is_registered():
     assert "Mjlab-RollerStandUp-Flat-MicroDuck" in list_tasks()
 
 
-def test_joint_indices_match_actual_roller_model():
-    """Verrou : les roues passives sont intercalées dans l'ordre des joints.
+def _servo_joint_names():
+    """Les noms de joints dans l'espace SERVO du modèle rollers.
 
-    Réutiliser les indices du standup ([0-4, 9-13]) donnerait des récompenses
-    qui pointent sur des roues. Ce test compile le vrai MjSpec du robot rollers
-    et vérifie les noms aux indices utilisés. Pur CPU, pas de sim.
+    Reproduit _servo_joint_ids() de mdp.py : joints d'entité (donc sans le
+    free-joint), moins les ``passive_*``. Pur CPU, pas de sim.
     """
     import mujoco
 
     from mjlab_microduck.robot.microduck_constants import get_walk_rollers_spec
-    from mjlab_microduck.tasks.microduck_roller_standup_env_cfg import (
-        _LEG_JOINTS,
-        _NECK_JOINTS,
-        _WHEEL_JOINTS,
-    )
 
     model = get_walk_rollers_spec().compile()
     articulated = [
@@ -141,19 +135,71 @@ def test_joint_indices_match_actual_roller_model():
         for j in range(model.njnt)
         if model.jnt_type[j] != mujoco.mjtJoint.mjJNT_FREE
     ]
+    return [n for n in articulated if not n.startswith("passive_")]
 
-    assert [articulated[i] for i in _LEG_JOINTS] == [
+
+def test_joint_indices_are_servo_space():
+    """Verrou sur le bug qui crashait l'env au premier calcul de récompense.
+
+    Les roues passives sont intercalées dans l'ordre des joints d'ENTITÉ, mais
+    pose_target_match / pose_l1_penalty passent par _servo_joint_pos(), qui les
+    a déjà retirées : elles indexent une vue à 14 colonnes. Les indices d'entité
+    ([0-4, 11-15]) y débordent — 14 et 15 sont hors bornes, ce qui déclenche un
+    device-side assert CUDA (« index out of bounds ») dès le premier pas.
+
+    Dans la vue servo, les roues n'existent plus : la disposition est celle du
+    modèle sans roues, donc les mêmes indices que standup / sitstand.
+    """
+    from mjlab_microduck.tasks.microduck_roller_standup_env_cfg import (
+        _LEG_JOINTS,
+        _NECK_JOINTS,
+    )
+
+    servo = _servo_joint_names()
+    assert len(servo) == 14, "la vue servo doit avoir exactement les 14 servos"
+
+    assert [servo[i] for i in _LEG_JOINTS] == [
         "left_hip_yaw", "left_hip_roll", "left_hip_pitch", "left_knee", "left_ankle",
         "right_hip_yaw", "right_hip_roll", "right_hip_pitch", "right_knee", "right_ankle",
     ]
-    assert [articulated[i] for i in _NECK_JOINTS] == [
+    assert [servo[i] for i in _NECK_JOINTS] == [
         "neck_pitch", "head_pitch", "head_yaw", "head_roll",
     ]
-    assert [articulated[i] for i in _WHEEL_JOINTS] == [
+    # Aucun recouvrement, et les deux listes couvrent toute la vue servo.
+    assert len(set(_LEG_JOINTS) | set(_NECK_JOINTS)) == len(servo)
+
+
+def test_entity_joint_order_matches_the_documented_layout():
+    """Épingle le bloc de commentaire d'ordre d'ENTITÉ du cfg.
+
+    Le cfg documente où tombent les roues dans le tableau de joints d'entité
+    (5-6 et 16-17) pour expliquer pourquoi ces indices-là ne valent pas côté
+    récompense. C'est ce commentaire qui justifie tout le reste du bloc, et plus
+    rien ne le vérifiait depuis la suppression de _WHEEL_JOINTS : sans ce test
+    il peut dériver silencieusement si le modèle rollers est réexporté.
+
+    Les bornes de la vue servo, elles, sont vérifiées pour TOUS les envs par
+    tests/test_joint_index_bounds.py.
+    """
+    import mujoco
+
+    from mjlab_microduck.robot.microduck_constants import get_walk_rollers_spec
+
+    model = get_walk_rollers_spec().compile()
+    articulated = [
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, j)
+        for j in range(model.njnt)
+        if model.jnt_type[j] != mujoco.mjtJoint.mjJNT_FREE
+    ]
+    assert len(articulated) == 18
+    assert [articulated[i] for i in (5, 6, 16, 17)] == [
         "passive_LF_wheel", "passive_LR_wheel", "passive_RF_wheel", "passive_RR_wheel",
     ]
-    # Aucun recouvrement, et les trois listes couvrent tous les joints.
-    assert len(set(_LEG_JOINTS) | set(_NECK_JOINTS) | set(_WHEEL_JOINTS)) == len(articulated)
+    assert [articulated[i] for i in (0, 4, 7, 10, 11, 15)] == [
+        "left_hip_yaw", "left_ankle",
+        "neck_pitch", "head_roll",
+        "right_hip_yaw", "right_ankle",
+    ]
 
 
 def test_recovery_rewards_present_with_expected_weights():


### PR DESCRIPTION
`Mjlab-RollerStandUp-Flat-MicroDuck` builds and resets fine, then dies on the first `step()` — on every run. This fixes it and adds a lock so the same class of error can't come back silently.

## The bug

`_LEG_JOINTS` was written in the **entity** joint space of the roller model, where the passive wheels are interleaved:

```
0-4    left_hip_yaw, left_hip_roll, left_hip_pitch, left_knee, left_ankle
5-6    passive_LF_wheel, passive_LR_wheel
7-10   neck_pitch, head_pitch, head_yaw, head_roll
11-15  right_hip_yaw, right_hip_roll, right_hip_pitch, right_knee, right_ankle
16-17  passive_RF_wheel, passive_RR_wheel
```

But `pose_target_match` / `pose_l1_penalty` don't index that array. They go through `_servo_joint_pos()`, which already applies `find_joints(r"^(?!passive_).*")` and hands them a **14-column servo view with the wheels removed**. Indices 14 and 15 are out of bounds there:

- GPU: `CUDA error: device-side assert triggered` from `IndexKernel.cu`, then ~800 lines of Warp teardown noise that bury the cause
- CPU: `IndexError: index 14 is out of bounds for dimension 0 with size 14`

In the servo view the wheel offset is gone, so the layout is the wheel-less one again — the same indices `standup` and `sitstand` already use.

## How it got here

Worth spelling out, because nobody wrote a wrong index.

When these indices were written (`65cd4ff`, 04/08), `pose_target_match` still read `asset.data.joint_pos` raw — entity space was correct, and the env ran. The reward-tuning commits from 05-06/08 describe observed policy behaviour, which is direct evidence of that.

The servo-view migration (`fa1b2ac`, 10/08) converted the pose functions and updated the envs on its own branch. This env was being developed in parallel. The two first met at the merge `fb0a223` (11/08), which left an entity-space cfg facing a servo-space mdp. Each side was self-consistent; the combination wasn't.

I checked the other cfgs for the same mismatch — `standup`, `sitstand`, `ball_kick`, `roulade` all already use servo-space indices. `roller_standup` was the only one left behind.

## Why the existing test didn't catch it

`test_joint_indices_match_actual_roller_model` validated the indices against the **entity** joint list, so it locked the wrong contract and stayed green while the env couldn't step. Replaced by `test_joint_indices_are_servo_space`, which compares joint **names** in the view that's actually indexed.

The name check matters: an entity-space index that happens to land **under** 14 raises nothing at all — it just applies the reward to the wrong joint. Concretely, the old `_NECK_JOINTS = [7,8,9,10]` is entirely in range and would silently select `head_yaw, head_roll, right_hip_yaw, right_hip_roll`. A bounds check cannot see that; only names can.

## The transverse lock

`tests/test_joint_index_bounds.py` scans every task cfg for index-carrying params (`joint_indices`, `target_overrides`, `sitting_joint_overrides`, `sit_overrides`, `tuck_overrides`) across rewards and events and asserts they fit the servo view.

Scope, stated honestly: this one is a **bounds** check, so it catches the crash class, not the silent wrong-joint class — it can't know which joint a term meant to target. The name-based check above covers that, per env. It carries a per-param-name guard so that renaming a cfg param can't quietly leave it asserting nothing.

## Also in here

- `joint_vel_l2_when_standing` had the same bug latently — still indexing the raw entity array while its two siblings `neck_joint_vel_l2` / `leg_joint_vel_l2` were converted. No cfg references it today, so nothing was broken, but it's the silent variant and no test can reach it since the index is hardcoded in `mdp.py`.
- `sitting_joint_overrides`' docstring still described `qpos[7+idx]`; it's been `qpos[7 + servo_ids[idx]]` since the migration.
- `docs/roller_standup_policy_summary.md` documented the entity indices as the ones to use and cited the now-deleted test.

## Verification

- full suite: 169 passed, 1 skipped (`uv run --frozen`)
- bounds test checked both ways — green on the fixed tree, red as soon as the old value is re-planted
- smoke: 64 envs x 5 iterations, rc=0
- ONNX export: `obs [1,61] -> actions [1,14]`, so the 61D hot-swap contract is intact

One caveat I can't close from here: this env has not been trained since the fix, so the reward tuning is unverified against a working roller model. The first real run is the validation.
