### PR TITLE
fix: intercept `train --hf-jobs` from the mjlab plugin hook (CLI unchanged)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ src/mjlab_microduck/
 │   ├── mdp.py                        # rewards, events, observations, custom classes
 │   ├── backlash.py                   # make_backlash_variant() env-cfg wrapper
 │   └── microduck_*_env_cfg.py        # one cfg module per task family
-├── train_cli.py                      # `train` entry point (+ --hf-jobs)
+├── train_cli.py                      # `train` script (identical to mjlab's)
+├── train_hook.py                     # intercepts `train ... --hf-jobs`
 └── hf_jobs.py                        # Hugging Face Jobs submission
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,17 @@ dependencies = [
 mjlab_microduck = "mjlab_microduck.tasks"
 
 [project.scripts]
-# Shadows mjlab's `train` entry point: identical behavior, plus a --hf-jobs
-# flag that submits the run to Hugging Face Jobs instead (see train_cli.py).
+# This name collides with mjlab's `train` ON PURPOSE and must stay declared.
+# Same-name console scripts are last-writer-wins and both dist-info RECORDs
+# then claim bin/train, so deleting this line does NOT hand the name back to
+# mjlab: `uv sync` uninstalls the file (ours, per our RECORD) and nothing
+# recreates mjlab's, leaving no `train` in the venv at all — `uv run train`
+# then finds some unrelated `train` on PATH (liblinear's, 2026-08-31).
+# The collision is harmless because the two shims are interchangeable:
+# --hf-jobs is intercepted from the `mjlab.tasks` entry point above
+# (train_hook.py), not here. Locked by tests/test_hf_jobs_flag.py.
 train = "mjlab_microduck.train_cli:main"
-  
+
 [tool.ruff]
 src = ["src"]  # Helpful for recognizing first-party imports.
 indent-width = 4

--- a/src/mjlab_microduck/hf_jobs.py
+++ b/src/mjlab_microduck/hf_jobs.py
@@ -1,6 +1,6 @@
 """Submit a mjlab-microduck training run as a Hugging Face Job.
 
-Invoked via the `train` wrapper (see train_cli.py):
+Invoked by the --hf-jobs interception (see train_hook.py):
 
     uv run train Mjlab-Kick-Flat-MicroDuck \
         --env.scene.num-envs 4096 --agent.max_iterations 4000 --hf-jobs
@@ -319,6 +319,9 @@ def submit(argv: list[str]) -> int:
     ckpt_repo = args.ckpt_repo or f"{namespace}/{run_name}"
 
     env: dict[str, str] = {
+        # Disarms the --hf-jobs interception inside the job, so the job's own
+        # `uv run train` can only ever train locally (see train_hook.py).
+        "MICRODUCK_IN_HF_JOB": "1",
         "CKPT_REPO": ckpt_repo,
         "TRAIN_ARGS": " ".join(shlex.quote(a) for a in [args.task, *train_args]),
     }

--- a/src/mjlab_microduck/tasks/__init__.py
+++ b/src/mjlab_microduck/tasks/__init__.py
@@ -1,3 +1,11 @@
+from mjlab_microduck.train_hook import maybe_submit_to_hf_jobs
+
+# `train <task> ... --hf-jobs` submits to HF Jobs and exits here, before any
+# of the cfg imports below: this module is what mjlab's plugin loader pulls
+# in, and it is the only train path no install order can take from us (see
+# train_hook.py). A no-op without the flag.
+maybe_submit_to_hf_jobs()
+
 from mjlab.tasks.registry import register_mjlab_task
 from mjlab.tasks.velocity.rl import VelocityOnPolicyRunner
 

--- a/src/mjlab_microduck/train_cli.py
+++ b/src/mjlab_microduck/train_cli.py
@@ -1,17 +1,20 @@
-"""`train` entry point: mjlab's trainer, plus `--hf-jobs` remote submission.
+"""`train` console script — deliberately identical to mjlab's own.
 
-This project's [project.scripts] `train` shadows mjlab's so the everyday
-command grows one flag:
+This project must keep DECLARING a `train` script even though it no longer
+needs one: `--hf-jobs` is intercepted from the `mjlab.tasks` plugin entry point
+(train_hook.py), on mjlab's own import path, so the wrapper has nothing left to
+do.
 
-    uv run train Mjlab-Kick-Flat-MicroDuck --env.scene.num-envs 4096 \
-        --agent.max_iterations 4000              # local, exactly as before
-    uv run train Mjlab-Kick-Flat-MicroDuck --env.scene.num-envs 4096 \
-        --agent.max_iterations 4000 --hf-jobs    # same run, on HF Jobs
+Why keep it anyway: same-name console scripts are last-writer-wins, and after
+an install BOTH dist-info RECORDs claim `.venv/bin/train`. Removing this
+declaration therefore does not hand the name back to mjlab — it makes the next
+`uv sync` UNINSTALL the file (ours, per our RECORD) while nothing reinstalls
+mjlab's. `train` then vanishes from the venv entirely and `uv run train` falls
+through to whatever `train` sits on PATH: on one machine liblinear's, which
+answered `can't open input file Mjlab-Velocity-Flat-MicroDuck` (2026-08-31).
 
-Without --hf-jobs, argv is passed to mjlab.scripts.train untouched. With it,
-the submission flags (--flavor, --namespace, --detach, ... see hf_jobs.py)
-are consumed here and everything else is forwarded to `uv run train` inside
-the job.
+So the collision stays, and is made harmless instead: whichever shim wins,
+`train` behaves the same, and the flag is handled in exactly one place.
 """
 
 from __future__ import annotations
@@ -20,12 +23,10 @@ import sys
 
 
 def main() -> int | None:
-    argv = sys.argv[1:]
-    if "--hf-jobs" in argv:
-        from mjlab_microduck.hf_jobs import submit
-
-        return submit([a for a in argv if a != "--hf-jobs"])
-
+    # This import runs mjlab's plugin loader, which imports
+    # mjlab_microduck.tasks -> train_hook.maybe_submit_to_hf_jobs(). A
+    # `--hf-jobs` invocation submits and exits inside the import below; it
+    # never comes back here.
     from mjlab.scripts.train import main as mjlab_train_main
 
     return mjlab_train_main()

--- a/src/mjlab_microduck/train_hook.py
+++ b/src/mjlab_microduck/train_hook.py
@@ -1,0 +1,64 @@
+"""Keep `train <task> ... --hf-jobs` working, whoever owns the `train` script.
+
+The flag used to live in a `train` console script of our own, declared in
+`[project.scripts]` and documented as "shadowing" mjlab's. It shadows nothing:
+mjlab 1.3.0 declares `train` too, two distributions declaring the SAME script
+name is last-writer-wins at install time, and mjlab won — `uv sync` left
+`mjlab.scripts.train:main` in `.venv/bin/train`, so our wrapper was never
+invoked and `uv run train ... --hf-jobs` died on tyro's
+`Unrecognized options: --hf-jobs` (2026-08-31). Nothing warns about it: the
+install succeeds and the flag silently disappears.
+
+So the flag is not implemented in a console script at all any more. It is
+intercepted here, from the `mjlab.tasks` plugin entry point: mjlab's own
+`mjlab/__init__.py` calls `_import_registered_packages()` at module scope,
+which imports `mjlab_microduck.tasks` — and mjlab's `train` reaches that while
+executing `from mjlab.scripts.train import main`, i.e. before its two-stage
+tyro parse ever sees argv. That path is mjlab's own, so no install order can
+take it away from us.
+
+`uv run scripts/hf/train_hf.py <task> ...` calls `submit()` directly and stays
+the escape hatch if this interception ever stops firing.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_FLAG = "--hf-jobs"
+
+#: Set on the job's environment by ``hf_jobs.submit`` — inside the job,
+#: ``uv run train`` must always mean "train locally".
+_IN_JOB_ENV = "MICRODUCK_IN_HF_JOB"
+
+
+def _invoked_as_train() -> bool:
+    """True when argv[0] is mjlab's trainer (console script or `-m`).
+
+    `play --hf-jobs` must NOT submit a training job; let that command's own
+    parser reject the flag instead.
+    """
+    prog = Path(sys.argv[0]).name
+    return prog.removesuffix(".py").removesuffix("-script") == "train"
+
+
+def maybe_submit_to_hf_jobs() -> None:
+    """Consume `--hf-jobs` and exit the process; a no-op without the flag.
+
+    Called at import time of `mjlab_microduck.tasks`, so it runs inside mjlab's
+    plugin loader. `SystemExit` is a `BaseException`, so it propagates through
+    the loader's `except Exception` and out of `import mjlab` — the local
+    trainer never starts.
+    """
+    if _FLAG not in sys.argv[1:]:
+        return
+    if os.environ.get(_IN_JOB_ENV):
+        return
+    if not _invoked_as_train():
+        return
+
+    from mjlab_microduck.hf_jobs import submit
+
+    sys.exit(submit([a for a in sys.argv[1:] if a != _FLAG]))

--- a/tests/test_hf_jobs_flag.py
+++ b/tests/test_hf_jobs_flag.py
@@ -1,0 +1,205 @@
+"""`train <task> ... --hf-jobs` must keep submitting to HF Jobs.
+
+The flag was owned by a `train` console script of ours that was supposed to
+shadow mjlab's. Same-name console scripts are last-writer-wins, mjlab's shim
+won, and the flag silently vanished: `uv run train ... --hf-jobs` hit mjlab's
+tyro parser and died with `Unrecognized options: --hf-jobs` (2026-08-31).
+
+It is now intercepted from the `mjlab.tasks` plugin entry point instead
+(train_hook.py), which mjlab imports itself, so either shim handles the flag.
+
+The `train` declaration stays, though — dropping it made things worse, not
+better: both RECORDs claim bin/train, so `uv sync` uninstalled the file and
+nothing recreated mjlab's, leaving `uv run train` to find liblinear's `train`
+on PATH ("can't open input file Mjlab-Velocity-Flat-MicroDuck").
+
+Three things must hold, none of which fails loudly on its own:
+
+1. `train` stays declared, and stays behaviorally identical to mjlab's.
+2. mjlab must still reach `mjlab_microduck.tasks` before it parses argv — a
+   refactor of mjlab's plugin loading would silently drop the flag.
+3. Both shims must intercept, since which one lands in bin/ is not ours to
+   decide.
+"""
+
+import shutil
+import subprocess
+import sys
+import tomllib
+from importlib.metadata import distribution
+from pathlib import Path
+
+import pytest
+
+from mjlab_microduck import train_hook
+
+_ROOT = Path(__file__).resolve().parents[1]
+_TASK = "Mjlab-Velocity-Flat-MicroDuck"
+
+
+def _our_scripts():
+    pyproject = tomllib.loads((_ROOT / "pyproject.toml").read_text())
+    return pyproject["project"].get("scripts", {})
+
+
+def test_train_script_stays_declared():
+    """Removing it uninstalls bin/train and recreates nothing (see docstring)."""
+    assert _our_scripts().get("train") == "mjlab_microduck.train_cli:main", (
+        "[project.scripts] must keep declaring `train`. Both this package and "
+        "mjlab claim bin/train in their RECORD, so dropping the declaration "
+        "makes `uv sync` DELETE the script instead of reverting it to mjlab's, "
+        "and `uv run train` then runs an unrelated `train` from PATH."
+    )
+
+
+def test_our_train_script_only_delegates_to_mjlab():
+    """The collision is only safe while the two shims are interchangeable."""
+    import mjlab.scripts.train
+
+    from mjlab_microduck import train_cli
+
+    called = []
+    original = mjlab.scripts.train.main
+    mjlab.scripts.train.main = lambda: called.append(True) or 5
+    try:
+        assert train_cli.main() == 5, "our `train` must return mjlab's exit code"
+    finally:
+        mjlab.scripts.train.main = original
+    assert called == [True], "our `train` must call mjlab's trainer, unmodified"
+
+
+def test_train_on_path_is_a_mjlab_trainer():
+    """Catches the vanished-script failure directly: `train` must be ours or
+    mjlab's, never whatever else is installed on the machine."""
+    exe = shutil.which("train")
+    assert exe is not None, (
+        "no `train` on PATH — the venv script was uninstalled and not recreated; "
+        "run `uv sync --reinstall-package mjlab-microduck`."
+    )
+    head = Path(exe).read_bytes()[:8192]
+    assert b"mjlab" in head, (
+        f"`train` resolves to {exe}, which is not a mjlab trainer. bin/train was "
+        "uninstalled and this is an unrelated binary from PATH."
+    )
+
+
+def test_we_register_the_task_plugin_entry_point():
+    """The interception rides on this entry point; without it, no flag."""
+    groups = {ep.group: ep.value for ep in distribution("mjlab-microduck").entry_points}
+    assert groups.get("mjlab.tasks") == "mjlab_microduck.tasks", (
+        "the `mjlab.tasks` entry point must stay pointed at mjlab_microduck.tasks: "
+        "it is both how tasks register AND where --hf-jobs is intercepted."
+    )
+
+
+@pytest.fixture
+def fake_submit(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "mjlab_microduck.hf_jobs.submit", lambda argv: calls.append(argv) or 0
+    )
+    return calls
+
+
+def test_hook_submits_and_strips_the_flag(monkeypatch, fake_submit):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["/x/.venv/bin/train", _TASK, "--env.scene.num-envs", "4096", "--hf-jobs"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        train_hook.maybe_submit_to_hf_jobs()
+    assert exc.value.code == 0
+    # --hf-jobs must not reach the job's own `uv run train`, which is mjlab's.
+    assert fake_submit == [[_TASK, "--env.scene.num-envs", "4096"]]
+
+
+def test_hook_propagates_the_submission_exit_code(monkeypatch):
+    monkeypatch.setattr("mjlab_microduck.hf_jobs.submit", lambda argv: 3)
+    monkeypatch.setattr(sys, "argv", ["train", _TASK, "--hf-jobs"])
+    with pytest.raises(SystemExit) as exc:
+        train_hook.maybe_submit_to_hf_jobs()
+    assert exc.value.code == 3
+
+
+def test_no_flag_trains_locally(monkeypatch, fake_submit):
+    monkeypatch.setattr(sys, "argv", ["train", _TASK, "--env.scene.num-envs", "4096"])
+    assert train_hook.maybe_submit_to_hf_jobs() is None
+    assert fake_submit == []
+
+
+def test_other_commands_do_not_submit(monkeypatch, fake_submit):
+    """`play --hf-jobs` must reach play's parser, not submit a training job."""
+    monkeypatch.setattr(sys, "argv", ["/x/.venv/bin/play", _TASK, "--hf-jobs"])
+    assert train_hook.maybe_submit_to_hf_jobs() is None
+    assert fake_submit == []
+
+
+def test_interception_is_disarmed_inside_the_job(monkeypatch, fake_submit):
+    """Otherwise a leaked flag would make the job submit another job."""
+    monkeypatch.setenv("MICRODUCK_IN_HF_JOB", "1")
+    monkeypatch.setattr(sys, "argv", ["train", _TASK, "--hf-jobs"])
+    assert train_hook.maybe_submit_to_hf_jobs() is None
+    assert fake_submit == []
+
+
+def test_submitted_job_env_disarms_the_interception():
+    """The env var above is only useful if submit() actually sets it."""
+    src = (_ROOT / "src/mjlab_microduck/hf_jobs.py").read_text()
+    assert f'"{train_hook._IN_JOB_ENV}": "1"' in src, (
+        f"submit() must put {train_hook._IN_JOB_ENV} on the job's env"
+    )
+
+
+# The load-bearing assumption, exercised through the real import paths: both
+# `from mjlab.scripts.train import main` (mjlab's shim) and our own shim must
+# reach the hook before mjlab parses argv. In a subprocess, because it ends in
+# SystemExit inside an import.
+_PROBE = """
+import sys
+sys.argv = ["train", "{task}", "--env.scene.num-envs", "4096", "--hf-jobs"]
+
+import mjlab_microduck.hf_jobs as hf_jobs
+
+def fake_submit(argv):
+    print("SUBMIT", argv, flush=True)
+    return 7
+
+hf_jobs.submit = fake_submit
+
+try:
+    {trigger}
+except SystemExit as e:
+    print("EXIT", e.code, flush=True)
+    raise SystemExit(0)
+
+print("NOT-INTERCEPTED", flush=True)
+raise SystemExit(1)
+"""
+
+_SHIMS = {
+    # exactly what a bin/train written by mjlab does
+    "mjlab": "from mjlab.scripts.train import main",
+    # ... and what one written by this package does
+    "ours": "from mjlab_microduck.train_cli import main; main()",
+}
+
+
+@pytest.mark.parametrize("shim", sorted(_SHIMS))
+def test_both_train_shims_reach_the_hook_before_parsing_argv(shim):
+    proc = subprocess.run(
+        [sys.executable, "-c", _PROBE.format(task=_TASK, trigger=_SHIMS[shim])],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=900,
+        cwd=_ROOT,
+    )
+    assert "NOT-INTERCEPTED" not in proc.stdout, (
+        f"the {shim} `train` shim no longer reaches the --hf-jobs interception "
+        "(mjlab's plugin loading changed, or it now runs after argv is parsed).\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr[-2000:]}"
+    )
+    assert proc.returncode == 0, f"probe failed:\n{proc.stderr[-2000:]}"
+    assert f"SUBMIT ['{_TASK}', '--env.scene.num-envs', '4096']" in proc.stdout
+    assert "EXIT 7" in proc.stdout


### PR DESCRIPTION
Supersedes #19, which renamed the command. This keeps the CLI **exactly** as documented — `uv run train <task> ... --hf-jobs` — and fixes it instead.

## The bug

```
uv run train Mjlab-Velocity-Flat-MicroDuck --env.scene.num-envs 4096 --hf-jobs
→ Unrecognized options: --hf-jobs
```

`[project.scripts] train = "mjlab_microduck.train_cli:main"` was commented as "shadows mjlab's `train` entry point". It shadows nothing: mjlab 1.3.0 declares `train` too, both dist-info `RECORD`s claim `../../../bin/train`, and the distribution installed **last** writes the shim. mjlab wins in practice, so our wrapper — the only thing that knew about `--hf-jobs` — was never invoked. Nothing warns; `uv sync` succeeds and the flag silently disappears. (Confirmed live: a hand-patched `bin/train` was overwritten by mjlab's again on the next `uv sync`.)

## Fix — stop fighting over the script name

mjlab imports our package itself: `mjlab/__init__.py` calls `_import_registered_packages()` at module scope, which loads the `mjlab.tasks` entry point (`mjlab_microduck.tasks`). `bin/train` does `from mjlab.scripts.train import main`, so that import runs **before** mjlab's two-stage tyro parse ever sees argv. Intercepting there is immune to install order, because the path belongs to mjlab's own `train`.

- **new `train_hook.py`** — on `--hf-jobs`: submit, exit with the submission's status. Otherwise a no-op. Ignores non-`train` `argv[0]`, so `play --hf-jobs` still errors out as before, and is disarmed by `MICRODUCK_IN_HF_JOB`, which `submit()` now sets on the job's env so the job's own `uv run train` can only train locally.
- **`train_cli.py` keeps the `train` script alive**, but now does nothing except call mjlab's `main()`.

### Why `[project.scripts]` still declares `train`

Dropping it looks like the clean fix and is worse — I tried it, and it broke the command differently. Both RECORDs claim `bin/train`, so removing our declaration doesn't revert the name to mjlab: `uv sync` **uninstalls** the file (ours, per our RECORD) and nothing reinstalls mjlab's. `train` vanishes from the venv and `uv run train` falls through to PATH:

```
$ uv run train Mjlab-Velocity-Flat-MicroDuck --env.scene.num-envs 4096 --hf-jobs
can't open input file Mjlab-Velocity-Flat-MicroDuck
$ which -a train
/opt/homebrew/bin/train -> ../Cellar/liblinear/2.50/bin/train
```

So the collision stays and is made harmless instead: whichever distribution wins the race writes a behaviorally identical `bin/train`, and the flag is handled in exactly one place.

Side benefit: the interception exits during `import mjlab`, so submission no longer pays for the torch/tyro imports.

No user-visible change. Docs untouched apart from one line of the README repo map.

## Verification

Locally, through the real `uv run train` on this branch:

```
$ uv run train Mjlab-Velocity-Flat-MicroDuck --env.scene.num-envs 4096 --hf-jobs --help
usage: train --hf-jobs [-h] [--flavor FLAVOR] ... task
Submit a microduck training run to HF Jobs.

$ uv run --with pytest pytest tests/test_hf_jobs_flag.py -q
12 passed

$ uv run train Mjlab-Velocity-Flat-MicroDuck --env.scene.num-envs 4096 --hf-jobs
error: Invalid user token. …          # submit() reached HF auth: interception works
```

Also checked: `train --help` unchanged (mjlab's top-level help), and `list-envs` still lists 33 MicroDuck tasks, so the hook is invisible without the flag.

`tests/test_hf_jobs_flag.py` covers the hook's branches (flag / no flag / other command / inside-job), the exit-code path, the `MICRODUCK_IN_HF_JOB` contract between hook and `submit()`, `train` staying declared, our shim doing nothing but delegate, `train` on PATH being a mjlab trainer at all (that one fails loudly on the vanished-script breakage above), and the load-bearing assumption: subprocesses doing the real `from mjlab.scripts.train import main` **and** our own shim must both reach the hook before argv is parsed — so a future mjlab refactoring plugin loading fails the suite instead of silently dropping the flag.

`ruff check` / `format` clean on the new files.

Assisted-by: Claude:claude-opus-5