### PR TITLE
Add validation for Blender motion exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Python-generated files
+.worktrees/
+
 __pycache__/
 *.py[oc]
 build/

--- a/README.md
+++ b/README.md
@@ -183,6 +183,20 @@ uv run --with pytest pytest tests/
 CPU-only config-invariant and reward-function regression tests — they lock in
 joint-index mappings, reward sign conventions, and NaN guards.
 
+## Blender motion validation
+
+Open Duck Blender exports native 50 Hz Microduck `.npz` motion archives. Before
+using one for imitation or reference-motion work, validate its exact 14-joint/
+15-body contract and forward kinematics against `robot_walk.xml`:
+
+```bash
+uv run scripts/validate_blender_motion.py /path/to/motion.npz
+```
+
+The command rejects reordered names, malformed or non-finite arrays, incorrect
+metadata, and body transforms that do not match a MuJoCo replay of the exported
+root pose and joint positions.
+
 ## Related projects
 
 - [microduck](https://github.com/pollen-robotics/microduck) — the Microduck project home, including the onboard runtime that runs the exported policies

--- a/scripts/validate_blender_motion.py
+++ b/scripts/validate_blender_motion.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Validate a motion exported by Open Duck Blender."""
+
+from __future__ import annotations
+
+import argparse
+
+from mjlab_microduck.blender_motion import MotionValidationError, validate_motion
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("motion", help="Blender-exported .npz archive")
+    args = parser.parse_args()
+    try:
+        result = validate_motion(args.motion)
+    except (MotionValidationError, OSError, ValueError) as exc:
+        parser.error(str(exc))
+    print(
+        f"Validated {result.frames} frames; max position error "
+        f"{result.max_position_error_m:.3g} m, orientation error "
+        f"{result.max_orientation_error_rad:.3g} rad"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mjlab_microduck/blender_motion.py
+++ b/src/mjlab_microduck/blender_motion.py
@@ -1,0 +1,131 @@
+"""Validate Blender motion archives against the canonical Microduck MJCF."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+from mjlab_microduck.robot.microduck_constants import MICRODUCK_WALK_XML
+
+
+REQUIRED_KEYS = {
+    "joint_pos",
+    "joint_vel",
+    "body_pos_w",
+    "body_quat_w",
+    "body_lin_vel_w",
+    "body_ang_vel_w",
+    "fps",
+    "schema_version",
+    "joint_names",
+    "body_names",
+    "source_hashes_json",
+}
+
+
+class MotionValidationError(ValueError):
+    """An archive cannot be consumed safely by the Microduck motion pipeline."""
+
+
+@dataclass(frozen=True)
+class MotionValidationResult:
+    frames: int
+    max_position_error_m: float
+    max_orientation_error_rad: float
+
+
+def _names(model: mujoco.MjModel, object_type, start: int, count: int) -> tuple[str, ...]:
+    return tuple(
+        mujoco.mj_id2name(model, object_type, index)
+        for index in range(start, count)
+    )
+
+
+def _scalar(array: np.ndarray, name: str) -> int:
+    flattened = np.asarray(array).reshape(-1)
+    if flattened.size != 1:
+        raise MotionValidationError(f"{name} must contain exactly one value")
+    return int(flattened[0])
+
+
+def validate_motion(
+    path: str | Path,
+    *,
+    mjcf_path: str | Path = MICRODUCK_WALK_XML,
+    position_tolerance_m: float = 1e-4,
+    orientation_tolerance_rad: float = 1e-4,
+) -> MotionValidationResult:
+    model = mujoco.MjModel.from_xml_path(str(mjcf_path))
+    expected_joints = _names(model, mujoco.mjtObj.mjOBJ_JOINT, 1, model.njnt)
+    expected_bodies = _names(model, mujoco.mjtObj.mjOBJ_BODY, 1, model.nbody)
+    with np.load(Path(path), allow_pickle=False) as archive:
+        missing = REQUIRED_KEYS - set(archive.files)
+        if missing:
+            raise MotionValidationError(f"archive is missing keys: {sorted(missing)}")
+        if _scalar(archive["fps"], "fps") != 50:
+            raise MotionValidationError("fps must be 50")
+        if _scalar(archive["schema_version"], "schema_version") != 1:
+            raise MotionValidationError("schema_version must be 1")
+        joint_names = tuple(str(name) for name in archive["joint_names"])
+        body_names = tuple(str(name) for name in archive["body_names"])
+        if joint_names != expected_joints:
+            raise MotionValidationError(
+                f"joint_names do not match canonical order: {joint_names!r}"
+            )
+        if body_names != expected_bodies:
+            raise MotionValidationError(
+                f"body_names do not match canonical order: {body_names!r}"
+            )
+        joint_pos = np.asarray(archive["joint_pos"], dtype=np.float64)
+        body_pos = np.asarray(archive["body_pos_w"], dtype=np.float64)
+        body_quat = np.asarray(archive["body_quat_w"], dtype=np.float64)
+        frames = joint_pos.shape[0] if joint_pos.ndim == 2 else 0
+        expected_shapes = {
+            "joint_pos": (frames, len(expected_joints)),
+            "joint_vel": (frames, len(expected_joints)),
+            "body_pos_w": (frames, len(expected_bodies), 3),
+            "body_quat_w": (frames, len(expected_bodies), 4),
+            "body_lin_vel_w": (frames, len(expected_bodies), 3),
+            "body_ang_vel_w": (frames, len(expected_bodies), 3),
+        }
+        for name, shape in expected_shapes.items():
+            values = np.asarray(archive[name])
+            if frames == 0 or values.shape != shape:
+                raise MotionValidationError(f"{name} must have shape {shape}, got {values.shape}")
+            if not np.isfinite(values).all():
+                raise MotionValidationError(f"{name} contains non-finite values")
+
+    data = mujoco.MjData(model)
+    max_position_error = 0.0
+    max_orientation_error = 0.0
+    joint_qpos_addresses = model.jnt_qposadr[1:]
+    for frame in range(frames):
+        data.qpos[:] = 0.0
+        data.qpos[:3] = body_pos[frame, 0]
+        root_quat = body_quat[frame, 0]
+        norm = np.linalg.norm(root_quat)
+        if norm < 1e-12:
+            raise MotionValidationError(f"body_quat_w has zero root quaternion at frame {frame}")
+        data.qpos[3:7] = root_quat / norm
+        data.qpos[joint_qpos_addresses] = joint_pos[frame]
+        mujoco.mj_forward(model, data)
+        position_error = np.linalg.norm(data.xpos[1:] - body_pos[frame], axis=1)
+        expected_quat = body_quat[frame]
+        expected_quat /= np.linalg.norm(expected_quat, axis=1, keepdims=True)
+        dots = np.clip(np.abs(np.sum(data.xquat[1:] * expected_quat, axis=1)), 0.0, 1.0)
+        orientation_error = 2.0 * np.arccos(dots)
+        max_position_error = max(max_position_error, float(position_error.max()))
+        max_orientation_error = max(max_orientation_error, float(orientation_error.max()))
+    if (
+        max_position_error > position_tolerance_m
+        or max_orientation_error > orientation_tolerance_rad
+    ):
+        raise MotionValidationError(
+            "kinematic replay differs from exported body transforms: "
+            f"position={max_position_error:.6g} m, "
+            f"orientation={max_orientation_error:.6g} rad"
+        )
+    return MotionValidationResult(frames, max_position_error, max_orientation_error)

--- a/src/mjlab_microduck/blender_motion.py
+++ b/src/mjlab_microduck/blender_motion.py
@@ -9,7 +9,8 @@ from pathlib import Path
 import mujoco
 import numpy as np
 
-from mjlab_microduck.robot.microduck_constants import MICRODUCK_WALK_XML
+
+MICRODUCK_WALK_XML = Path(__file__).parent / "robot/microduck/robot_walk.xml"
 
 
 REQUIRED_KEYS = {

--- a/src/mjlab_microduck/blender_motion.py
+++ b/src/mjlab_microduck/blender_motion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 from pathlib import Path
 
 import mujoco
@@ -65,6 +66,9 @@ def validate_motion(
         missing = REQUIRED_KEYS - set(archive.files)
         if missing:
             raise MotionValidationError(f"archive is missing keys: {sorted(missing)}")
+        extra = set(archive.files) - REQUIRED_KEYS
+        if extra:
+            raise MotionValidationError(f"archive has unexpected keys: {sorted(extra)}")
         if _scalar(archive["fps"], "fps") != 50:
             raise MotionValidationError("fps must be 50")
         if _scalar(archive["schema_version"], "schema_version") != 1:
@@ -79,6 +83,18 @@ def validate_motion(
             raise MotionValidationError(
                 f"body_names do not match canonical order: {body_names!r}"
             )
+        hashes = np.asarray(archive["source_hashes_json"])
+        if hashes.shape != (1,) or hashes.dtype.kind not in "US":
+            raise MotionValidationError("source_hashes_json must contain one JSON string")
+        try:
+            hash_payload = json.loads(str(hashes[0]))
+        except json.JSONDecodeError as exc:
+            raise MotionValidationError("source_hashes_json is not valid JSON") from exc
+        if not isinstance(hash_payload, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in hash_payload.items()
+        ):
+            raise MotionValidationError("source_hashes_json must encode a string map")
         joint_pos = np.asarray(archive["joint_pos"], dtype=np.float64)
         body_pos = np.asarray(archive["body_pos_w"], dtype=np.float64)
         body_quat = np.asarray(archive["body_quat_w"], dtype=np.float64)
@@ -97,6 +113,12 @@ def validate_motion(
                 raise MotionValidationError(f"{name} must have shape {shape}, got {values.shape}")
             if not np.isfinite(values).all():
                 raise MotionValidationError(f"{name} contains non-finite values")
+        quaternion_norms = np.linalg.norm(body_quat, axis=2)
+        if np.any(quaternion_norms < 1e-12):
+            frame, body = (int(value) for value in np.argwhere(quaternion_norms < 1e-12)[0])
+            raise MotionValidationError(
+                f"body_quat_w has zero quaternion at frame {frame}, body {body}"
+            )
 
     data = mujoco.MjData(model)
     max_position_error = 0.0
@@ -106,10 +128,7 @@ def validate_motion(
         data.qpos[:] = 0.0
         data.qpos[:3] = body_pos[frame, 0]
         root_quat = body_quat[frame, 0]
-        norm = np.linalg.norm(root_quat)
-        if norm < 1e-12:
-            raise MotionValidationError(f"body_quat_w has zero root quaternion at frame {frame}")
-        data.qpos[3:7] = root_quat / norm
+        data.qpos[3:7] = root_quat / np.linalg.norm(root_quat)
         data.qpos[joint_qpos_addresses] = joint_pos[frame]
         mujoco.mj_forward(model, data)
         position_error = np.linalg.norm(data.xpos[1:] - body_pos[frame], axis=1)

--- a/tests/test_blender_motion_validator.py
+++ b/tests/test_blender_motion_validator.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import pytest
+
+from mjlab_microduck.blender_motion import MotionValidationError, validate_motion
+from mjlab_microduck.robot.microduck_constants import MICRODUCK_WALK_XML
+
+
+def _valid_archive(path: Path) -> Path:
+    model = mujoco.MjModel.from_xml_path(str(MICRODUCK_WALK_XML))
+    data = mujoco.MjData(model)
+    data.qpos[2] = 0.3
+    data.qpos[3] = 1.0
+    mujoco.mj_forward(model, data)
+    joint_names = [
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, index)
+        for index in range(1, model.njnt)
+    ]
+    body_names = [
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, index)
+        for index in range(1, model.nbody)
+    ]
+    zeros_joint = np.zeros((1, len(joint_names)), dtype=np.float32)
+    zeros_body = np.zeros((1, len(body_names), 3), dtype=np.float32)
+    np.savez_compressed(
+        path,
+        joint_pos=zeros_joint,
+        joint_vel=zeros_joint,
+        body_pos_w=data.xpos[1:][None].astype(np.float32),
+        body_quat_w=data.xquat[1:][None].astype(np.float32),
+        body_lin_vel_w=zeros_body,
+        body_ang_vel_w=zeros_body,
+        fps=np.array([50], dtype=np.int32),
+        schema_version=np.array([1], dtype=np.int32),
+        joint_names=np.asarray(joint_names),
+        body_names=np.asarray(body_names),
+        source_hashes_json=np.asarray(["{}"]),
+    )
+    return path
+
+
+def test_accepts_native_archive_and_replays_kinematics(tmp_path):
+    result = validate_motion(_valid_archive(tmp_path / "valid.npz"))
+    assert result.frames == 1
+    assert result.max_position_error_m < 1e-6
+    assert result.max_orientation_error_rad < 1e-6
+
+
+def test_rejects_body_pose_that_disagrees_with_joint_replay(tmp_path):
+    source = _valid_archive(tmp_path / "valid.npz")
+    with np.load(source) as loaded:
+        archive = {key: loaded[key] for key in loaded.files}
+    archive["body_pos_w"] = archive["body_pos_w"].copy()
+    archive["body_pos_w"][0, -1, 0] += 0.01
+    invalid = tmp_path / "invalid.npz"
+    np.savez_compressed(invalid, **archive)
+    with pytest.raises(MotionValidationError, match="kinematic replay"):
+        validate_motion(invalid)
+
+
+def test_rejects_wrong_joint_order(tmp_path):
+    source = _valid_archive(tmp_path / "valid.npz")
+    with np.load(source) as loaded:
+        archive = {key: loaded[key] for key in loaded.files}
+    archive["joint_names"] = archive["joint_names"][::-1]
+    invalid = tmp_path / "invalid-order.npz"
+    np.savez_compressed(invalid, **archive)
+    with pytest.raises(MotionValidationError, match="joint_names"):
+        validate_motion(invalid)

--- a/tests/test_blender_motion_validator.py
+++ b/tests/test_blender_motion_validator.py
@@ -69,3 +69,32 @@ def test_rejects_wrong_joint_order(tmp_path):
     np.savez_compressed(invalid, **archive)
     with pytest.raises(MotionValidationError, match="joint_names"):
         validate_motion(invalid)
+
+
+def test_rejects_nonroot_zero_quaternion(tmp_path):
+    source = _valid_archive(tmp_path / "valid.npz")
+    with np.load(source) as loaded:
+        archive = {key: loaded[key] for key in loaded.files}
+    archive["body_quat_w"] = archive["body_quat_w"].copy()
+    archive["body_quat_w"][0, -1] = 0.0
+    invalid = tmp_path / "zero-quat.npz"
+    np.savez_compressed(invalid, **archive)
+    with pytest.raises(MotionValidationError, match="zero quaternion"):
+        validate_motion(invalid)
+
+
+def test_rejects_extra_keys_and_invalid_source_hash_metadata(tmp_path):
+    source = _valid_archive(tmp_path / "valid.npz")
+    with np.load(source) as loaded:
+        archive = {key: loaded[key] for key in loaded.files}
+    archive["surprise"] = np.array([1])
+    extra = tmp_path / "extra.npz"
+    np.savez_compressed(extra, **archive)
+    with pytest.raises(MotionValidationError, match="unexpected keys"):
+        validate_motion(extra)
+    archive.pop("surprise")
+    archive["source_hashes_json"] = np.asarray(["not-json"])
+    malformed = tmp_path / "bad-hashes.npz"
+    np.savez_compressed(malformed, **archive)
+    with pytest.raises(MotionValidationError, match="source_hashes_json"):
+        validate_motion(malformed)


### PR DESCRIPTION
## Summary

- validate the exact 50 Hz, 14-joint, 15-body Blender NPZ contract
- reject malformed metadata, reordered names, non-finite arrays, and invalid quaternions
- replay every frame through the canonical Microduck MuJoCo model and report transform errors
- add a standalone validation CLI and regression tests

## Verification

- `uv run --with pytest pytest tests/`: 159 passed, 1 architecture-specific skip
- verified the paired Blender crouch export (51 frames): max position error 2.23e-08 m, max orientation error 5.44e-07 rad

Paired Blender PR: https://github.com/pollen-robotics/Open_Duck_Blender/pull/2