### PR TITLE
Checkpoint progress videos + rig pages (agent tooling)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ uv run train <TASK_ID> --env.scene.num-envs 64 --agent.max_iterations 5   # SMOK
 uv run play <TASK_ID> --wandb-run-path <entity/project/run_id>
 uv run scripts/export.py <TASK_ID> --wandb-run-path <...>   # → ONNX (bakes obs normalizer — mandatory path)
 uv run scripts/infer_policy.py --walking out.onnx   # CPU MuJoCo deployment rehearsal
+uv run scripts/progress_video.py --run-dir logs/rsl_rl/<exp>/<run> --out /tmp/progress.mp4   # checkpoint progress grid
+uv run scripts/make_rig_page.py --checkpoint logs/.../model_12250.pt --out /tmp/rig.html     # interactive rig + policy I/O page
 uv run --with pytest pytest tests/
 ```
 
@@ -36,7 +38,8 @@ Never launch a long run without one.
 - `src/mjlab_microduck/robot/microduck/` — MJCF exports from Onshape
   (onshape-to-robot, one `config_mjcf_*.json` per model) + scenes + `add_backlash.py`.
 - `src/mjlab_microduck/actuator/friction_dr_bam.py` — BAM actuator + friction DR + backlash encoder.
-- `scripts/` — export, infer, sim2real comparison, wandb helpers.
+- `scripts/` — export, infer, sim2real comparison, wandb helpers, progress
+  videos + rig pages (below).
 - `tests/` — cfg-invariant and mdp-function regression tests (CPU, no GPU needed).
 
 ## Invariants — do not break these
@@ -215,6 +218,23 @@ Never launch a long run without one.
   fails the human eye — watch the video AND check which geom/axis touches.
 - Report what rollouts actually show ("rolls but face-plants 1 in 3"), not
   "it works!". The user decides when it's good enough.
+
+## Progress videos & rig pages — showing, not claiming
+
+- **After any training milestone, make the progress grid and watch it.**
+  `progress_video.py --run-dir <run>` auto-discovers `model_<iter>.pt`
+  checkpoints, picks 4 evenly spaced (first→last), rolls each out from the
+  same seed with the phase-aligned reset, and tiles them labeled into one mp4.
+  Sim metrics can pass while the video fails the human eye — attach the grid
+  to your report instead of claiming "it works".
+- Hand-pick tiles with repeated `--checkpoint` flags; `--three-views` gives
+  the front/45°/side strip per tile; `--seconds` sets per-tile length.
+- `make_rig_page.py --checkpoint <model.pt>` bakes one rollout into a
+  self-contained interactive HTML (animated rig, per-joint pos/vel/action
+  traces, live 61D obs vector, XL330→policy→servo signal-path map). Use it
+  when debugging *why* a policy misbehaves, not whether.
+- Both need a GPU and default to `Mjlab-GroundPick-Flat-MicroDuck`; pass
+  `--task` for other envs.
 
 ## Sim2real footguns (cost real debugging weeks)
 

--- a/scripts/dump_rig_signals.py
+++ b/scripts/dump_rig_signals.py
@@ -1,0 +1,119 @@
+"""Dump per-step hardware signals + policy I/O for the rig visualizer.
+
+Runs one rollout with a checkpoint and records, per policy step:
+  - raw joint positions / velocities (the "hardware" signals the XL330s report)
+  - the exact 61D actor obs vector (post encoder-bias, lag, noise, normalization
+    is applied inside the policy's normalizer — obs here is pre-normalization)
+  - the policy's action output (14D joint position targets)
+
+Usage:
+  uv run scripts/dump_rig_signals.py --checkpoint logs/.../model_12250.pt \
+      --out rig_data.json --seconds 12
+
+`dump_signals()` is importable — make_rig_page.py bakes it straight into the
+interactive HTML page without a JSON round-trip.
+"""
+
+import argparse
+import json
+from dataclasses import asdict
+
+import torch
+
+import mjlab.tasks  # noqa: F401
+import mjlab_microduck.tasks  # noqa: F401
+
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.rl import MjlabOnPolicyRunner, RslRlVecEnvWrapper
+from mjlab.tasks.registry import load_env_cfg, load_rl_cfg, load_runner_cls
+from mjlab.utils.torch import configure_torch_backends
+
+DEFAULT_TASK = "Mjlab-GroundPick-Flat-MicroDuck"
+
+
+def dump_signals(
+  task: str, checkpoint: str, seconds: float, device: str, seed: int = 0
+) -> dict:
+  """Roll out `checkpoint` for `seconds` and return the rig-visualizer payload."""
+  configure_torch_backends()
+  torch.manual_seed(seed)
+
+  env_cfg = load_env_cfg(task, play=True)
+  agent_cfg = load_rl_cfg(task)
+  env_cfg.scene.num_envs = 1
+  # Pin the command cycle to phase 0 at every reset so rollouts start aligned
+  # (matches runtime behavior; not all tasks have a phase-randomized twist).
+  try:
+    twist = env_cfg.commands["twist"]
+  except (KeyError, TypeError):
+    twist = None
+  if twist is not None and hasattr(twist, "randomize_phase"):
+    twist.randomize_phase = False
+  env = ManagerBasedRlEnv(cfg=env_cfg, device=device, render_mode=None)
+
+  robot = env.scene["robot"]
+  joint_names = list(robot.joint_names)
+  n_joints = len(joint_names)
+  print(f"[INFO] {n_joints} joints: {joint_names}")
+
+  env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+  runner_cls = load_runner_cls(task) or MjlabOnPolicyRunner
+  runner = runner_cls(env, asdict(agent_cfg), device=device)
+  runner.load(
+    checkpoint, load_cfg={"actor": True}, strict=True, map_location=device
+  )
+  policy = runner.get_inference_policy(device=device)
+
+  fps = round(1.0 / env.unwrapped.step_dt)
+  n_steps = int(seconds * fps)
+
+  rec = {"t": [], "joint_pos": [], "joint_vel": [], "obs": [], "action": []}
+  env.reset()
+  for i in range(n_steps):
+    obs = env.get_observations()
+    with torch.no_grad():
+      actions = policy(obs)
+    env.step(actions)
+    rec["t"].append(i / fps)
+    rec["joint_pos"].append(robot.data.joint_pos[0].cpu().tolist())
+    rec["joint_vel"].append(robot.data.joint_vel[0].cpu().tolist())
+    rec["obs"].append(obs["actor"][0].cpu().tolist())
+    rec["action"].append(actions[0].cpu().tolist())
+    if (i + 1) % fps == 0:
+      print(f"  {(i + 1) // fps}/{seconds:.0f}s", flush=True)
+
+  env.close()
+  return {
+    "fps": fps,
+    "joint_names": joint_names,
+    "obs_terms": [
+      {"name": "base_ang_vel", "dim": 3},
+      {"name": "projected_gravity", "dim": 3},
+      {"name": "joint_pos", "dim": n_joints},
+      {"name": "joint_vel", "dim": n_joints},
+      {"name": "actions", "dim": n_joints},
+      {"name": "command", "dim": 3},
+      {"name": "head_command", "dim": 4},
+      {"name": "body_command", "dim": 6},
+    ],
+    "data": rec,
+  }
+
+
+def main() -> None:
+  p = argparse.ArgumentParser()
+  p.add_argument("--task", default=DEFAULT_TASK)
+  p.add_argument("--checkpoint", required=True)
+  p.add_argument("--out", required=True)
+  p.add_argument("--seconds", type=float, default=12.0)
+  p.add_argument("--device", default="cuda:0")
+  args = p.parse_args()
+
+  out = dump_signals(args.task, args.checkpoint, args.seconds, args.device)
+  with open(args.out, "w") as f:
+    json.dump(out, f)
+  print(f"Wrote {args.out}")
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/make_rig_page.py
+++ b/scripts/make_rig_page.py
@@ -1,0 +1,52 @@
+"""Bake one checkpoint rollout into the interactive rig HTML page.
+
+Wraps dump_rig_signals.dump_signals() + rig_template.html into a single
+self-contained file: animated side-view rig, per-joint pos/vel/action traces,
+live 61D actor obs vector, and the XL330→policy→servo signal-path map.
+Open the output in any browser (no server needed) — use it to debug *why* a
+policy misbehaves, not whether.
+
+Usage:
+  uv run scripts/make_rig_page.py --checkpoint logs/.../model_12250.pt \
+      --out /tmp/rig.html --seconds 12
+"""
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+from dump_rig_signals import DEFAULT_TASK, dump_signals
+
+
+def main() -> None:
+  p = argparse.ArgumentParser()
+  p.add_argument("--task", default=DEFAULT_TASK)
+  p.add_argument("--checkpoint", required=True)
+  p.add_argument("--out", required=True)
+  p.add_argument("--seconds", type=float, default=12.0)
+  p.add_argument("--device", default="cuda:0")
+  p.add_argument("--seed", type=int, default=0)
+  args = p.parse_args()
+
+  data = dump_signals(
+    args.task, args.checkpoint, args.seconds, args.device, seed=args.seed
+  )
+
+  ckpt = Path(args.checkpoint)
+  m = re.search(r"model_(\d+)\.pt$", ckpt.name)
+  label = f"iter {m.group(1)}" if m else ckpt.name
+  sub = (
+    f"{args.task} <b>{ckpt.parent.name}</b> {label} "
+    f"· {data['fps']} Hz · {len(data['joint_names'])}× Dynamixel XL330"
+  )
+
+  template = Path(__file__).with_name("rig_template.html").read_text()
+  payload = json.dumps(data).replace("</", "<\\/")  # keep </script> out of JSON
+  html = template.replace("/*__DATA__*/", payload).replace("__SUB__", sub)
+  Path(args.out).write_text(html)
+  print(f"Wrote {args.out} — open in a browser")
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/progress_video.py
+++ b/scripts/progress_video.py
@@ -1,0 +1,240 @@
+"""Tile checkpoints from one training run into a single progress-grid mp4.
+
+Each tile is the same task rolled out from the same seed with a different
+checkpoint, labeled with its iteration, all playing in sync — so "did training
+actually improve the behavior" is answerable by watching one video.
+
+Usage:
+  # auto: discover model_*.pt in a run dir, pick 4 evenly spaced (first..last)
+  uv run scripts/progress_video.py --run-dir logs/rsl_rl/ground_pick/<run> \
+      --out /tmp/progress.mp4
+
+  # explicit: hand-pick checkpoints (order = reading order, row-major)
+  uv run scripts/progress_video.py \
+      --checkpoint model_500.pt --checkpoint model_2000.pt \
+      --checkpoint model_8000.pt --checkpoint model_19999.pt \
+      --out /tmp/progress.mp4
+
+Requires a GPU (MuJoCo Warp) and ffmpeg on PATH (or imageio-ffmpeg's bundled
+binary, which uv resolves automatically).
+"""
+
+import argparse
+import math
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import asdict
+from pathlib import Path
+
+# Headless GPU rendering needs EGL, and it must be selected before mujoco is
+# imported (via mjlab below) or rendering dies with "an OpenGL platform
+# library has not been loaded". Skip when a real X display is available.
+if "DISPLAY" not in os.environ:
+  os.environ.setdefault("MUJOCO_GL", "egl")
+  os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+
+import imageio.v2 as imageio
+import imageio_ffmpeg
+import numpy as np
+import torch
+from PIL import Image, ImageDraw
+
+import mjlab.tasks  # noqa: F401
+import mjlab_microduck.tasks  # noqa: F401
+
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.rl import MjlabOnPolicyRunner, RslRlVecEnvWrapper
+from mjlab.tasks.registry import load_env_cfg, load_rl_cfg, load_runner_cls
+from mjlab.utils.torch import configure_torch_backends
+from mjlab.viewer.offscreen_renderer import OffscreenRenderer
+from mjlab.viewer.viewer_config import ViewerConfig
+
+DEFAULT_TASK = "Mjlab-GroundPick-Flat-MicroDuck"
+VIEWS = {"front": 270.0, "45deg": 315.0, "side": 0.0}
+VIEW_W, VIEW_H = 640, 480
+# Keeps tile height (480 + 32) a multiple of 16 so h264 needs no padding.
+LABEL_H = 32
+
+
+def find_checkpoints(run_dir: Path) -> list[tuple[int, Path]]:
+  """All `model_<iter>.pt` under run_dir, sorted by iteration."""
+  out = []
+  for p in run_dir.glob("model_*.pt"):
+    m = re.fullmatch(r"model_(\d+)\.pt", p.name)
+    if m:
+      out.append((int(m.group(1)), p))
+  return sorted(out)
+
+
+def pick_evenly(ckpts: list[tuple[int, Path]], k: int) -> list[tuple[int, Path]]:
+  """Up to k checkpoints, evenly spaced, always including first and last."""
+  if len(ckpts) <= k:
+    return ckpts
+  idx = sorted({round(i * (len(ckpts) - 1) / (k - 1)) for i in range(k)})
+  return [ckpts[i] for i in idx]
+
+
+def label_bar(text: str, width: int) -> np.ndarray:
+  img = Image.new("RGB", (width, LABEL_H), (15, 20, 27))
+  ImageDraw.Draw(img).text((10, 9), text, fill=(255, 206, 61))
+  return np.asarray(img)
+
+
+def stack_tiles(
+  tile_paths: list[Path], out: Path, cols: int, rows: int, w: int, h: int,
+  fps: int, seconds: float,
+) -> None:
+  """ffmpeg-xstack the per-checkpoint tiles into one grid video."""
+  if len(tile_paths) == 1:
+    shutil.copy(tile_paths[0], out)
+    return
+  ffmpeg = shutil.which("ffmpeg") or imageio_ffmpeg.get_ffmpeg_exe()
+  cmd = [ffmpeg, "-y"]
+  for t in tile_paths:
+    cmd += ["-i", str(t)]
+  n_inputs = len(tile_paths)
+  # fill any empty grid cells with black so xstack sees cols*rows inputs
+  for _ in range(cols * rows - n_inputs):
+    cmd += ["-f", "lavfi", "-i", f"color=c=black:s={w}x{h}:r={fps}:d={seconds}"]
+    n_inputs += 1
+  layout = "|".join(
+    f"{(i % cols) * w}_{(i // cols) * h}" for i in range(cols * rows)
+  )
+  fc = "".join(f"[{i}:v]" for i in range(n_inputs))
+  fc += f"xstack=inputs={n_inputs}:layout={layout}[v]"
+  cmd += [
+    "-filter_complex", fc, "-map", "[v]",
+    "-c:v", "libx264", "-crf", "20", "-pix_fmt", "yuv420p", str(out),
+  ]
+  subprocess.run(cmd, check=True, capture_output=True)
+
+
+def main() -> None:
+  p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+  src = p.add_mutually_exclusive_group(required=True)
+  src.add_argument("--run-dir", type=Path,
+                   help="directory containing model_<iter>.pt checkpoints")
+  src.add_argument("--checkpoint", action="append", type=Path,
+                   help="explicit checkpoint; repeat for each tile")
+  p.add_argument("--task", default=DEFAULT_TASK)
+  p.add_argument("--out", type=Path, required=True)
+  p.add_argument("--tiles", type=int, default=4,
+                 help="max tiles in auto mode (grid is ceil(sqrt)-wide)")
+  p.add_argument("--seconds", type=float, default=6.0, help="per tile")
+  p.add_argument("--view", choices=list(VIEWS), default="45deg")
+  p.add_argument("--three-views", action="store_true",
+                 help="front/45deg/side strip per tile (3x wider video)")
+  p.add_argument("--distance", type=float, default=0.8)
+  p.add_argument("--elevation", type=float, default=-10.0)
+  p.add_argument("--device", default="cuda:0")
+  p.add_argument("--seed", type=int, default=0,
+                 help="same seed for every tile so luck is shared")
+  args = p.parse_args()
+
+  if args.run_dir:
+    ckpts = pick_evenly(find_checkpoints(args.run_dir), args.tiles)
+    if not ckpts:
+      raise SystemExit(f"no model_<iter>.pt checkpoints in {args.run_dir}")
+  else:
+    ckpts = []
+    for c in args.checkpoint:
+      m = re.search(r"model_(\d+)\.pt$", c.name)
+      ckpts.append((int(m.group(1)) if m else -1, c))
+
+  azimuths = list(VIEWS.values()) if args.three_views else [VIEWS[args.view]]
+  tile_w, tile_h = VIEW_W * len(azimuths), VIEW_H + LABEL_H
+  print(f"[INFO] {len(ckpts)} tiles: "
+        + ", ".join(f"iter {i}" for i, _ in ckpts))
+
+  configure_torch_backends()
+  torch.manual_seed(args.seed)
+
+  env_cfg = load_env_cfg(args.task, play=True)
+  agent_cfg = load_rl_cfg(args.task)
+  env_cfg.scene.num_envs = 1
+  # Pin the command cycle to phase 0 at every reset so all tiles start aligned
+  # (matches runtime behavior; only tasks with a phase-randomized twist have it).
+  try:
+    twist = env_cfg.commands["twist"]
+  except (KeyError, TypeError):
+    twist = None
+  if twist is not None and hasattr(twist, "randomize_phase"):
+    twist.randomize_phase = False
+  env = ManagerBasedRlEnv(cfg=env_cfg, device=args.device, render_mode=None)
+
+  # Single renderer; azimuth is swapped per view each frame (multiple
+  # OffscreenRenderers in one process can trip over EGL contexts).
+  cam_cfg = ViewerConfig(
+    origin_type=ViewerConfig.OriginType.ASSET_BODY,
+    entity_name="robot",
+    body_name="trunk_base",
+    env_idx=0,
+    azimuth=azimuths[0],
+    elevation=args.elevation,
+    distance=args.distance,
+    height=VIEW_H,
+    width=VIEW_W,
+    enable_reflections=False,
+  )
+  renderer = OffscreenRenderer(model=env.sim.mj_model, cfg=cam_cfg, scene=env.scene)
+  renderer.initialize()
+
+  env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+  runner_cls = load_runner_cls(args.task) or MjlabOnPolicyRunner
+  runner = runner_cls(env, asdict(agent_cfg), device=args.device)
+
+  fps = round(1.0 / env.unwrapped.step_dt)
+  n_steps = int(args.seconds * fps)
+
+  with tempfile.TemporaryDirectory() as tmp:
+    tile_paths = []
+    for iteration, ckpt in ckpts:
+      print(f"[INFO] tile iter {iteration}: {ckpt}")
+      runner.load(
+        str(ckpt), load_cfg={"actor": True}, strict=True,
+        map_location=args.device,
+      )
+      policy = runner.get_inference_policy(device=args.device)
+
+      tile_path = Path(tmp) / f"tile_{iteration}.mp4"
+      writer = imageio.get_writer(
+        tile_path, fps=fps, codec="libx264", quality=8, macro_block_size=16
+      )
+      bar = label_bar(
+        f"iter {iteration}" if iteration >= 0 else ckpt.name, tile_w
+      )
+      torch.manual_seed(args.seed)  # same episode luck for every tile
+      env.reset()
+      for i in range(n_steps):
+        obs = env.get_observations()
+        with torch.no_grad():
+          actions = policy(obs)
+        env.step(actions)
+        frames = []
+        for azimuth in azimuths:
+          renderer._cam.azimuth = azimuth
+          renderer.update(env.unwrapped.sim.data)
+          frames.append(renderer.render())
+        frame = np.concatenate(frames, axis=1)
+        writer.append_data(np.concatenate([bar, frame], axis=0))
+        if (i + 1) % fps == 0:
+          print(f"  {(i + 1) // fps}/{args.seconds:.0f}s", flush=True)
+      writer.close()
+      tile_paths.append(tile_path)
+
+    cols = math.ceil(math.sqrt(len(tile_paths)))
+    rows = math.ceil(len(tile_paths) / cols)
+    print(f"[INFO] stacking {len(tile_paths)} tiles ({cols}x{rows}) -> {args.out}")
+    stack_tiles(
+      tile_paths, args.out, cols, rows, tile_w, tile_h, fps, args.seconds
+    )
+
+  env.close()
+  print(f"Wrote {args.out}")
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/rig_template.html
+++ b/scripts/rig_template.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>MicroDuck Rig — hardware signals → policy I/O</title>
+<style>
+  :root {
+    --bg:#0f141b; --panel:#182030; --panel2:#1f2a3d; --line:#2c3a52;
+    --txt:#dbe4f0; --dim:#8ea1bb; --duck:#ffce3d; --accent:#4fc3f7;
+    --pos:#66bb6a; --vel:#ab47bc; --act:#ff7043;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--txt);
+         font:14px/1.45 -apple-system,"Segoe UI",Roboto,sans-serif; }
+  header { padding:12px 18px; border-bottom:1px solid var(--line);
+           display:flex; align-items:center; gap:14px; flex-wrap:wrap; }
+  header h1 { font-size:17px; margin:0; color:var(--duck); }
+  header .sub { color:var(--dim); font-size:12px; }
+  #controls { display:flex; align-items:center; gap:10px; margin-left:auto; }
+  button { background:var(--panel2); color:var(--txt); border:1px solid var(--line);
+           border-radius:6px; padding:6px 14px; cursor:pointer; font-size:13px; }
+  button:hover { border-color:var(--accent); }
+  #scrub { width:280px; accent-color:var(--duck); }
+  #tlabel { font-variant-numeric:tabular-nums; color:var(--dim); min-width:90px; }
+  main { display:grid; grid-template-columns:460px 1fr; gap:14px; padding:14px 18px; }
+  .card { background:var(--panel); border:1px solid var(--line); border-radius:10px; padding:12px; }
+  .card h2 { margin:0 0 8px; font-size:13px; text-transform:uppercase;
+             letter-spacing:.08em; color:var(--dim); }
+  #rig { display:block; margin:auto; }
+  .joint-row { display:grid; grid-template-columns:130px 1fr 64px; gap:8px;
+               align-items:center; padding:3px 6px; border-radius:6px; cursor:pointer; }
+  .joint-row:hover { background:var(--panel2); }
+  .joint-row.sel { background:#27344c; outline:1px solid var(--duck); }
+  .joint-row .nm { font-size:12px; }
+  .joint-row .bar { height:8px; background:#0c1119; border-radius:4px; position:relative; overflow:hidden; }
+  .joint-row .bar i { position:absolute; top:0; bottom:0; background:var(--accent); border-radius:4px; }
+  .joint-row .vl { font-size:11px; color:var(--dim); text-align:right; font-variant-numeric:tabular-nums; }
+  #lower { display:grid; grid-template-columns:1fr 1fr; gap:14px; padding:0 18px 14px; }
+  #obsbar { display:flex; gap:1px; height:54px; margin-top:6px; }
+  #obsbar div { border-radius:2px; position:relative; cursor:default; }
+  #obslegend { display:flex; gap:12px; flex-wrap:wrap; margin-top:8px; font-size:11px; color:var(--dim); }
+  #obslegend b { font-weight:600; }
+  canvas.chart { width:100%; height:120px; background:#0c1119; border-radius:8px; }
+  .chlabel { font-size:11px; margin:8px 0 3px; color:var(--dim); }
+  #mapinfo { font-size:12.5px; }
+  #mapinfo .flow { display:flex; align-items:center; gap:6px; flex-wrap:wrap; margin:8px 0; }
+  #mapinfo .node { background:var(--panel2); border:1px solid var(--line); border-radius:6px; padding:4px 9px; }
+  #mapinfo .arrow { color:var(--duck); }
+  #mapinfo code { color:var(--accent); }
+  .tag { display:inline-block; background:#0c1119; border:1px solid var(--line); border-radius:4px;
+         padding:1px 6px; margin:1px 2px; font-size:11px; color:var(--dim); }
+  .tooltip { position:fixed; pointer-events:none; background:#000a; border:1px solid var(--line);
+             border-radius:6px; padding:5px 9px; font-size:11.5px; display:none; z-index:10; }
+</style>
+</head>
+<body>
+<header>
+  <h1>🦆 MicroDuck Rig</h1>
+  <div class="sub">hardware signals → policy input/output &nbsp;·&nbsp; __SUB__</div>
+  <div id="controls">
+    <button id="playbtn">⏸ Pause</button>
+    <input id="scrub" type="range" min="0" max="599" value="0">
+    <span id="tlabel">0.00 s</span>
+  </div>
+</header>
+<main>
+  <div class="card">
+    <h2>Rig — click a joint (side view animated · roll/yaw as gauges)</h2>
+    <svg id="rig" width="440" height="470" viewBox="0 0 440 470"></svg>
+  </div>
+  <div class="card">
+    <h2>Joints — live position</h2>
+    <div id="jointlist"></div>
+    <div id="mapinfo" style="margin-top:12px"></div>
+  </div>
+</main>
+<div id="lower">
+  <div class="card">
+    <h2>Selected joint — signals over the rollout</h2>
+    <div class="chlabel" style="color:var(--pos)">present_position (rad) — encoder reading the policy sees (with bias/noise)</div>
+    <canvas class="chart" id="ch_pos" width="900" height="120"></canvas>
+    <div class="chlabel" style="color:var(--vel)">present_velocity (rad/s) — 1-control-step lag (Dynamixel moving average)</div>
+    <canvas class="chart" id="ch_vel" width="900" height="120"></canvas>
+    <div class="chlabel" style="color:var(--act)">policy action (rad) — target position written back to the servo</div>
+    <canvas class="chart" id="ch_act" width="900" height="120"></canvas>
+  </div>
+  <div class="card">
+    <h2>Policy input vector (61D) — live</h2>
+    <div id="obsbar"></div>
+    <div id="obslegend"></div>
+    <p style="font-size:12px;color:var(--dim)">
+      Layout: <code>base_ang_vel(3) · projected_gravity(3) · joint_pos(14) · joint_vel(14) · actions(14) · command(3) · head_command(4) · body_command(6)</code>.
+      Actor obs carry sim2real corruptions (IMU misalignment, encoder bias, noise, velocity lag); the critic sees clean values.
+      Vector is obs-normalized before the MLP — the normalizer is baked into the exported ONNX.
+    </p>
+  </div>
+</div>
+<div class="tooltip" id="tip"></div>
+<script id="rig-data" type="application/json">/*__DATA__*/</script>
+<script>
+const DATA = JSON.parse(document.getElementById('rig-data').textContent);
+const JN = DATA.joint_names, D = DATA.data, N = D.t.length, FPS = DATA.fps;
+// obs layout offsets
+const TERMS = DATA.obs_terms; let off = []; TERMS.reduce((a,t,i)=>(off.push(a),a+t.dim),0);
+const termColor = { base_ang_vel:'#4fc3f7', projected_gravity:'#26a69a', joint_pos:'#66bb6a',
+  joint_vel:'#ab47bc', actions:'#ff7043', command:'#ffce3d', head_command:'#7e57c2', body_command:'#5c6bc0' };
+
+let sel = 5; // neck_pitch by default — the star of the ground pick
+let frame = 0, playing = true, lastT = 0;
+
+// ── rig drawing (side view, sagittal chain + gauges) ─────────────────────────
+const svg = document.getElementById('rig');
+const NS = 'http://www.w3.org/2000/svg';
+function el(tag, attrs, parent) { const e = document.createElementNS(NS, tag);
+  for (const k in attrs) e.setAttribute(k, attrs[k]); (parent||svg).appendChild(e); return e; }
+
+const S = 900; // px per meter
+const ORIGIN = {x: 220, y: 200}; // hip center
+// link lengths (m)
+const L = { trunk: 0.10, neck: 0.055, head: 0.065, thigh: 0.055, shank: 0.05, foot: 0.035 };
+
+// structure: groups per leg so rotation composes
+function makeLeg(dx, shade) {
+  const hip = el('g', {}, svg);
+  const thigh = el('line', {x1:0,y1:0,x2:0,y2:L.thigh*S, stroke:shade?'#9aa7ba':'#dbe4f0', 'stroke-width':13, 'stroke-linecap':'round'}, hip);
+  const kneeG = el('g', {transform:`translate(0,${L.thigh*S})`}, hip);
+  const shank = el('line', {x1:0,y1:0,x2:0,y2:L.shank*S, stroke:shade?'#8b98ac':'#c4cedd', 'stroke-width':11, 'stroke-linecap':'round'}, kneeG);
+  const ankG = el('g', {transform:`translate(0,${L.shank*S})`}, kneeG);
+  const foot = el('line', {x1:-L.foot*S*0.5,y1:0,x2:L.foot*S*0.6,y2:0, stroke:'#ffce3d', 'stroke-width':9, 'stroke-linecap':'round'}, ankG);
+  const hipJ = el('circle', {r:8, fill:'#182030', stroke:'#4fc3f7','stroke-width':2, cursor:'pointer'}, hip);
+  const kneeJ = el('circle', {r:7, fill:'#182030', stroke:'#4fc3f7','stroke-width':2, cursor:'pointer'}, kneeG);
+  const ankJ = el('circle', {r:6, fill:'#182030', stroke:'#4fc3f7','stroke-width':2, cursor:'pointer'}, ankG);
+  return {hip, kneeG, ankG, hipJ, kneeJ, ankJ, dx};
+}
+// right leg behind (slightly offset, darker)
+const legR = makeLeg(14, true), legL = makeLeg(0, false);
+const trunk = el('rect', {x:ORIGIN.x-34, y:ORIGIN.y-L.trunk*S, width:68, height:L.trunk*S, rx:16, fill:'#f4f7fb', stroke:'#c4cedd'}, svg);
+// neck chain from top of trunk
+const neckG = el('g', {transform:`translate(0,${-L.trunk*S})`}, svg);
+const neckL = el('line', {x1:0,y1:0,x2:0,y2:-L.neck*S, stroke:'#c4cedd','stroke-width':10,'stroke-linecap':'round'}, neckG);
+const neckJ = el('circle', {r:7, fill:'#182030', stroke:'#4fc3f7','stroke-width':2, cursor:'pointer'}, neckG);
+const headG = el('g', {transform:`translate(0,${-L.neck*S})`}, neckG);
+const headJ = el('circle', {r:6, fill:'#182030', stroke:'#4fc3f7','stroke-width':2, cursor:'pointer'}, headG);
+const head = el('ellipse', {cx:6, cy:-L.head*S*0.55, rx:30, ry:22, fill:'#f4f7fb', stroke:'#c4cedd'}, headG);
+const brim = el('rect', {x:-24, y:-L.head*S*0.55+14, width:60, height:6, rx:3, fill:'#ffce3d'}, headG);
+const eye  = el('circle', {cx:16, cy:-L.head*S*0.55-4, r:5, fill:'#333'}, headG);
+const beak = el('path', {d:`M 30 ${-L.head*S*0.55+8} L 46 ${-L.head*S*0.55+14} L 30 ${-L.head*S*0.55+18} Z`, fill:'#ffce3d'}, headG);
+
+// ground
+el('line', {x1:10, y1:ORIGIN.y+(L.thigh+L.shank)*S, x2:430, y2:ORIGIN.y+(L.thigh+L.shank)*S, stroke:'#2c3a52','stroke-width':2}, svg);
+el('text', {x:16, y:ORIGIN.y+(L.thigh+L.shank)*S+18, fill:'#8ea1bb','font-size':11}, svg).textContent = 'ground';
+
+// gauges for roll/yaw joints (bottom row)
+const gauges = {};
+function makeGauge(x, y, label) {
+  const g = el('g', {transform:`translate(${x},${y})`}, svg);
+  el('circle', {r:22, fill:'#0c1119', stroke:'#2c3a52'}, g);
+  const needle = el('line', {x1:0,y1:0,x2:0,y2:-18, stroke:'#ffce3d','stroke-width':3,'stroke-linecap':'round'}, g);
+  const dot = el('circle', {r:22, fill:'transparent', cursor:'pointer'}, g);
+  el('text', {x:0, y:38, fill:'#8ea1bb','font-size':10,'text-anchor':'middle'}, g).textContent = label;
+  return {needle, dot};
+}
+[['left_hip_yaw',60],['left_hip_roll',130],['head_yaw',300],['head_roll',370]].forEach(([n,x]) => gauges[n] = makeGauge(x, 425, n));
+
+// joint name → rig element (for click + highlight)
+const rigTargets = {
+  left_hip_pitch: legL.hipJ, left_knee: legL.kneeJ, left_ankle: legL.ankJ,
+  right_hip_pitch: legR.hipJ, right_knee: legR.kneeJ, right_ankle: legR.ankJ,
+  neck_pitch: neckJ, head_pitch: headJ,
+  left_hip_yaw: gauges.left_hip_yaw.dot, left_hip_roll: gauges.left_hip_roll.dot,
+  head_yaw: gauges.head_yaw.dot, head_roll: gauges.head_roll.dot,
+};
+
+// ── joint list ───────────────────────────────────────────────────────────────
+const list = document.getElementById('jointlist');
+const rows = JN.map((n, i) => {
+  const r = document.createElement('div'); r.className = 'joint-row'; r.dataset.i = i;
+  r.innerHTML = `<span class="nm">${i}: ${n}</span><span class="bar"><i></i></span><span class="vl"></span>`;
+  r.onclick = () => select(i);
+  list.appendChild(r); return r;
+});
+
+// ── obs bar ──────────────────────────────────────────────────────────────────
+const obsbar = document.getElementById('obsbar');
+const cells = [];
+TERMS.forEach(t => { for (let k = 0; k < t.dim; k++) {
+  const c = document.createElement('div');
+  c.style.background = termColor[t.name]; c.style.flex = '1'; c.style.opacity = .45;
+  obsbar.appendChild(c); cells.push(c);
+}});
+document.getElementById('obslegend').innerHTML = TERMS.map(t =>
+  `<span><b style="color:${termColor[t.name]}">■</b> ${t.name} [${off[TERMS.indexOf(t)]}..${off[TERMS.indexOf(t)]+t.dim-1}]</span>`).join('');
+
+// tooltip for obs cells
+const tip = document.getElementById('tip');
+cells.forEach((c, idx) => {
+  c.onmousemove = e => { tip.style.display='block'; tip.style.left=e.clientX+12+'px'; tip.style.top=e.clientY+12+'px';
+    const t = TERMS.find((t,j)=> idx>=off[j] && idx<off[j]+t.dim);
+    tip.textContent = `obs[${idx}] ${t.name}[${idx-off[TERMS.indexOf(t)]}] = ${D.obs[frame][idx].toFixed(3)}`; };
+  c.onmouseleave = () => tip.style.display='none';
+});
+
+// ── map info ─────────────────────────────────────────────────────────────────
+function mapHTML(i) {
+  const n = JN[i];
+  return `<h2 style="margin-top:0">Signal path — <span style="color:var(--duck)">${n}</span> (joint ${i})</h2>
+  <div class="flow">
+    <span class="node">XL330 servo<br><small>present_position / present_velocity</small></span><span class="arrow">→</span>
+    <span class="node">obs builder<br><small>+encoder bias · +noise · vel lag 1 step</small></span><span class="arrow">→</span>
+    <span class="node">obs[${off[2]+i}], obs[${off[3]+i}]<br><small>joint_pos[${i}] · joint_vel[${i}]</small></span><span class="arrow">→</span>
+    <span class="node">obs normalizer<br><small>baked into ONNX</small></span><span class="arrow">→</span>
+    <span class="node">MLP 512·256·128</span><span class="arrow">→</span>
+    <span class="node">action[${i}]<br><small>target pos, scale 1.0</small></span><span class="arrow">→</span>
+    <span class="node">XL330 goal_position</span>
+  </div>
+  <div>
+    <span class="tag">feedback: obs[${off[4]+i}] = last action</span>
+    <span class="tag">encoder bias ±0.015 rad (per-env, DR)</span>
+    <span class="tag">pos noise ±0.001 rad</span>
+    <span class="tag">vel noise ±0.25 rad/s</span>
+    <span class="tag">vel lag: 1 ctrl step (20 ms)</span>
+    <span class="tag">IMU misalignment ±6° affects base obs, not this joint</span>
+  </div>`;
+}
+
+// ── charts ───────────────────────────────────────────────────────────────────
+function drawChart(id, series, color) {
+  const cv = document.getElementById(id), ctx = cv.getContext('2d');
+  const W = cv.width, H = cv.height;
+  ctx.clearRect(0,0,W,H);
+  let mn = Math.min(...series), mx = Math.max(...series);
+  if (mx-mn < 1e-6) { mn -= 1; mx += 1; }
+  const pad = (mx-mn)*0.12; mn -= pad; mx += pad;
+  // zero line
+  if (mn < 0 && mx > 0) { const zy = H*(1-(0-mn)/(mx-mn));
+    ctx.strokeStyle='#2c3a52'; ctx.beginPath(); ctx.moveTo(0,zy); ctx.lineTo(W,zy); ctx.stroke(); }
+  ctx.strokeStyle = color; ctx.lineWidth = 1.6; ctx.beginPath();
+  series.forEach((v,i) => { const x=i/(N-1)*W, y=H*(1-(v-mn)/(mx-mn)); i?ctx.lineTo(x,y):ctx.moveTo(x,y); });
+  ctx.stroke();
+  // playhead
+  const px = frame/(N-1)*W;
+  ctx.strokeStyle='#ffce3d'; ctx.lineWidth=1; ctx.beginPath(); ctx.moveTo(px,0); ctx.lineTo(px,H); ctx.stroke();
+  // min/max labels
+  ctx.fillStyle='#8ea1bb'; ctx.font='10px sans-serif';
+  ctx.fillText(mx.toFixed(3), 4, 11); ctx.fillText(mn.toFixed(3), 4, H-4);
+}
+function drawCharts() {
+  drawChart('ch_pos', D.joint_pos.map(r=>r[sel]), '#66bb6a');
+  drawChart('ch_vel', D.joint_vel.map(r=>r[sel]), '#ab47bc');
+  drawChart('ch_act', D.action.map(r=>r[sel]), '#ff7043');
+}
+
+// ── per-frame update ─────────────────────────────────────────────────────────
+function update() {
+  const q = D.joint_pos[frame];
+  const gi = n => JN.indexOf(n);
+  // legs: hip_pitch, knee, ankle (positive = forward swing, sign tuned visually)
+  function poseLeg(leg, pre) {
+    const hp = -q[gi(pre+'hip_pitch')], kn = q[gi(pre+'knee')], an = -q[gi(pre+'ankle')];
+    leg.hip.setAttribute('transform', `translate(${ORIGIN.x+leg.dx},${ORIGIN.y}) rotate(${hp*57.3})`);
+    leg.kneeG.setAttribute('transform', `translate(0,${L.thigh*S}) rotate(${kn*57.3})`);
+    leg.ankG.setAttribute('transform', `translate(0,${L.shank*S}) rotate(${an*57.3})`);
+  }
+  poseLeg(legL, 'left_'); poseLeg(legR, 'right_');
+  // head chain: neck_pitch + head_pitch (positive pitch = face down toward ground)
+  const np = -q[gi('neck_pitch')], hpt = -q[gi('head_pitch')];
+  neckG.setAttribute('transform', `translate(${ORIGIN.x},${ORIGIN.y-L.trunk*S}) rotate(${np*57.3})`);
+  headG.setAttribute('transform', `translate(0,${-L.neck*S}) rotate(${hpt*57.3})`);
+  // gauges
+  for (const n in gauges) gauges[n].needle.setAttribute('transform', `rotate(${q[gi(n)]*57.3})`);
+
+  // joint list bars
+  rows.forEach((r,i) => {
+    const v = q[i], lim = 1.6;
+    const pct = Math.max(-1, Math.min(1, v/lim));
+    const bar = r.querySelector('i');
+    bar.style.left = pct < 0 ? (50+pct*50)+'%' : '50%';
+    bar.style.width = Math.abs(pct)*50+'%';
+    bar.style.background = i===sel ? 'var(--duck)' : 'var(--accent)';
+    r.querySelector('.vl').textContent = v.toFixed(3);
+    r.classList.toggle('sel', i===sel);
+  });
+
+  // obs bar live values
+  const o = D.obs[frame];
+  cells.forEach((c,idx) => { c.style.opacity = .25 + .7*Math.min(1, Math.abs(o[idx])/2);
+    c.style.outline = (idx===off[2]+sel || idx===off[3]+sel || idx===off[4]+sel) ? '1.5px solid #ffce3d' : 'none'; });
+
+  document.getElementById('tlabel').textContent = (frame/FPS).toFixed(2)+' s';
+  document.getElementById('scrub').value = frame;
+}
+
+function select(i) { sel = i;
+  document.getElementById('mapinfo').innerHTML = mapHTML(i);
+  drawCharts(); update(); }
+
+Object.entries(rigTargets).forEach(([n,e]) => e && (e.onclick = () => select(JN.indexOf(n))));
+
+// playback
+const scrub = document.getElementById('scrub');
+scrub.max = N-1;
+scrub.oninput = () => { frame = +scrub.value; update(); };
+document.getElementById('playbtn').onclick = function() {
+  playing = !playing; this.textContent = playing ? '⏸ Pause' : '▶ Play'; };
+function tick(ts) {
+  if (playing && ts - lastT > 1000/FPS) { lastT = ts; frame = (frame+1)%N; update(); }
+  requestAnimationFrame(tick);
+}
+select(5);
+requestAnimationFrame(tick);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Two one-command tools so an AI coding agent (or a human) can **show** training progress instead of claiming it:

- **`scripts/progress_video.py`** — tiles checkpoints from a run into one labeled progress-grid mp4.
  ```bash
  uv run scripts/progress_video.py --run-dir logs/rsl_rl/<exp>/<run> --out progress.mp4
  ```
  - Auto-discovers `model_<iter>.pt`, picks 4 evenly spaced (first→last); or repeated `--checkpoint` for a hand-picked set
  - Every tile rolls out from the **same seed** with the phase-aligned reset, so checkpoints are compared on identical episodes
  - `--three-views` for the front/45°/side strip per tile; `--seconds` per tile; ffmpeg xstack for the grid
  - Headless EGL is set up automatically (no more "an OpenGL platform library has not been loaded")

- **`scripts/make_rig_page.py`** — bakes one checkpoint rollout into a self-contained interactive rig HTML (animated rig, per-joint pos/vel/action traces, live 61D actor obs, XL330→policy→servo signal-path map). For debugging *why* a policy misbehaves, not whether.
  - `dump_rig_signals.py` refactored to expose `dump_signals()`; `rig_template.html` header run label is now substituted instead of hardcoded

- **AGENTS.md**: commands block entries + a "Progress videos & rig pages — showing, not claiming" section instructing agents to attach the grid after training milestones.

## Tested

End-to-end on the `2026-08-29_10-42-34_sockpick_v1` ground-pick run (RTX 3090, headless EGL): 3-tile grid (iter 0 / 10000 / 19999) renders correctly with labels; rig page contains valid 150-frame 61D obs / 14-joint data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)