### PR TITLE
Add follow-me behavior demo (CPU MuJoCo, stock walking policy)

### DIFF
--- a/scripts/behavior_demos/follow_me/README.md
+++ b/scripts/behavior_demos/follow_me/README.md
@@ -1,0 +1,193 @@
+# follow-me — behavior demo
+
+A CPU MuJoCo demo in which the Microduck follows a walking leader's **actual
+path**, turning where the leader turned instead of cutting the corner.
+
+This is a **behavior layer over a stock exported walking policy**. It does not
+train, fine-tune, or replace a locomotion network: it only chooses the 3-DoF
+twist command `(vx, vy, wz)` written into the policy's existing command slots.
+
+> **Scope.** This is a simulation demo, not robot autonomy. The leader is a
+> scripted kinematic mocap body and its pose is read directly from the
+> simulator — there is no person detector, and this has not been validated on
+> hardware. See [Limitations](#limitations).
+
+## Run it
+
+Requires an exported walking policy (the 61D observation layout, e.g.
+`alpha_walking.onnx`). No policy is bundled; pass one explicitly:
+
+```bash
+# metrics only, no rendering
+uv run python scripts/behavior_demos/follow_me/run_follow_me.py \
+    --policy /path/to/alpha_walking.onnx --no-render
+
+# with frames + metrics
+uv run python scripts/behavior_demos/follow_me/run_follow_me.py \
+    --policy /path/to/alpha_walking.onnx \
+    --out /tmp/follow-me-frames --metrics /tmp/follow-me-metrics.json
+```
+
+Encode the frames with ffmpeg:
+
+```bash
+ffmpeg -framerate 50 -i /tmp/follow-me-frames/f%05d.png \
+    -c:v libx264 -crf 18 -pix_fmt yuv420p -movflags +faststart follow-me.mp4
+```
+
+## Following footsteps, not poses
+
+An earlier iteration selected the duck's command from the leader's **current**
+pose. When the leader began turning, the duck turned immediately from its own
+coordinates and cut across the inside of the corner instead of arriving at it.
+
+This version follows a queue of world-space footsteps. At 50 Hz the behavior
+records the leader's accumulated path in world coordinates, and the duck
+pursues the interpolated point the leader walked `0.65 m` of **path length**
+earlier:
+
+```text
+leader position → append world-space sample → subtract 0.65 m of path length
+                                               ↓
+                                  queued footprint + stored motion phase
+                                               ↓
+                                      stock walking policy command
+```
+
+Because the gap is a path length rather than a time delay, a corner stays in
+the queue: the duck keeps walking straight and turns at the recorded corner,
+a measured **5.44 s delayed turn** rather than an immediate mirrored one.
+
+## True opposite turns
+
+Two directional errors were corrected while building this demo:
+
+1. the phase labelled `LEFT TURN` used negative world yaw, so it was physically
+   a right-hand curve;
+2. the later `RIGHT` phase was a diagonal strafe, not an opposite turn.
+
+The route now uses conventional actor-relative directions. Facing `+X`, a left
+turn increases world yaw by `+90°`; the later right turn decreases it by `−90°`
+and returns the leader to its original heading. `test_turns_are_genuinely_opposite`
+locks this in.
+
+## Route
+
+| Phase | Time | Description |
+|---|---:|---|
+| READY | `0–2 s` | both stand |
+| FORWARD | `2–7 s` | straight approach |
+| LEFT TURN | `7–15 s` | a genuine `+90°` left arc |
+| STOP | `15–18 s` | both stop; the path queue freezes |
+| RIGHT TURN | `18–35 s` | a genuine `−90°` right arc, then a straight exit |
+| BACKWARD | `35–41 s` | both reverse |
+| DONE | `41–44 s` | stable final stand |
+
+Both turns occur at the same queued locations after the leader:
+
+| Turn | Leader starts | Duck starts | Spatial delay | Leader yaw Δ | Duck yaw Δ |
+|---|---:|---:|---:|---:|---:|
+| Left | `7.00 s` | `12.44 s` | `5.44 s` | `+90.0°` | `+86.4°` |
+| Right | `18.00 s` | `23.44 s` | `5.44 s` | `−90.0°` | `−84.0°` |
+
+The signs are measured from the simulated trunk orientation, not inferred from
+labels or camera projection.
+
+## Controller detail
+
+The stock walking policy has strongly **asymmetric turning authority** — a
+single mirrored command does not produce mirrored body motion. The controller
+therefore closes the loop on the delayed footprint yaw using separately
+measured limits:
+
+- positive-yaw / left correction: `wz = +0.60 … +1.00`
+- negative-yaw / right correction: `wz = −0.18 … −0.32`
+- deadband: `3°`
+- forward command during turns: `vx = +0.24`
+
+The policy has a sharp gait-onset threshold, so tiny continuous velocity
+corrections are counterproductive; inside the deadband the command is exactly
+zero. Actions use the shipped `0.9` action scale.
+
+The angular-velocity sensor is resolved **by name** (`imu_ang_vel` and
+aliases). Silently reading the last sensor by index picked up a different
+quantity during development and produced unstable, falsely-good results, so it
+is rejected explicitly.
+
+**Reverse is a deliberate safety exception.** When the leader backs toward the
+follower, the duck backs away immediately instead of waiting for the leader's
+reverse footprint to arrive, so the leader cannot walk into it. This makes the
+queued-footprint error grow during the final reverse — that is expected, and
+`test_reverse_is_immediate_and_overrides_the_queue` pins the behavior.
+Cornering and lateral motion still come exclusively from the recorded trail.
+
+## Gaze and camera
+
+Gaze and camera stabilization run entirely in a **separate rendering `MjData`**
+copied from the physical state each step. They never feed back into the walking
+dynamics — the physical locomotion state stays authoritative.
+
+Person visibility in the picture-in-picture view is computed **geometrically**
+(frustum test plus an occlusion ray against the known mocap pose), not from
+image content.
+
+## Measured validation
+
+A 44 s / 2,200-step rollout with the stock walking policy:
+
+- both leader turns have opposite signed `+90.0° / −90.0°` yaw changes;
+- both duck turns have opposite signed `+86.4° / −84.0°` changes;
+- both delayed turn starts occur `5.44 s` after the leader, at the queued
+  footprint;
+- all seven phases complete over `44.0 s` / `2,200` control steps;
+- `fallen_steps = 0`, minimum trunk height `0.114 m`, final height `0.116 m`;
+- leader range mean `0.857 m` (`0.519–1.363 m`);
+- leader visible in the stabilized view for `2,200 / 2,200` steps.
+
+`run_follow_me.py` writes all of these to the `--metrics` JSON so any run can be
+re-checked.
+
+## Tests
+
+`tests/test_follow_me_demo.py` covers the choreography, the world-space trail,
+the asymmetric controller, the reverse exception, and the scene/model
+invariants. Everything runs on CPU and **needs no policy file, GPU, or
+renderer**:
+
+```bash
+uv run --with pytest pytest tests/test_follow_me_demo.py
+```
+
+## Files
+
+- `scene_follow_me.xml` — the official `robot_walk.xml` collision model plus the
+  animated leader, footprint marker and stabilized camera rig.
+- `follow_motion.py` — leader route, world-space trail, asymmetric turn
+  controller. Free of MuJoCo/ONNX imports so it is unit-testable.
+- `camera_tracking.py` — isolated gaze and geometric visibility measurement.
+- `video_overlay.py` — HUD, picture-in-picture and timeline (rendering only).
+- `run_follow_me.py` — ONNX rollout and metrics.
+
+### Scene asset resolution
+
+`scene_follow_me.xml` lives outside the robot directory, so it restates
+`<compiler meshdir=...>` pointing back at the robot assets. That tag **must stay
+after** the `<include>`: MuJoCo resolves `meshdir` against the top-level file
+and applies the *last* `<compiler>` it parses. Placing it before the include
+lets the robot's own `meshdir` win and the meshes fail to load.
+`test_demo_scene_compiles_and_matches_the_reference_walk_model` compares the
+compiled model against `scene_walk.xml` so a silent unit or asset change is
+caught.
+
+## Limitations
+
+- **The leader is scripted.** It follows a fixed semantic choreography and its
+  pose is read from the simulator. There is no person detector, no tracking
+  from images, and no real perception of any kind.
+- **Simulation only.** No hardware validation; the numbers above are from
+  MuJoCo, not from a real robot.
+- **Gaze is isolated render state.** It exists to make the picture-in-picture
+  watchable and never influences locomotion.
+- **The policy is unmodified.** All following behavior comes from command-slot
+  steering of a stock walking policy, so its turning authority — including the
+  left/right asymmetry compensated above — is a fixed constraint here.

--- a/scripts/behavior_demos/follow_me/camera_tracking.py
+++ b/scripts/behavior_demos/follow_me/camera_tracking.py
@@ -1,0 +1,208 @@
+"""Isolated head-camera gaze and person-visibility measurement.
+
+Everything in this module runs in a SEPARATE ``MjData`` (``gaze_data``) that is
+copied from the physical state each step. The gaze angles written here are
+never fed back into the walking policy, the actuators, or the physical
+``MjData``: the locomotion state stays authoritative and the demo cannot
+accidentally "improve" its own walking through the camera loop.
+
+The stabilized camera exists so the picture-in-picture view is watchable. It is
+NOT a perception system: person visibility is computed geometrically from the
+known mocap position of the scripted leader (frustum test + occlusion ray),
+not from image content. There is no person detector here.
+"""
+
+from __future__ import annotations
+
+import math
+
+import mujoco
+import numpy as np
+
+# Head servo indices in the 14-actuator layout (see AGENTS.md "Joint layout":
+# 5-8 are neck_pitch, head_pitch, head_yaw, head_roll).
+HEAD_PITCH_ACT = 6
+HEAD_YAW_ACT = 7
+HEAD_ROLL_ACT = 8
+
+# Keep the gaze off the mechanical stops so the rendered view never jams.
+YAW_MARGIN_RAD = math.radians(3.0)
+PITCH_MARGIN_RAD = math.radians(5.0)
+
+# Occlusion ray budget: enough to walk out of the robot's own geometry.
+MAX_RAY_BOUNCES = 10
+
+
+class HeadCameraTracker:
+    """Aim a rendering-only head pose at the leader without altering locomotion."""
+
+    def __init__(self, model, data, qpos_idx, trunk_id, pip_size=(225, 165)):
+        self.model = model
+        self.gaze_data = mujoco.MjData(model)
+        self.qpos_idx = qpos_idx
+        self.trunk_id = trunk_id
+        self.pip_w, self.pip_h = pip_size
+        self.head_pitch_joint = int(model.actuator_trnid[HEAD_PITCH_ACT, 0])
+        self.head_yaw_joint = int(model.actuator_trnid[HEAD_YAW_ACT, 0])
+        self.head_cam = mujoco.mj_name2id(
+            model, mujoco.mjtObj.mjOBJ_CAMERA, "head_camera")
+        self.follow_cam = mujoco.mj_name2id(
+            model, mujoco.mjtObj.mjOBJ_CAMERA, "follow_camera")
+        if self.head_cam < 0 or self.follow_cam < 0:
+            raise RuntimeError(
+                "scene must define both 'head_camera' (robot) and "
+                "'follow_camera' (stabilized rig)")
+        follow_rig = mujoco.mj_name2id(
+            model, mujoco.mjtObj.mjOBJ_BODY, "follow_camera_rig")
+        self.follow_mocap = int(model.body_mocapid[follow_rig])
+        self.person_id = mujoco.mj_name2id(
+            model, mujoco.mjtObj.mjOBJ_BODY, "person")
+        self.person_mocap = int(model.body_mocapid[self.person_id])
+
+        # Rotate the robot's head camera into a conventional optical frame:
+        # MuJoCo cameras look along -Z. This touches cam_quat only, which has
+        # no effect on dynamics.
+        model.cam_quat[self.head_cam] = np.array(
+            [math.sqrt(0.5), 0.0, 0.0, -math.sqrt(0.5)], dtype=np.float64)
+        mujoco.mj_forward(model, data)
+
+        self.gaze_pitch = float(data.qpos[qpos_idx[HEAD_PITCH_ACT]])
+        self.gaze_yaw = float(data.qpos[qpos_idx[HEAD_YAW_ACT]])
+        vertical_half = math.radians(float(model.cam_fovy[self.follow_cam])) * 0.5
+        self.tan_v = math.tan(vertical_half)
+        self.tan_h = (self.pip_w / self.pip_h) * self.tan_v
+        self.person_bodies = self._descendants(self.person_id)
+        self.self_bodies = self._descendants(trunk_id)
+        self.self_bodies.add(trunk_id)
+        self.lost_steps = 0
+        self.max_off_axis = 0.0
+        self.off_axis_sq_sum = 0.0
+        self.samples = 0
+        self.visible = False
+        self.off_axis = 0.0
+
+    def _descendants(self, root):
+        bodies = {root}
+        for body in range(self.model.nbody):
+            parent = body
+            while parent > 0:
+                if parent == root:
+                    bodies.add(body)
+                    break
+                parent = int(self.model.body_parentid[parent])
+        return bodies
+
+    def _pose_gaze_data(self, data):
+        """Copy physical state, then overwrite ONLY the head angles."""
+        mujoco.mj_copyData(self.gaze_data, self.model, data)
+        self.gaze_data.qpos[self.qpos_idx[HEAD_PITCH_ACT]] = self.gaze_pitch
+        self.gaze_data.qpos[self.qpos_idx[HEAD_YAW_ACT]] = self.gaze_yaw
+        # Keep the rendered optical horizon level: the walking policy's head
+        # roll is a balance output, not a gaze request.
+        self.gaze_data.qpos[self.qpos_idx[HEAD_ROLL_ACT]] = 0.0
+        mujoco.mj_forward(self.model, self.gaze_data)
+
+    def _stabilize_camera(self, target):
+        """Use the physical camera POSITION with an electronically level view."""
+        eye = self.gaze_data.cam_xpos[self.head_cam].copy()
+        forward = target - eye
+        forward /= max(float(np.linalg.norm(forward)), 1e-9)
+        world_up = np.array([0.0, 0.0, 1.0])
+        right = np.cross(forward, world_up)
+        if np.linalg.norm(right) < 1e-6:
+            right = np.array([1.0, 0.0, 0.0])
+        right /= np.linalg.norm(right)
+        up = np.cross(right, forward)
+        up /= np.linalg.norm(up)
+        rotation = np.column_stack((right, up, -forward))
+        quaternion = np.empty(4, dtype=np.float64)
+        mujoco.mju_mat2Quat(quaternion, rotation.ravel())
+        self.gaze_data.mocap_pos[self.follow_mocap] = eye
+        self.gaze_data.mocap_quat[self.follow_mocap] = quaternion
+        mujoco.mj_forward(self.model, self.gaze_data)
+
+    def update(self, data):
+        self._pose_gaze_data(data)
+        cam_rot = self.gaze_data.cam_xmat[self.head_cam].reshape(3, 3)
+        forward = -cam_rot[:, 2]
+        left = -cam_rot[:, 0]
+        up = cam_rot[:, 1]
+        target = self.gaze_data.mocap_pos[self.person_mocap].copy()
+        target[2] += 0.02
+        to_person = target - self.gaze_data.cam_xpos[self.head_cam]
+        unit = to_person / max(float(np.linalg.norm(to_person)), 1e-9)
+        bearing = math.atan2(float(np.dot(unit, left)), float(np.dot(unit, forward)))
+        elevation = math.atan2(float(np.dot(unit, up)), float(np.dot(unit, forward)))
+
+        yaw_lo, yaw_hi = self.model.jnt_range[self.head_yaw_joint]
+        pitch_lo, pitch_hi = self.model.jnt_range[self.head_pitch_joint]
+        self.gaze_yaw = float(np.clip(
+            self.gaze_yaw + bearing, yaw_lo + YAW_MARGIN_RAD, yaw_hi - YAW_MARGIN_RAD))
+        # Positive physical pitch points the camera down.
+        self.gaze_pitch = float(np.clip(
+            self.gaze_pitch - elevation,
+            pitch_lo + PITCH_MARGIN_RAD, pitch_hi - PITCH_MARGIN_RAD))
+        self._pose_gaze_data(data)
+        self._stabilize_camera(target)
+
+        eye = self.gaze_data.cam_xpos[self.follow_cam].copy()
+        cam_rot = self.gaze_data.cam_xmat[self.follow_cam].reshape(3, 3)
+        right = cam_rot[:, 0]
+        up = cam_rot[:, 1]
+        forward = -cam_rot[:, 2]
+        to_person = target - eye
+        distance = float(np.linalg.norm(to_person))
+        unit = to_person / max(distance, 1e-9)
+        depth = float(np.dot(to_person, forward))
+        image_x = float(np.dot(to_person, right))
+        image_y = float(np.dot(to_person, up))
+        in_fov = (depth > 0.0
+                  and abs(image_x) <= depth * self.tan_h
+                  and abs(image_y) <= depth * self.tan_v)
+        self.off_axis = math.acos(float(np.clip(np.dot(unit, forward), -1.0, 1.0)))
+        occluded = self._occluded(eye, unit, distance) if in_fov else False
+        self.visible = in_fov and not occluded
+
+        self.samples += 1
+        self.max_off_axis = max(self.max_off_axis, self.off_axis)
+        self.off_axis_sq_sum += self.off_axis * self.off_axis
+        if not self.visible:
+            self.lost_steps += 1
+        return {
+            "visible": self.visible,
+            "off_axis": self.off_axis,
+            "gaze_yaw": self.gaze_yaw,
+            "gaze_pitch": self.gaze_pitch,
+        }
+
+    def _occluded(self, eye, direction, target_distance):
+        """Ray-march to the leader, stepping through the robot's own geometry."""
+        travelled = 0.02
+        geom_id = np.zeros(1, dtype=np.int32)
+        for _ in range(MAX_RAY_BOUNCES):
+            origin = eye + direction * travelled
+            hit = mujoco.mj_ray(
+                self.model, self.gaze_data, origin, direction,
+                None, 1, -1, geom_id)
+            if geom_id[0] < 0 or hit < 0.0:
+                return False
+            body = int(self.model.geom_bodyid[int(geom_id[0])])
+            if body in self.person_bodies:
+                return False
+            if body in self.self_bodies:
+                travelled += hit + 0.005
+                if travelled >= target_distance:
+                    return False
+                continue
+            return travelled + hit < target_distance - 0.02
+        return False
+
+    @property
+    def camera_id(self):
+        return self.follow_cam
+
+    @property
+    def rms_off_axis(self):
+        if not self.samples:
+            return 0.0
+        return math.sqrt(self.off_axis_sq_sum / self.samples)

--- a/scripts/behavior_demos/follow_me/follow_motion.py
+++ b/scripts/behavior_demos/follow_me/follow_motion.py
@@ -1,0 +1,327 @@
+"""Leader choreography, world-space footprint trail and the follow controller.
+
+This module is deliberately free of MuJoCo and ONNX imports below the
+``animate_person`` helper so the behavior logic can be unit-tested on CPU
+without a model or a policy file (see ``tests/test_follow_me_demo.py``).
+
+The behavior is a thin layer ON TOP of the stock ``alpha_walking`` policy: it
+only chooses the 3-DoF twist command ``(vx, vy, wz)`` that is written into the
+policy's command slots. No locomotion network is trained, replaced or filtered
+here.
+"""
+
+from __future__ import annotations
+
+import math
+from bisect import bisect_right
+from dataclasses import dataclass
+
+import numpy as np
+
+# Spatial gap between the leader and the queued footprint the duck pursues.
+# This is a PATH LENGTH in metres, not a time delay: the duck walks to the
+# place the leader stood 0.65 m of walking ago, so corners stay in the queue.
+TRAIL_DISTANCE = 0.65
+
+# Policies are trained and deployed at 50 Hz.
+CTRL_HZ = 50.0
+CMD_TAU = 1.0 / CTRL_HZ
+
+# Leader route timing (seconds). The phase boundaries are shared with the HUD
+# timeline so the video and the metrics cannot drift apart.
+READY_END = 2.0
+FORWARD_END = 7.0
+LEFT_TURN_END = 15.0
+STOP_END = 18.0
+RIGHT_ARC_END = 26.0
+RIGHT_EXIT_END = 35.0
+BACKWARD_END = 41.0
+DEMO_SECONDS = 44.0
+
+# Leader speeds (m/s) and turn geometry.
+FORWARD_SPEED = 0.055
+TURN_SPEED = 0.120
+TURN_DURATION = 8.0
+EXIT_SPEED = 0.080
+BACK_SPEED = 0.080
+
+# Measured asymmetric turning authority of the stock walking policy. A single
+# mirrored command does NOT produce mirrored body motion, so left and right
+# corrections use separately measured magnitude bands.
+YAW_DEADBAND_RAD = math.radians(3.0)
+LEFT_WZ_MIN, LEFT_WZ_MAX = 0.60, 1.00
+RIGHT_WZ_MIN, RIGHT_WZ_MAX = 0.18, 0.32
+YAW_GAIN = 1.25
+TURN_VX = 0.24
+
+# The stock policy has a sharp gait-onset threshold, so tiny continuous
+# velocity corrections are counterproductive: phases command discrete speeds.
+FORWARD_CMD = (0.24, 0.0, 0.0)
+BACKWARD_CMD = (-0.32, 0.0, 0.20)
+IDLE_CMD = (0.0, 0.0, 0.0)
+
+TURN_PHASES = ("LEFT TURN", "RIGHT TURN")
+
+
+@dataclass(frozen=True)
+class PersonState:
+    """Scripted leader pose at one instant."""
+
+    phase: str
+    pos: np.ndarray
+    yaw: float
+    velocity: np.ndarray
+    yaw_rate: float
+    moving: bool
+    progress: float
+
+
+@dataclass(frozen=True)
+class TrailState:
+    """A point recovered from the leader's recorded world-space path."""
+
+    phase: str
+    pos: np.ndarray
+    yaw: float
+    path_s: float
+    leader_path_s: float
+    moving: bool
+
+
+def wrap(angle: float) -> float:
+    """Wrap an angle to the half-open interval [-pi, pi)."""
+    return (angle + math.pi) % (2.0 * math.pi) - math.pi
+
+
+def _forward(yaw: float) -> np.ndarray:
+    return np.array([math.cos(yaw), math.sin(yaw)], dtype=np.float64)
+
+
+def person_trajectory(t: float) -> PersonState:
+    """Script a true left arc followed by a true right arc.
+
+    With the actor initially facing +X, positive world yaw is its LEFT turn and
+    negative world yaw is its RIGHT turn. The two curves therefore have
+    opposite signed angular velocities and trace an S-shaped route, rather than
+    two same-signed curves that merely look different on camera.
+    """
+    start = np.array([0.65, 0.0], dtype=np.float64)
+
+    if t < READY_END:
+        return PersonState("READY", start, 0.0, np.zeros(2), 0.0, False,
+                           t / READY_END)
+    if t < FORWARD_END:
+        u = t - READY_END
+        pos = start + np.array([FORWARD_SPEED * u, 0.0])
+        return PersonState("FORWARD", pos, 0.0,
+                           np.array([FORWARD_SPEED, 0.0]), 0.0, True,
+                           u / (FORWARD_END - READY_END))
+
+    left_start = start + np.array([FORWARD_SPEED * (FORWARD_END - READY_END), 0.0])
+    omega_left = (math.pi / 2.0) / TURN_DURATION
+    radius = TURN_SPEED / omega_left
+    if t < LEFT_TURN_END:
+        u = t - FORWARD_END
+        yaw = omega_left * u
+        pos = left_start + np.array([
+            radius * math.sin(yaw),
+            radius * (1.0 - math.cos(yaw)),
+        ])
+        return PersonState("LEFT TURN", pos, yaw, TURN_SPEED * _forward(yaw),
+                           omega_left, True, u / TURN_DURATION)
+
+    left_end = left_start + np.array([radius, radius])
+    left_yaw = math.pi / 2.0
+    if t < STOP_END:
+        return PersonState("STOP", left_end, left_yaw, np.zeros(2), 0.0, False,
+                           (t - LEFT_TURN_END) / (STOP_END - LEFT_TURN_END))
+
+    # Turn right from +Y back to +X: the opposite signed curvature.
+    omega_right = -(math.pi / 2.0) / TURN_DURATION
+    if t < RIGHT_ARC_END:
+        u = t - STOP_END
+        yaw = left_yaw + omega_right * u
+        pos = left_end + np.array([
+            (TURN_SPEED / omega_right) * (math.sin(yaw) - 1.0),
+            -(TURN_SPEED / omega_right) * math.cos(yaw),
+        ])
+        return PersonState("RIGHT TURN", pos, yaw, TURN_SPEED * _forward(yaw),
+                           omega_right, True, u / TURN_DURATION)
+
+    right_end = left_end + np.array([radius, radius])
+    if t < RIGHT_EXIT_END:
+        # Straight exit: gives the delayed duck room to finish the same curve.
+        u = t - RIGHT_ARC_END
+        velocity = np.array([EXIT_SPEED, 0.0])
+        return PersonState("RIGHT TURN", right_end + velocity * u, 0.0,
+                           velocity, 0.0, True,
+                           (TURN_DURATION + u) / (RIGHT_EXIT_END - STOP_END))
+
+    exit_end = right_end + np.array([EXIT_SPEED * (RIGHT_EXIT_END - RIGHT_ARC_END), 0.0])
+    if t < BACKWARD_END:
+        u = t - RIGHT_EXIT_END
+        velocity = np.array([-BACK_SPEED, 0.0])
+        return PersonState("BACKWARD", exit_end + velocity * u, 0.0, velocity,
+                           0.0, True, u / (BACKWARD_END - RIGHT_EXIT_END))
+
+    back_end = exit_end + np.array([-BACK_SPEED * (BACKWARD_END - RIGHT_EXIT_END), 0.0])
+    return PersonState("DONE", back_end, 0.0, np.zeros(2), 0.0, False,
+                       min((t - BACKWARD_END) / (DEMO_SECONDS - BACKWARD_END), 1.0))
+
+
+class FootstepTrail:
+    """Return the world-space point the leader walked ``gap`` metres earlier.
+
+    This is the core of the behavior. An earlier iteration selected the duck's
+    command from the leader's CURRENT pose; when the leader began turning, the
+    duck turned immediately from its own coordinates and cut across the inside
+    of the corner instead of arriving at it.
+
+    Here the leader's accumulated path is recorded in world coordinates at
+    50 Hz and the duck pursues the interpolated point one ``gap`` of PATH
+    LENGTH behind. A corner therefore stays in the queue: the duck keeps
+    walking straight and turns where the leader actually turned.
+    """
+
+    def __init__(self, initial: PersonState, gap: float = TRAIL_DISTANCE):
+        self.gap = gap
+        self.path_s = 0.0
+        self.previous_pos = initial.pos.copy()
+        # Seed with a virtual sample one gap BEHIND the leader's start so the
+        # queue is well-defined before any distance has accumulated.
+        virtual_start = initial.pos - gap * _forward(initial.yaw)
+        self.distances = [-gap, 0.0]
+        self.samples = [
+            TrailState("FORWARD", virtual_start, initial.yaw, -gap, 0.0, False),
+            TrailState("FORWARD", initial.pos.copy(), initial.yaw, 0.0, 0.0, False),
+        ]
+
+    def update(self, leader: PersonState) -> TrailState:
+        delta = float(np.linalg.norm(leader.pos - self.previous_pos))
+        if delta > 1e-8:
+            # Only real displacement advances the queue, so a stopped leader
+            # freezes it rather than filling it with duplicate samples.
+            self.path_s += delta
+            self.distances.append(self.path_s)
+            self.samples.append(TrailState(
+                leader.phase, leader.pos.copy(), leader.yaw,
+                self.path_s, self.path_s, leader.moving))
+        self.previous_pos = leader.pos.copy()
+
+        target_s = self.path_s - self.gap
+        upper = min(max(bisect_right(self.distances, target_s), 1),
+                    len(self.distances) - 1)
+        lower = upper - 1
+        a, b = self.samples[lower], self.samples[upper]
+        span = self.distances[upper] - self.distances[lower]
+        fraction = 0.0 if span <= 1e-10 else (
+            target_s - self.distances[lower]) / span
+        pos = a.pos + fraction * (b.pos - a.pos)
+        yaw = wrap(a.yaw + fraction * wrap(b.yaw - a.yaw))
+        return TrailState(
+            phase=b.phase,
+            pos=pos,
+            yaw=yaw,
+            path_s=target_s,
+            leader_path_s=self.path_s,
+            moving=leader.moving,
+        )
+
+
+class FollowController:
+    """Replay the motion stored at the delayed world-space trail point."""
+
+    def __init__(self, hz: float = CTRL_HZ):
+        self.dt = 1.0 / hz
+        self.command = np.zeros(3, dtype=np.float32)
+
+    @staticmethod
+    def turn_rate(yaw_error: float) -> float:
+        """Measured asymmetric yaw command for a heading error, in rad/s.
+
+        The stock policy's positive-yaw (left) authority is much weaker than
+        its negative-yaw (right) authority, so the two directions get separate
+        measured magnitude bands. Inside the deadband the command is exactly
+        zero: small continuous corrections sit below the policy's gait-onset
+        threshold and only produce shuffling.
+        """
+        if abs(yaw_error) < YAW_DEADBAND_RAD:
+            return 0.0
+        if yaw_error > 0.0:
+            magnitude = min(LEFT_WZ_MAX, max(LEFT_WZ_MIN, YAW_GAIN * yaw_error))
+        else:
+            magnitude = min(RIGHT_WZ_MAX, max(RIGHT_WZ_MIN, YAW_GAIN * -yaw_error))
+        return math.copysign(magnitude, yaw_error)
+
+    @staticmethod
+    def replay_phase(leader: PersonState, trail: TrailState) -> str:
+        """Phase the duck replays: the queued one, except when reversing.
+
+        Reversal is the single safety exception to trail following. If the duck
+        waited for the leader's reverse footprint to arrive, the leader would
+        walk into it; so the duck backs off immediately. Turning and lateral
+        motion still come exclusively from the recorded world-space trail.
+        """
+        return "BACKWARD" if leader.phase == "BACKWARD" else trail.phase
+
+    def update(self, leader: PersonState, trail: TrailState,
+               duck_pos: np.ndarray, duck_yaw: float) -> tuple[np.ndarray, dict]:
+        error_world = trail.pos - np.asarray(duck_pos[:2], dtype=np.float64)
+        yaw_error = wrap(trail.yaw - duck_yaw)
+        replay = self.replay_phase(leader, trail)
+
+        if not leader.moving:
+            raw_command = IDLE_CMD
+        elif replay in TURN_PHASES:
+            # Close the loop on the measured trunk world yaw so each turn uses
+            # the empirically verified sign and stops at its target heading
+            # instead of inheriting the previous one.
+            raw_command = (TURN_VX, 0.0, self.turn_rate(yaw_error))
+        elif replay == "FORWARD":
+            raw_command = FORWARD_CMD
+        elif replay == "BACKWARD":
+            raw_command = BACKWARD_CMD
+        else:
+            raw_command = IDLE_CMD
+
+        target_cmd = np.array(raw_command, dtype=np.float32)
+        alpha = min(1.0, self.dt / CMD_TAU)
+        self.command += alpha * (target_cmd - self.command)
+        metrics = {
+            "target_pos": trail.pos,
+            "error_world": error_world,
+            "error": float(np.linalg.norm(error_world)),
+            "yaw_error": yaw_error,
+            "target_cmd": target_cmd,
+            "trail_phase": trail.phase,
+            "replay_phase": replay,
+            "trail_path_s": trail.path_s,
+            "leader_path_s": trail.leader_path_s,
+            "spatial_lag": trail.leader_path_s - trail.path_s,
+        }
+        return self.command.copy(), metrics
+
+
+def animate_person(model, data, person: PersonState, t: float) -> None:
+    """Apply the leader root pose and a speed-dependent opposing limb cycle."""
+    body_id = model.body("person").id
+    mocap_id = int(model.body_mocapid[body_id])
+    data.mocap_pos[mocap_id, :2] = person.pos
+    data.mocap_pos[mocap_id, 2] = 0.36 + (
+        0.006 * abs(math.sin(2 * math.pi * t * 1.3)) if person.moving else 0.0)
+    data.mocap_quat[mocap_id] = np.array([
+        math.cos(person.yaw / 2.0), 0.0, 0.0, math.sin(person.yaw / 2.0)
+    ])
+
+    amplitude = math.radians(24.0) if person.moving else 0.0
+    stride = amplitude * math.sin(2.0 * math.pi * 1.3 * t)
+    values = {
+        "person_hip_l": stride,
+        "person_hip_r": -stride,
+        "person_shoulder_l": -0.65 * stride,
+        "person_shoulder_r": 0.65 * stride,
+    }
+    for name, value in values.items():
+        joint_id = model.joint(name).id
+        data.qpos[int(model.jnt_qposadr[joint_id])] = value
+        data.qvel[int(model.jnt_dofadr[joint_id])] = 0.0

--- a/scripts/behavior_demos/follow_me/run_follow_me.py
+++ b/scripts/behavior_demos/follow_me/run_follow_me.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Follow-me behavior demo: queued-footstep following with true opposite turns.
+
+A CPU MuJoCo demo showing that a stock exported walking policy can be steered
+to follow a moving target's ACTUAL PATH — turning where the leader turned,
+rather than cutting the corner — using only the 3-DoF twist command slots. No
+network is trained or modified here.
+
+This is a SIMULATION demo, not robot autonomy: the leader is a scripted
+kinematic mocap body and its position is read directly from the simulator.
+There is no person detector and this has not been validated on hardware.
+
+Usage (from the repository root):
+
+    uv run python scripts/behavior_demos/follow_me/run_follow_me.py \\
+        --policy /path/to/alpha_walking.onnx --no-render
+
+Add ``--out DIR`` to write PNG frames, then encode them with ffmpeg:
+
+    ffmpeg -framerate 50 -i DIR/f%05d.png -c:v libx264 -crf 18 \\
+        -pix_fmt yuv420p -movflags +faststart follow-me.mp4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import onnxruntime as ort
+from camera_tracking import HeadCameraTracker
+from follow_motion import (
+    CTRL_HZ,
+    DEMO_SECONDS,
+    TRAIL_DISTANCE,
+    FollowController,
+    FootstepTrail,
+    animate_person,
+    person_trajectory,
+    wrap,
+)
+
+# Sibling modules (camera_tracking, follow_motion, video_overlay) are imported
+# directly: Python puts this script's own directory on sys.path when it is run
+# as a script, and the tests add it explicitly.
+
+DEFAULT_SCENE = Path(__file__).resolve().parent / "scene_follow_me.xml"
+
+# Pose the walking policy's actions are offsets from, and that joint
+# observations are measured relative to. Must match DEFAULT_POSE in
+# scripts/infer_policy.py and the STAND keyframe in the scene.
+DEFAULT_POSE = np.array([
+    0.0, -0.0873, -0.4579, -0.0049, 0.4530,
+    0.3491, 0.3491, 0.0, 0.0,
+    0.0, 0.0873, 0.4579, 0.0049, -0.4530,
+], dtype=np.float32)
+
+# Shipped walking action scale. 1.0 crosses the measured stability boundary on
+# long forward legs.
+ACTION_SCALE = 0.9
+
+# Trunk height below which a step counts as fallen.
+FALLEN_Z = 0.09
+
+EXPECTED_ACTUATORS = 14
+EXPECTED_COMMAND_DIM = 13
+
+# The angular-velocity sensor is resolved BY NAME. Reading the last sensor by
+# index silently picked up a different sensor during development and produced
+# unstable, falsely-good results.
+GYRO_SENSOR_NAMES = ("imu_gyro", "gyro", "imu_ang_vel", "angular-velocity")
+
+
+def yaw_of_body(data, body_id):
+    """World yaw of a body, taken from its rotation matrix's forward axis."""
+    forward = data.xmat[body_id].reshape(3, 3)[:, 0]
+    return math.atan2(float(forward[1]), float(forward[0]))
+
+
+def resolve_gyro_adr(model):
+    for sensor_name in GYRO_SENSOR_NAMES:
+        sensor_id = mujoco.mj_name2id(
+            model, mujoco.mjtObj.mjOBJ_SENSOR, sensor_name)
+        if sensor_id >= 0:
+            return int(model.sensor_adr[sensor_id])
+    raise RuntimeError(
+        "no angular-velocity sensor found; expected one of "
+        f"{GYRO_SENSOR_NAMES}")
+
+
+def make_observation(data, qpos_idx, qvel_idx, trunk_id, gyro_adr,
+                     last_action, command, command_dim):
+    """Build the 61D actor observation: 48 proprioception + 13 command."""
+    quat = data.xquat[trunk_id].astype(np.float32)
+    w, xyz = quat[0], quat[1:4]
+    gravity_world = np.array([0.0, 0.0, -1.0], dtype=np.float32)
+    cross = np.cross(xyz, gravity_world) * 2.0
+    gravity = gravity_world - w * cross + np.cross(xyz, cross)
+    gyro = data.sensordata[gyro_adr:gyro_adr + 3].astype(np.float32)
+    joint_pos = data.qpos[qpos_idx].astype(np.float32) - DEFAULT_POSE
+    joint_vel = data.qvel[qvel_idx].astype(np.float32)
+    # Only the twist slots are driven; head_pose and body_pose stay zeroed, as
+    # the walking policy family requires the full command block to be present.
+    policy_command = np.zeros(command_dim, dtype=np.float32)
+    policy_command[:3] = command
+    return np.concatenate([
+        gyro, gravity, joint_pos, joint_vel, last_action, policy_command
+    ]).astype(np.float32)
+
+
+def phase_summary(records):
+    result = {}
+    for phase in sorted({r["phase"] for r in records}):
+        rows = [r for r in records if r["phase"] == phase]
+        result[phase] = {
+            "samples": len(rows),
+            "follow_rmse_m": math.sqrt(
+                sum(r["follow_error_m"] ** 2 for r in rows) / len(rows)),
+            "follow_max_m": max(r["follow_error_m"] for r in rows),
+            "person_range_mean_m": sum(r["person_range_m"] for r in rows) / len(rows),
+            "person_range_min_m": min(r["person_range_m"] for r in rows),
+            "person_range_max_m": max(r["person_range_m"] for r in rows),
+            "min_trunk_z_m": min(r["trunk_z_m"] for r in rows),
+            "camera_visible_pct": 100.0 * sum(r["visible"] for r in rows) / len(rows),
+        }
+    return result
+
+
+def turn_yaw_delta(records, phase):
+    """Signed yaw change measured on the trunk during a duck command phase."""
+    rows = [r for r in records if r["command_phase"] == phase]
+    if not rows:
+        return float("nan")
+    return rows[-1]["duck_yaw_deg"] - rows[0]["duck_yaw_deg"]
+
+
+def build_summary(records, args, total_steps, frames, tracker,
+                  leader_phase_times, command_phase_times):
+    errors = [r["follow_error_m"] for r in records]
+    return {
+        "duration_s": args.seconds,
+        "control_steps": total_steps,
+        "frames": frames,
+        "trail_distance_m": TRAIL_DISTANCE,
+        "target_semantics":
+            "leader world-space path point TRAIL_DISTANCE metres earlier",
+        "follow_rmse_m": math.sqrt(sum(e * e for e in errors) / len(errors)),
+        "follow_mean_m": sum(errors) / len(errors),
+        "follow_max_m": max(errors),
+        "person_range_mean_m": sum(r["person_range_m"] for r in records) / len(records),
+        "person_range_min_m": min(r["person_range_m"] for r in records),
+        "person_range_max_m": max(r["person_range_m"] for r in records),
+        "min_trunk_z_m": min(r["trunk_z_m"] for r in records),
+        "final_trunk_z_m": records[-1]["trunk_z_m"],
+        "fallen_steps": sum(r["trunk_z_m"] < FALLEN_Z for r in records),
+        "camera_visible_steps": total_steps - tracker.lost_steps,
+        "camera_lost_steps": tracker.lost_steps,
+        "camera_visible_pct": 100.0 * (total_steps - tracker.lost_steps) / total_steps,
+        "camera_rms_off_axis_deg": math.degrees(tracker.rms_off_axis),
+        "camera_max_off_axis_deg": math.degrees(tracker.max_off_axis),
+        "leader_phase_first_seen_s": leader_phase_times,
+        "duck_command_phase_first_seen_s": command_phase_times,
+        "left_turn_delay_s": (
+            command_phase_times.get("LEFT TURN", float("nan"))
+            - leader_phase_times.get("LEFT TURN", float("nan"))),
+        "right_turn_delay_s": (
+            command_phase_times.get("RIGHT TURN", float("nan"))
+            - leader_phase_times.get("RIGHT TURN", float("nan"))),
+        "backward_delay_s": (
+            command_phase_times.get("BACKWARD", float("nan"))
+            - leader_phase_times.get("BACKWARD", float("nan"))),
+        "leader_left_turn_yaw_delta_deg": 90.0,
+        "leader_right_turn_yaw_delta_deg": -90.0,
+        "duck_left_turn_yaw_delta_deg": turn_yaw_delta(records, "LEFT TURN"),
+        "duck_right_turn_yaw_delta_deg": turn_yaw_delta(records, "RIGHT TURN"),
+        "phases": phase_summary(records),
+    }
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--policy", required=True,
+        help="path to an exported walking ONNX policy (e.g. alpha_walking.onnx)")
+    parser.add_argument("--xml", default=str(DEFAULT_SCENE),
+                        help="scene XML (default: the demo scene next to this script)")
+    parser.add_argument("--seconds", type=float, default=DEMO_SECONDS)
+    parser.add_argument("--out", default=None,
+                        help="directory for PNG frames; omit to skip rendering")
+    parser.add_argument("--metrics", default=None,
+                        help="path to write the metrics JSON")
+    parser.add_argument("--width", type=int, default=960)
+    parser.add_argument("--height", type=int, default=640)
+    parser.add_argument("--fps", type=int, default=50)
+    parser.add_argument("--no-render", action="store_true",
+                        help="metrics only, no frames (no Pillow/display needed)")
+    parser.add_argument("--quiet", action="store_true",
+                        help="suppress the per-step progress log")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    render = not args.no_render and args.out is not None
+    if render:
+        os.makedirs(args.out, exist_ok=True)
+
+    model = mujoco.MjModel.from_xml_path(args.xml)
+    data = mujoco.MjData(model)
+    mujoco.mj_resetData(model, data)
+
+    if model.nu != EXPECTED_ACTUATORS:
+        raise RuntimeError(
+            f"expected {EXPECTED_ACTUATORS} policy actuators, got {model.nu}")
+    qpos_idx = np.array([
+        int(model.jnt_qposadr[model.actuator_trnid[i, 0]]) for i in range(model.nu)])
+    qvel_idx = np.array([
+        int(model.jnt_dofadr[model.actuator_trnid[i, 0]]) for i in range(model.nu)])
+    for index, qpos_address in enumerate(qpos_idx):
+        data.qpos[qpos_address] = DEFAULT_POSE[index]
+    data.ctrl[:] = DEFAULT_POSE
+
+    trunk_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "trunk_base")
+    person_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "person")
+    person_mocap = int(model.body_mocapid[person_id])
+    trail_target_mocap = int(model.body_mocapid[
+        mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "trail_target")])
+    gyro_adr = resolve_gyro_adr(model)
+
+    initial_person = person_trajectory(0.0)
+    animate_person(model, data, initial_person, 0.0)
+    mujoco.mj_forward(model, data)
+
+    session = ort.InferenceSession(
+        args.policy, providers=["CPUExecutionProvider"])
+    input_name = session.get_inputs()[0].name
+    output_name = session.get_outputs()[0].name
+    observation_dim = int(session.get_inputs()[0].shape[1])
+    command_dim = observation_dim - (3 + 3 + model.nu * 3)
+    if command_dim != EXPECTED_COMMAND_DIM:
+        raise RuntimeError(
+            f"expected {EXPECTED_COMMAND_DIM} command dimensions, got {command_dim}; "
+            f"is {args.policy} a walking policy with the 61D observation layout?")
+
+    sim_dt = model.opt.timestep
+    decimation = max(1, round((1.0 / CTRL_HZ) / sim_dt))
+    total_steps = int(args.seconds * CTRL_HZ)
+    frame_every = max(1, round(CTRL_HZ / args.fps))
+    controller = FollowController()
+    footsteps = FootstepTrail(initial_person)
+
+    if render:
+        from video_overlay import PIP_H, PIP_W, compose
+    else:
+        PIP_W, PIP_H = 225, 165
+    tracker = HeadCameraTracker(model, data, qpos_idx, trunk_id, (PIP_W, PIP_H))
+
+    last_action = np.zeros(model.nu, dtype=np.float32)
+    previous_yaw = yaw_of_body(data, trunk_id)
+    min_height = float(data.xpos[trunk_id, 2])
+    records = []
+    frames = 0
+
+    if render:
+        renderer = mujoco.Renderer(model, height=args.height, width=args.width)
+        pip_renderer = mujoco.Renderer(model, height=PIP_H, width=PIP_W)
+        camera = mujoco.MjvCamera()
+        mujoco.mjv_defaultCamera(camera)
+        camera.distance = 1.85
+        camera.elevation = -20
+        # Rear three-quarter view keeps actor-relative left and right readable.
+        camera.azimuth = -45
+        camera_lookat = np.array([0.4, 0.0, 0.15], dtype=np.float64)
+
+    if not args.quiet:
+        print(f"follow-me: {total_steps} steps, trail={TRAIL_DISTANCE:.2f} m, "
+              f"decimation={decimation}, render={render}")
+
+    last_phase = None
+    last_command_phase = None
+    leader_phase_times = {}
+    command_phase_times = {}
+
+    for step in range(total_steps):
+        t = step / CTRL_HZ
+        person = person_trajectory(t)
+        animate_person(model, data, person, t)
+        mujoco.mj_forward(model, data)
+        duck_pos_before = data.xpos[trunk_id].copy()
+        duck_yaw_before = yaw_of_body(data, trunk_id)
+        trail = footsteps.update(person)
+        data.mocap_pos[trail_target_mocap] = np.array(
+            [trail.pos[0], trail.pos[1], 0.012])
+        command, follow = controller.update(
+            person, trail, duck_pos_before, duck_yaw_before)
+        command_phase = follow["replay_phase"] if person.moving else "STOPPED"
+
+        observation = make_observation(
+            data, qpos_idx, qvel_idx, trunk_id, gyro_adr,
+            last_action, command, command_dim)
+        action = session.run(
+            [output_name], {input_name: observation.reshape(1, -1)}
+        )[0].squeeze(0).astype(np.float32)
+        last_action = action.copy()
+        data.ctrl[:] = DEFAULT_POSE + ACTION_SCALE * action
+        for _ in range(decimation):
+            mujoco.mj_step(model, data)
+
+        # Advance the leader to the END of the control interval so the frame
+        # and the recorded metrics describe the same instant.
+        display_t = min(t + 1.0 / CTRL_HZ, args.seconds)
+        display_person = person_trajectory(display_t)
+        animate_person(model, data, display_person, display_t)
+        mujoco.mj_forward(model, data)
+        duck_pos = data.xpos[trunk_id].copy()
+        duck_yaw = yaw_of_body(data, trunk_id)
+        yaw_rate = math.degrees(wrap(duck_yaw - previous_yaw)) * CTRL_HZ
+        previous_yaw = duck_yaw
+        min_height = min(min_height, float(duck_pos[2]))
+        camera_state = tracker.update(data)
+
+        target_pos = follow["target_pos"]
+        follow_error = float(np.linalg.norm(target_pos - duck_pos[:2]))
+        person_range = float(np.linalg.norm(
+            data.mocap_pos[person_mocap, :2] - duck_pos[:2]))
+        follow.update({"error": follow_error, "person_range": person_range})
+        records.append({
+            "t": display_t,
+            "phase": display_person.phase,
+            "trail_phase": trail.phase,
+            "command_phase": command_phase,
+            "trail_target_xy": trail.pos.tolist(),
+            "spatial_lag_m": follow["spatial_lag"],
+            "follow_error_m": follow_error,
+            "person_range_m": person_range,
+            "yaw_error_deg": math.degrees(follow["yaw_error"]),
+            "leader_yaw_deg": math.degrees(display_person.yaw),
+            "duck_yaw_deg": math.degrees(duck_yaw),
+            "trunk_z_m": float(duck_pos[2]),
+            "visible": bool(camera_state["visible"]),
+            "off_axis_deg": math.degrees(camera_state["off_axis"]),
+            "command": command.tolist(),
+        })
+
+        leader_phase_times.setdefault(display_person.phase, display_t)
+        command_phase_times.setdefault(command_phase, display_t)
+        if not args.quiet:
+            if display_person.phase != last_phase:
+                print(f"  t={display_t:5.2f}s LEADER -> {display_person.phase:9s} "
+                      f"duck_replays={command_phase:9s}")
+                last_phase = display_person.phase
+            if command_phase != last_command_phase:
+                print(f"  t={display_t:5.2f}s DUCK   -> {command_phase:9s} "
+                      f"at trail=({trail.pos[0]:+.3f},{trail.pos[1]:+.3f})")
+                last_command_phase = command_phase
+
+        if render and step % frame_every == 0:
+            center = 0.5 * (duck_pos + data.mocap_pos[person_mocap])
+            center[2] = 0.15
+            camera_lookat += 0.08 * (center - camera_lookat)
+            camera.lookat[:] = camera_lookat
+            renderer.update_scene(tracker.gaze_data, camera=camera)
+            pip_renderer.update_scene(tracker.gaze_data, camera=tracker.camera_id)
+            image = compose(
+                renderer.render(), pip_renderer.render(), t=display_t,
+                total_seconds=args.seconds, person=display_person,
+                duck_pos=duck_pos, duck_yaw=duck_yaw, follow=follow,
+                command=command, camera=camera_state, yaw_rate=yaw_rate,
+                min_height=min_height)
+            # Imported lazily: the demo runs headless without imageio.
+            import imageio.v2 as imageio
+            imageio.imwrite(Path(args.out) / f"f{frames:05d}.png", np.asarray(image))
+            frames += 1
+
+    summary = build_summary(records, args, total_steps, frames, tracker,
+                            leader_phase_times, command_phase_times)
+    if args.metrics:
+        Path(args.metrics).write_text(json.dumps(summary, indent=2) + "\n")
+    print(json.dumps(summary, indent=2))
+    return summary
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/behavior_demos/follow_me/scene_follow_me.xml
+++ b/scripts/behavior_demos/follow_me/scene_follow_me.xml
@@ -1,0 +1,129 @@
+<mujoco model="scene_follow_me">
+    <!-- Follow-me behavior demo scene.
+
+         The official Velocity task uses robot_walk.xml: non-foot trunk/head
+         contacts are stripped so ordinary walking does not self-collide. This
+         demo drives a stock walking policy, so it must use the same collision
+         model the policy was trained on.
+
+         IMPORTANT — asset resolution. MuJoCo resolves `meshdir` relative to the
+         TOP-LEVEL file, not the included one, so robot_walk.xml's own
+         `meshdir="assets"` would resolve against this directory and fail. The
+         <compiler> below restates the robot's compiler settings with a meshdir
+         pointing back at the robot assets. It MUST stay AFTER the include:
+         MuJoCo applies the last <compiler> it parses, so placing it before the
+         include lets robot_walk.xml's own meshdir win and the meshes go
+         missing. Keeping angle/autolimits identical to robot_walk.xml is what
+         makes this scene compile byte-identically to scene_walk.xml (locked by
+         tests/test_follow_me_demo.py). -->
+    <include file="../../../src/mjlab_microduck/robot/microduck/robot_walk.xml" />
+    <compiler angle="radian" autolimits="true"
+              meshdir="../../../src/mjlab_microduck/robot/microduck/assets" />
+
+    <visual>
+        <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
+        <rgba haze="0.15 0.25 0.35 1" />
+        <!-- offwidth/offheight size the offscreen buffer for the 960x640 main
+             view; the head-camera PiP renders from the same buffer. -->
+        <global azimuth="160" elevation="-20" offwidth="1280" offheight="960" />
+    </visual>
+
+    <asset>
+        <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0"
+                 width="512" height="3072" />
+        <texture type="2d" name="groundplane" builtin="checker" mark="edge"
+                 rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3" markrgb="0.8 0.8 0.8"
+                 width="300" height="300" />
+        <material name="groundplane" texture="groundplane" texuniform="true"
+                  texrepeat="5 5" reflectance="0.2" />
+        <material name="skinmat" rgba="0.85 0.65 0.5 1" />
+        <material name="shirtmat" rgba="0.15 0.38 0.78 1" />
+        <material name="trousermat" rgba="0.08 0.12 0.22 1" />
+        <material name="shoemat" rgba="0.04 0.04 0.05 1" />
+        <material name="accentmat" rgba="0.95 0.75 0.12 1" />
+        <material name="trailmat" rgba="0.15 1.0 0.35 0.65" />
+    </asset>
+
+    <worldbody>
+        <light pos="0 0 3.5" dir="0 0 -1" directional="true" />
+        <geom name="floor" size="0 0 0.05" pos="0 0 0" type="plane"
+              material="groundplane" />
+
+        <!-- Green disc: the exact queued world-space footprint the duck
+             pursues. It visibly stays on the old leg while the leader turns,
+             which is the whole point of the trail-following behavior. -->
+        <body name="trail_target" mocap="true" pos="0 0 0.012">
+            <geom name="trail_target_disc" type="cylinder" size="0.027 0.004"
+                  material="trailmat" contype="0" conaffinity="0" />
+        </body>
+
+        <!-- Rendering-only stabilized viewpoint. Its position is copied from
+             the physical head camera each step, but its optical up axis is
+             held to world-up. It exists purely so the PiP is watchable; it is
+             never read by the policy. -->
+        <body name="follow_camera_rig" mocap="true" pos="0 0 0.2">
+            <camera name="follow_camera" fovy="45" />
+        </body>
+
+        <!-- Kinematic leader. The root is a mocap body driven by a scripted
+             planar trajectory; four hinge children animate a readable walk
+             cycle. Local +X is the leader's forward direction. Every geom is
+             contype=0/conaffinity=0: the leader is a visual/semantic target,
+             it never collides with the robot. -->
+        <body name="person" mocap="true" pos="0.65 0 0.36">
+            <geom name="person_torso" type="capsule" fromto="0 0 -0.10 0 0 0.16"
+                  size="0.075" material="shirtmat" contype="0" conaffinity="0" />
+            <geom name="person_head" type="sphere" pos="0 0 0.25" size="0.062"
+                  material="skinmat" contype="0" conaffinity="0" />
+            <geom name="person_nose" type="sphere" pos="0.058 0 0.25" size="0.018"
+                  material="accentmat" contype="0" conaffinity="0" />
+
+            <body name="person_leg_l" pos="0 0.035 -0.10">
+                <joint name="person_hip_l" type="hinge" axis="0 1 0"
+                       range="-35 35" damping="1" />
+                <geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032"
+                      material="trousermat" contype="0" conaffinity="0" />
+                <geom type="capsule" fromto="0 0 -0.26 0.07 0 -0.27" size="0.034"
+                      material="shoemat" contype="0" conaffinity="0" />
+            </body>
+            <body name="person_leg_r" pos="0 -0.035 -0.10">
+                <joint name="person_hip_r" type="hinge" axis="0 1 0"
+                       range="-35 35" damping="1" />
+                <geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032"
+                      material="trousermat" contype="0" conaffinity="0" />
+                <geom type="capsule" fromto="0 0 -0.26 0.07 0 -0.27" size="0.034"
+                      material="shoemat" contype="0" conaffinity="0" />
+            </body>
+            <body name="person_arm_l" pos="0 0.075 0.11">
+                <joint name="person_shoulder_l" type="hinge" axis="0 1 0"
+                       range="-30 30" damping="1" />
+                <geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025"
+                      material="skinmat" contype="0" conaffinity="0" />
+            </body>
+            <body name="person_arm_r" pos="0 -0.075 0.11">
+                <joint name="person_shoulder_r" type="hinge" axis="0 1 0"
+                       range="-30 30" damping="1" />
+                <geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025"
+                      material="skinmat" contype="0" conaffinity="0" />
+            </body>
+        </body>
+    </worldbody>
+
+    <keyframe>
+        <!-- 21 robot qpos (7 free + 14 servos) + 4 leader hinges = 25. -->
+        <key name="INIT" qpos="0 0 0.12 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+             ctrl="0 0 0 0 0 0 0 0 0 0 0 0 0 0" />
+        <!-- STAND matches the walking policy's DEFAULT_POSE (see
+             scripts/infer_policy.py): actions are offsets from this pose. -->
+        <key name="STAND" qpos="
+        0 0 0.12 1 0 0 0
+        0 -0.08726646259971647 -0.457924 -0.004940 0.452984
+        0.3490658503988659 0.3490658503988659 0 0
+        0 0.08726646259971647 0.457924 0.004940 -0.452984
+        0 0 0 0"
+        ctrl="
+        0 -0.08726646259971647 -0.457924 -0.004940 0.452984
+        0.3490658503988659 0.3490658503988659 0 0
+        0 0.08726646259971647 0.457924 0.004940 -0.452984" />
+    </keyframe>
+</mujoco>

--- a/scripts/behavior_demos/follow_me/video_overlay.py
+++ b/scripts/behavior_demos/follow_me/video_overlay.py
@@ -1,0 +1,135 @@
+"""HUD and head-camera picture-in-picture composition for the demo video.
+
+Rendering-only. Nothing here is read back by the behavior or the policy; if
+Pillow is unavailable the demo still runs with ``--no-render`` and produces the
+full metrics JSON.
+"""
+
+from __future__ import annotations
+
+import math
+
+from follow_motion import (
+    BACKWARD_END,
+    FORWARD_END,
+    LEFT_TURN_END,
+    READY_END,
+    RIGHT_EXIT_END,
+    STOP_END,
+)
+from PIL import Image, ImageDraw, ImageFont
+
+PIP_W, PIP_H = 225, 165
+
+PHASES = ["READY", "FORWARD", "LEFT TURN", "STOP", "RIGHT TURN", "BACKWARD", "DONE"]
+
+# Phase boundaries are derived from the choreography constants rather than
+# retyped, so the timeline drawn on the video can never drift from the route
+# actually simulated.
+PHASE_BOUNDARIES = [0.0, READY_END, FORWARD_END, LEFT_TURN_END, STOP_END,
+                    RIGHT_EXIT_END, BACKWARD_END]
+
+PHASE_COLORS = {
+    "READY": (180, 210, 255),
+    "FORWARD": (100, 235, 145),
+    "LEFT TURN": (255, 205, 80),
+    "STOP": (255, 120, 120),
+    "RIGHT TURN": (120, 215, 255),
+    "BACKWARD": (215, 155, 255),
+    "DONE": (180, 255, 180),
+    "STOPPED": (255, 120, 120),
+}
+
+# Trunk height below which the run is reported as fallen.
+FALLEN_Z = 0.09
+
+# First readable monospace font found wins; the bitmap default is the fallback
+# so the HUD renders on a bare CI box with no system fonts installed.
+_FONT_CANDIDATES = (
+    "/System/Library/Fonts/SFNSMono.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+    "/usr/share/fonts/TTF/DejaVuSansMono.ttf",
+    "DejaVuSansMono.ttf",
+)
+
+
+def _font(size=14):
+    for path in _FONT_CANDIDATES:
+        try:
+            return ImageFont.truetype(path, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def compose(main_rgb, pip_rgb, *, t, total_seconds, person, duck_pos,
+            duck_yaw, follow, command, camera, yaw_rate, min_height):
+    image = Image.fromarray(main_rgb)
+    pip = Image.fromarray(pip_rgb)
+    draw = ImageDraw.Draw(image)
+    font = _font(14)
+    small = _font(12)
+    width, height = image.size
+    phase_color = PHASE_COLORS[person.phase]
+
+    draw.rectangle([0, 0, width, 126], fill=(4, 8, 14))
+    replay = follow["replay_phase"] if person.moving else "STOPPED"
+    replay_color = PHASE_COLORS.get(replay, (235, 240, 245))
+    draw.text((12, 8), f"FOLLOW-ME · TRUE LEFT / RIGHT   t={t:05.2f}s",
+              fill=phase_color, font=font)
+    draw.text((12, 31), f"LEADER: {person.phase:<9}   DUCK REPLAYS: {replay:<9}",
+              fill=replay_color, font=small)
+    draw.text((12, 51),
+              f"world-path lag={follow['spatial_lag']:.3f} m   "
+              f"trail error={follow['error']:.3f} m   "
+              f"person range={follow['person_range']:.3f} m",
+              fill=(235, 240, 245), font=small)
+    draw.text((12, 71),
+              f"command vx={command[0]:+.3f} vy={command[1]:+.3f} wz={command[2]:+.3f}   "
+              f"heading error={math.degrees(follow['yaw_error']):+5.1f} deg",
+              fill=(235, 240, 245), font=small)
+    stable = duck_pos[2] >= FALLEN_Z
+    draw.text((12, 91),
+              f"trunk z={duck_pos[2]:.3f} m   min={min_height:.3f} m   "
+              f"{'UPRIGHT' if stable else 'FALLEN'}",
+              fill=(145, 255, 165) if stable else (255, 90, 90), font=small)
+
+    visible = camera["visible"]
+    draw.text((12, 111),
+              f"head camera: {'PERSON VISIBLE' if visible else 'TARGET LOST'}   "
+              f"off-axis={math.degrees(camera['off_axis']):.1f} deg",
+              fill=(120, 255, 140) if visible else (255, 110, 110), font=small)
+
+    px0, py0 = width - PIP_W - 12, 138
+    border = (100, 255, 130) if visible else (255, 90, 90)
+    draw.rectangle([px0 - 4, py0 - 22, px0 + PIP_W + 4, py0 + PIP_H + 4],
+                   fill=(2, 5, 8))
+    draw.text((px0, py0 - 19), "DUCK VIEW · STABILIZED HEAD CAM",
+              fill=border, font=small)
+    image.paste(pip, (px0, py0))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle([px0 - 1, py0 - 1, px0 + PIP_W, py0 + PIP_H],
+                   outline=border, width=3)
+    cx, cy = px0 + PIP_W // 2, py0 + PIP_H // 2
+    draw.line([cx - 8, cy, cx + 8, cy], fill=(255, 235, 80), width=1)
+    draw.line([cx, cy - 8, cx, cy + 8], fill=(255, 235, 80), width=1)
+
+    # Timeline makes the choreography readable at a glance. Boundaries are
+    # clamped to the rendered duration so a shortened run (--seconds, used for
+    # smoke tests) still draws a valid, monotonically increasing bar.
+    bar_y = height - 34
+    x0, x1 = 12, width - 12
+    draw.rectangle([x0, bar_y, x1, bar_y + 12], fill=(25, 34, 46))
+    boundaries = [min(b, total_seconds) for b in (*PHASE_BOUNDARIES, total_seconds)]
+    for index, phase in enumerate(PHASES):
+        left = x0 + (x1 - x0) * boundaries[index] / total_seconds
+        right = x0 + (x1 - x0) * boundaries[index + 1] / total_seconds
+        if right <= left:
+            continue
+        color = PHASE_COLORS[phase]
+        draw.rectangle([left, bar_y, right, bar_y + 12], fill=color)
+        if right - left > 55:
+            draw.text((left + 3, bar_y - 15), phase, fill=color, font=small)
+    marker = x0 + (x1 - x0) * min(t / total_seconds, 1.0)
+    draw.line([marker, bar_y - 4, marker, bar_y + 17], fill=(255, 255, 255), width=2)
+    return image

--- a/tests/test_follow_me_demo.py
+++ b/tests/test_follow_me_demo.py
@@ -1,0 +1,489 @@
+"""CPU tests for the follow-me behavior demo.
+
+These cover the pure behavior logic (leader choreography, world-space footprint
+trail, asymmetric turn controller) and the demo scene's model invariants.
+Nothing here needs an ONNX policy, a GPU, or a renderer.
+"""
+
+import math
+import sys
+from itertools import pairwise
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+DEMO_DIR = Path(__file__).resolve().parents[1] / "scripts" / "behavior_demos" / "follow_me"
+sys.path.insert(0, str(DEMO_DIR))
+
+from follow_motion import (
+    BACKWARD_END,
+    CTRL_HZ,
+    DEMO_SECONDS,
+    FORWARD_END,
+    LEFT_TURN_END,
+    LEFT_WZ_MAX,
+    LEFT_WZ_MIN,
+    READY_END,
+    RIGHT_EXIT_END,
+    RIGHT_WZ_MAX,
+    RIGHT_WZ_MIN,
+    STOP_END,
+    TRAIL_DISTANCE,
+    TURN_VX,
+    YAW_DEADBAND_RAD,
+    YAW_GAIN,
+    FollowController,
+    FootstepTrail,
+    PersonState,
+    TrailState,
+    person_trajectory,
+    wrap,
+)
+
+SCENE = DEMO_DIR / "scene_follow_me.xml"
+
+
+def _trail_state(phase, pos, yaw):
+    return TrailState(phase=phase, pos=np.asarray(pos, dtype=np.float64),
+                      yaw=yaw, path_s=0.0, leader_path_s=0.0, moving=True)
+
+
+# --------------------------------------------------------------------------
+# Leader choreography
+# --------------------------------------------------------------------------
+
+def test_route_phase_order_and_coverage():
+    """Every phase appears, in order, and the route fills the demo duration."""
+    seen = []
+    for step in range(int(DEMO_SECONDS * CTRL_HZ)):
+        phase = person_trajectory(step / CTRL_HZ).phase
+        if not seen or seen[-1] != phase:
+            seen.append(phase)
+    assert seen == ["READY", "FORWARD", "LEFT TURN", "STOP", "RIGHT TURN",
+                    "BACKWARD", "DONE"]
+
+
+def test_turns_are_genuinely_opposite():
+    """The left turn adds +90 deg of world yaw; the right turn subtracts 90.
+
+    This is the invariant an earlier iteration violated: a phase LABELLED
+    "left turn" used negative world yaw, so it was physically a right-hand
+    curve, and the two turns were not opposites at all.
+    """
+    left_start = person_trajectory(FORWARD_END).yaw
+    left_end = person_trajectory(LEFT_TURN_END - 1e-9).yaw
+    right_start = person_trajectory(STOP_END).yaw
+    right_end = person_trajectory(RIGHT_EXIT_END - 1e-9).yaw
+
+    assert math.degrees(left_end - left_start) == pytest.approx(90.0, abs=0.1)
+    assert math.degrees(right_end - right_start) == pytest.approx(-90.0, abs=0.1)
+    # Opposite signs, and the leader returns to its original heading.
+    assert (left_end - left_start) * (right_end - right_start) < 0.0
+    assert person_trajectory(RIGHT_EXIT_END - 1e-9).yaw == pytest.approx(0.0, abs=1e-9)
+
+
+def test_leader_path_is_continuous_across_phase_boundaries():
+    """No teleports: position is continuous at every phase change."""
+    for boundary in (READY_END, FORWARD_END, LEFT_TURN_END, STOP_END,
+                     RIGHT_EXIT_END, BACKWARD_END):
+        before = person_trajectory(boundary - 1e-6).pos
+        after = person_trajectory(boundary + 1e-6).pos
+        assert np.linalg.norm(after - before) < 1e-3, f"jump at t={boundary}"
+
+
+def test_stationary_phases_are_marked_not_moving():
+    assert not person_trajectory(1.0).moving          # READY
+    assert not person_trajectory(16.0).moving         # STOP
+    assert not person_trajectory(43.0).moving         # DONE
+    assert person_trajectory(4.0).moving              # FORWARD
+    assert person_trajectory(10.0).moving             # LEFT TURN
+
+
+# --------------------------------------------------------------------------
+# World-space footprint trail
+# --------------------------------------------------------------------------
+
+def test_trail_lags_leader_by_the_configured_path_length():
+    """Once the queue is primed, the gap is TRAIL_DISTANCE of PATH length.
+
+    Checked two ways: the queue's own bookkeeping, and the independently
+    integrated arc length of the leader's route between the queued footprint
+    and the leader. On the straight leg both must also equal the plain
+    straight-line distance.
+    """
+    trail = FootstepTrail(person_trajectory(0.0))
+    state = None
+    previous = person_trajectory(0.0).pos
+    arc_by_time = [(0.0, 0.0)]
+    travelled = 0.0
+    steps = int(20.0 * CTRL_HZ)
+    for step in range(steps):
+        t = step / CTRL_HZ
+        leader = person_trajectory(t)
+        travelled += float(np.linalg.norm(leader.pos - previous))
+        previous = leader.pos
+        arc_by_time.append((t, travelled))
+        state = trail.update(leader)
+
+    assert state.leader_path_s - state.path_s == pytest.approx(TRAIL_DISTANCE)
+
+    # Independent geometric check on the straight leg, where path length and
+    # straight-line distance coincide.
+    trail_straight = FootstepTrail(person_trajectory(0.0))
+    straight_state = None
+    sample_t = FORWARD_END - 0.5
+    for step in range(int(sample_t * CTRL_HZ)):
+        straight_state = trail_straight.update(person_trajectory(step / CTRL_HZ))
+    leader_now = person_trajectory(sample_t - 1.0 / CTRL_HZ)
+    gap = float(np.linalg.norm(leader_now.pos - straight_state.pos))
+    assert gap == pytest.approx(TRAIL_DISTANCE, abs=0.02)
+
+
+def test_trail_target_lies_on_the_route_the_leader_actually_walked():
+    """The queued point must be ON the leader's past path, not interpolated
+    across the chord of the turn.
+
+    A follower that reconstructs a target from the leader's current pose can
+    sit inside the arc; a genuine footstep queue cannot.
+    """
+    trail = FootstepTrail(person_trajectory(0.0))
+    route = []
+    state = None
+    for step in range(int(LEFT_TURN_END * CTRL_HZ)):
+        leader = person_trajectory(step / CTRL_HZ)
+        route.append(leader.pos.copy())
+        state = trail.update(leader)
+    route = np.array(route)
+    distance_to_route = float(np.min(np.linalg.norm(route - state.pos, axis=1)))
+    assert distance_to_route < 1e-3
+
+
+def test_trail_keeps_the_corner_instead_of_cutting_it():
+    """The queued footprint stays on the pre-turn leg while the leader turns.
+
+    This is the whole point of following footsteps rather than the leader's
+    current pose: a pose-mirroring follower would already be turning here.
+    """
+    trail = FootstepTrail(person_trajectory(0.0))
+    state = None
+    # Sample shortly after the leader commits to the left turn.
+    for step in range(int((FORWARD_END + 1.5) * CTRL_HZ)):
+        state = trail.update(person_trajectory(step / CTRL_HZ))
+    leader = person_trajectory(FORWARD_END + 1.5)
+    assert leader.yaw > math.radians(5.0), "leader should already be turning"
+    # The queued target has not started the turn yet.
+    assert abs(state.yaw) < math.radians(5.0)
+    # And it is still behind the leader, on the straight leg.
+    assert state.pos[0] < leader.pos[0]
+
+
+def test_stopped_leader_freezes_the_queue():
+    """A leader that does not move must not advance the path length.
+
+    The queue is sampled from the FIRST stationary step onward: the step that
+    enters STOP still carries the last real displacement of the turn arc.
+    """
+    trail = FootstepTrail(person_trajectory(0.0))
+    first_stop = int(LEFT_TURN_END * CTRL_HZ) + 1
+    for step in range(first_stop):
+        trail.update(person_trajectory(step / CTRL_HZ))
+    assert not person_trajectory((first_stop - 1) / CTRL_HZ).moving
+    frozen = trail.path_s
+    for step in range(first_stop, int(STOP_END * CTRL_HZ)):
+        trail.update(person_trajectory(step / CTRL_HZ))
+    assert trail.path_s == pytest.approx(frozen)
+
+
+def test_trail_yaw_interpolation_wraps_across_pi():
+    """Interpolating between +170 deg and -170 deg must cross pi, not unwind.
+
+    A naive linear blend of the two yaw values would sweep the long way round
+    through 0 deg, pointing the follower backwards mid-corner.
+    """
+    start = PersonState("FORWARD", np.array([0.0, 0.0]), math.radians(170.0),
+                        np.zeros(2), 0.0, True, 0.0)
+    trail = FootstepTrail(start, gap=0.5)
+    for i in range(1, 40):
+        pos = np.array([-0.05 * i, 0.0])
+        trail.update(PersonState("FORWARD", pos, math.radians(-170.0),
+                                 np.zeros(2), 0.0, True, 0.0))
+    state = trail.update(PersonState("FORWARD", np.array([-2.0, 0.0]),
+                                     math.radians(-170.0), np.zeros(2), 0.0,
+                                     True, 0.0))
+    assert abs(state.yaw) > math.radians(150.0)
+
+
+def test_trail_yaw_takes_the_short_way_around_during_interpolation():
+    """Directly exercise the blend halfway between +170 and -170 degrees.
+
+    The midpoint must be near +/-180, never near 0.
+    """
+    start = PersonState("FORWARD", np.array([0.0, 0.0]), math.radians(170.0),
+                        np.zeros(2), 0.0, True, 0.0)
+    trail = FootstepTrail(start, gap=1.0)
+    # One sample 2 m away with the opposite heading: the queued point lands
+    # midway between the two, so the yaw blend is exercised at fraction≈0.5.
+    trail.update(PersonState("FORWARD", np.array([2.0, 0.0]),
+                             math.radians(-170.0), np.zeros(2), 0.0, True, 0.0))
+    state = trail.update(PersonState("FORWARD", np.array([2.0, 0.0]),
+                                     math.radians(-170.0), np.zeros(2), 0.0,
+                                     True, 0.0))
+    assert abs(state.yaw) > math.radians(170.0), (
+        f"yaw blend unwound the short way: {math.degrees(state.yaw):.1f} deg")
+
+
+# --------------------------------------------------------------------------
+# Asymmetric turn controller
+# --------------------------------------------------------------------------
+
+def test_turn_rate_deadband_is_exactly_zero():
+    """Inside the deadband the command is 0.0 — not a small nudge.
+
+    The stock policy has a sharp gait-onset threshold, so sub-threshold
+    corrections only produce shuffling.
+    """
+    for error_deg in (-2.9, -1.0, 0.0, 1.0, 2.9):
+        assert FollowController.turn_rate(math.radians(error_deg)) == 0.0
+    assert FollowController.turn_rate(YAW_DEADBAND_RAD * 1.01) != 0.0
+
+
+def test_turn_rate_is_asymmetric_and_correctly_signed():
+    """Left and right use separately measured magnitude bands."""
+    left = FollowController.turn_rate(math.radians(45.0))
+    right = FollowController.turn_rate(math.radians(-45.0))
+    assert left > 0.0 and right < 0.0
+    assert LEFT_WZ_MIN <= left <= LEFT_WZ_MAX
+    assert RIGHT_WZ_MIN <= -right <= RIGHT_WZ_MAX
+    # Asymmetry is the point: a mirrored command does not mirror the motion.
+    assert left > -right
+
+
+def test_turn_rate_magnitude_stays_within_measured_limits():
+    for error_deg in np.linspace(-180.0, 180.0, 721):
+        wz = FollowController.turn_rate(math.radians(error_deg))
+        if wz > 0.0:
+            assert LEFT_WZ_MIN <= wz <= LEFT_WZ_MAX
+        elif wz < 0.0:
+            assert RIGHT_WZ_MIN <= -wz <= RIGHT_WZ_MAX
+
+
+def test_turn_rate_is_monotonic_in_error_magnitude():
+    errors = np.linspace(YAW_DEADBAND_RAD, math.pi, 200)
+    left = [FollowController.turn_rate(e) for e in errors]
+    right = [-FollowController.turn_rate(-e) for e in errors]
+    assert all(b >= a - 1e-12 for a, b in pairwise(left))
+    assert all(b >= a - 1e-12 for a, b in pairwise(right))
+
+
+def test_turn_rate_is_strictly_proportional_inside_the_band():
+    """Between the clamps the response must actually scale with the error.
+
+    Monotonicity alone is satisfied by a constant, so it would not notice the
+    proportional term being neutralised (e.g. by an inverted gain, which
+    copysign then hides). These samples sit strictly inside each clamp band.
+    """
+    left_lo, left_hi = LEFT_WZ_MIN / YAW_GAIN, LEFT_WZ_MAX / YAW_GAIN
+    right_lo, right_hi = RIGHT_WZ_MIN / YAW_GAIN, RIGHT_WZ_MAX / YAW_GAIN
+
+    for lo, hi, sign in ((left_lo, left_hi, +1.0), (right_lo, right_hi, -1.0)):
+        samples = np.linspace(lo + 1e-3, hi - 1e-3, 12)
+        magnitudes = [abs(FollowController.turn_rate(sign * e)) for e in samples]
+        assert all(b > a for a, b in pairwise(magnitudes)), (
+            f"turn_rate is flat inside the proportional band: {magnitudes}")
+        # And it really is the proportional law, not an arbitrary ramp.
+        for error, magnitude in zip(samples, magnitudes):
+            assert magnitude == pytest.approx(YAW_GAIN * error)
+
+
+def test_stopped_leader_commands_zero():
+    controller = FollowController()
+    leader = PersonState("STOP", np.array([1.0, 0.0]), 0.0, np.zeros(2), 0.0,
+                         False, 0.0)
+    command, _ = controller.update(
+        leader, _trail_state("STOP", [1.0, 0.0], 0.0), np.zeros(3), 0.0)
+    assert np.allclose(command, np.zeros(3))
+
+
+def test_turning_command_walks_forward_while_turning():
+    """Turns keep a forward velocity: the duck corners, it does not pivot.
+
+    The forward speed is asserted as a literal, not against TURN_VX, so that
+    silently zeroing the constant (turning a corner into a stationary pivot)
+    fails here instead of comparing the constant to itself.
+    """
+    controller = FollowController()
+    leader = PersonState("LEFT TURN", np.array([1.0, 0.0]), 0.5, np.zeros(2),
+                         0.0, True, 0.0)
+    command, _ = controller.update(
+        leader, _trail_state("LEFT TURN", [1.0, 0.0], math.radians(40.0)),
+        np.zeros(3), 0.0)
+    assert command[0] == pytest.approx(0.24)
+    assert TURN_VX == pytest.approx(0.24)
+    assert command[2] > 0.0
+
+
+def test_measured_controller_constants_are_pinned():
+    """Lock the empirically measured controller envelope.
+
+    These numbers came from measured rollouts of the stock policy, not from
+    theory. Changing one silently changes the validated behavior, so it should
+    require deliberately updating this test.
+    """
+    assert (LEFT_WZ_MIN, LEFT_WZ_MAX) == (0.60, 1.00)
+    assert (RIGHT_WZ_MIN, RIGHT_WZ_MAX) == (0.18, 0.32)
+    assert YAW_DEADBAND_RAD == pytest.approx(math.radians(3.0))
+    assert TRAIL_DISTANCE == pytest.approx(0.65)
+    assert CTRL_HZ == 50.0
+
+
+# --------------------------------------------------------------------------
+# Reverse safety exception
+# --------------------------------------------------------------------------
+
+def test_reverse_is_immediate_and_overrides_the_queue():
+    """When the leader backs up, the duck backs up NOW.
+
+    Waiting for the leader's reverse footprint to arrive would let the leader
+    walk into the follower, so reversal deliberately bypasses the trail.
+    """
+    leader = PersonState("BACKWARD", np.array([2.0, 0.0]), 0.0,
+                         np.array([-0.08, 0.0]), 0.0, True, 0.0)
+    # The queue is still replaying an old forward leg.
+    trail = _trail_state("FORWARD", [1.5, 0.0], 0.0)
+    assert FollowController.replay_phase(leader, trail) == "BACKWARD"
+
+    command, metrics = FollowController().update(leader, trail, np.zeros(3), 0.0)
+    assert command[0] < 0.0
+    assert metrics["replay_phase"] == "BACKWARD"
+
+
+def test_reverse_is_the_only_phase_that_bypasses_the_trail():
+    """Every non-reverse phase replays the QUEUED phase, not the leader's."""
+    trail = _trail_state("FORWARD", [1.0, 0.0], 0.0)
+    for leader_phase in ("FORWARD", "LEFT TURN", "RIGHT TURN", "STOP", "DONE"):
+        leader = PersonState(leader_phase, np.array([2.0, 0.0]), 0.0,
+                             np.zeros(2), 0.0, True, 0.0)
+        assert FollowController.replay_phase(leader, trail) == "FORWARD"
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+def test_wrap_maps_angles_into_half_open_pi_interval():
+    """wrap() normalizes to [-pi, pi) and preserves the represented angle."""
+    assert wrap(0.0) == pytest.approx(0.0)
+    assert wrap(3.0 * math.pi) == pytest.approx(-math.pi)
+    assert wrap(math.pi) == pytest.approx(-math.pi)
+    for angle in np.linspace(-20.0, 20.0, 401):
+        wrapped = wrap(angle)
+        assert -math.pi <= wrapped < math.pi
+        assert math.isclose(math.cos(wrapped), math.cos(angle), abs_tol=1e-9)
+        assert math.isclose(math.sin(wrapped), math.sin(angle), abs_tol=1e-9)
+
+
+# --------------------------------------------------------------------------
+# Scene / model invariants (no policy required)
+# --------------------------------------------------------------------------
+
+def test_demo_scene_exists_and_uses_the_walking_collision_model():
+    assert SCENE.is_file()
+    text = SCENE.read_text()
+    # The stock walking policy was trained on robot_walk.xml; the demo must
+    # not silently switch to the allcollisions model.
+    assert "robot_walk.xml" in text
+
+
+def test_demo_scene_compiles_and_matches_the_reference_walk_model():
+    """The demo scene must be the official walk model plus scenery.
+
+    The scene includes robot_walk.xml from another directory, so it has to
+    restate <compiler meshdir=...> AFTER the include (MuJoCo resolves meshdir
+    against the top-level file and applies the LAST compiler tag it parses).
+    Getting that wrong silently changes joint units, so compare against the
+    reference scene rather than merely asserting the file loads.
+    """
+    mujoco = pytest.importorskip("mujoco")
+    reference_path = (Path(__file__).resolve().parents[1] / "src" /
+                      "mjlab_microduck" / "robot" / "microduck" / "scene_walk.xml")
+    reference = mujoco.MjModel.from_xml_path(str(reference_path))
+    model = mujoco.MjModel.from_xml_path(str(SCENE))
+
+    assert model.nu == reference.nu == 14
+    np.testing.assert_allclose(model.jnt_range[:reference.njnt], reference.jnt_range)
+    np.testing.assert_allclose(model.actuator_ctrlrange, reference.actuator_ctrlrange)
+
+
+def test_demo_scene_provides_the_bodies_and_cameras_the_demo_needs():
+    mujoco = pytest.importorskip("mujoco")
+    model = mujoco.MjModel.from_xml_path(str(SCENE))
+    for body in ("trunk_base", "person", "trail_target", "follow_camera_rig"):
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, body) >= 0, body
+    for body in ("person", "trail_target", "follow_camera_rig"):
+        assert model.body(body).mocapid[0] >= 0, f"{body} must be a mocap body"
+    for camera in ("head_camera", "follow_camera"):
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, camera) >= 0
+
+
+def test_leader_never_collides_with_the_robot():
+    """The scripted leader is a visual target: all its geoms are non-colliding."""
+    mujoco = pytest.importorskip("mujoco")
+    model = mujoco.MjModel.from_xml_path(str(SCENE))
+    person_root = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "person")
+    person_bodies = set()
+    for body in range(model.nbody):
+        parent = body
+        while parent > 0:
+            if parent == person_root:
+                person_bodies.add(body)
+                break
+            parent = int(model.body_parentid[parent])
+    assert person_bodies
+    for geom in range(model.ngeom):
+        if int(model.geom_bodyid[geom]) in person_bodies:
+            assert model.geom_contype[geom] == 0
+            assert model.geom_conaffinity[geom] == 0
+
+
+def test_angular_velocity_sensor_resolves_by_name():
+    """The gyro is resolved BY NAME, never by trailing sensor index.
+
+    Silently reading the last sensor picked up a different quantity during
+    development and produced unstable, falsely-good results.
+    """
+    mujoco = pytest.importorskip("mujoco")
+    from run_follow_me import GYRO_SENSOR_NAMES, resolve_gyro_adr
+
+    model = mujoco.MjModel.from_xml_path(str(SCENE))
+    adr = resolve_gyro_adr(model)
+    assert adr >= 0
+    named = [mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, n)
+             for n in GYRO_SENSOR_NAMES]
+    assert any(i >= 0 for i in named)
+
+
+def test_stand_keyframe_matches_the_policy_default_pose():
+    """Actions are offsets from DEFAULT_POSE, so the scene must start there."""
+    mujoco = pytest.importorskip("mujoco")
+    from run_follow_me import DEFAULT_POSE
+
+    model = mujoco.MjModel.from_xml_path(str(SCENE))
+    data = mujoco.MjData(model)
+    mujoco.mj_resetDataKeyframe(model, data, model.key("STAND").id)
+    qpos_idx = [int(model.jnt_qposadr[model.actuator_trnid[i, 0]])
+                for i in range(model.nu)]
+    np.testing.assert_allclose(data.qpos[qpos_idx], DEFAULT_POSE, atol=1e-3)
+
+
+def test_demo_requires_an_explicit_policy_path():
+    """No baked-in policy path: --policy is mandatory and has no default."""
+    from run_follow_me import parse_args
+
+    with pytest.raises(SystemExit):
+        parse_args([])
+    args = parse_args(["--policy", "some/policy.onnx"])
+    assert args.policy == "some/policy.onnx"
+    # The default scene ships with the demo and resolves independently of CWD.
+    assert Path(args.xml).is_absolute()
+    assert Path(args.xml).is_file()


### PR DESCRIPTION
## What this adds

A self-contained **behavior demo** in which the Microduck follows a moving leader's **actual walked path**, turning where the leader turned instead of cutting the corner.

It is a **behavior layer over a stock exported walking policy**: it only chooses the 3-DoF twist command `(vx, vy, wz)` written into the policy's existing command slots. No locomotion network is trained, fine-tuned, replaced, or filtered.

> **Scope:** this is a **CPU MuJoCo simulation demo, not production robot autonomy**. See [Limitations](#limitations) — I'd rather be explicit about that up front than have it read as more than it is.

Opening as a **draft**: I don't know whether a `scripts/behavior_demos/` area is something you want in this repo at all, and I'd rather check that before polishing further. Happy to relocate, reshape, or drop it.

## Use case

"Follow me" is the demo people ask a small legged robot for first, and it's a good stress test of the shipped walking policy: it needs sustained forward motion, two opposite corners, a stop, and a reverse — driven purely through the command interface the runtime already exposes.

The interesting part is *what* the robot follows. Selecting a command from the leader's **current pose** makes the robot turn from its own coordinates the moment the leader turns, cutting across the inside of the corner. Following a **queue of world-space footprints** makes it walk to the place the leader actually stood, so it arrives at the corner and turns there.

## Implementation

- **`FootstepTrail`** records the leader's accumulated path in world coordinates at 50 Hz and returns the interpolated point walked **0.65 m of path length** earlier. Because the gap is a *path length*, not a time delay, a corner stays in the queue — producing measured **5.44 s delayed turns**. A stopped leader freezes the queue.
- **True opposite turns.** The route uses conventional actor-relative directions: facing `+X`, the left turn adds `+90°` of world yaw and the later right turn subtracts `90°`, returning the leader to its original heading. An earlier iteration labelled a *negative*-yaw curve `LEFT TURN`, so the two turns were physically same-signed; a test now locks the signs.
- **Asymmetric measured controller.** The stock policy's turning authority is strongly asymmetric — a single mirrored command does not produce mirrored body motion. The controller closes the loop on the delayed footprint yaw using separately measured bands: left `wz = +0.60…+1.00`, right `wz = −0.18…−0.32`, `3°` deadband, `vx = +0.24` while turning. The policy has a sharp gait-onset threshold, so inside the deadband the command is exactly zero rather than a small nudge.
- **Reverse safety exception.** When the leader backs toward the follower, the duck backs away **immediately** instead of waiting for the leader's reverse footprint to arrive, so the leader cannot walk into it. This is the one deliberate departure from trail following, and it is why the queued-footprint error grows during the final reverse. Cornering and lateral motion still come exclusively from the recorded trail.
- **Isolated gaze.** Gaze and camera stabilization run entirely in a separate rendering `MjData` copied from the physical state each step. They never feed back into walking dynamics.
- **Sensor resolved by name.** The angular-velocity sensor is looked up by name (`imu_ang_vel` and aliases). Reading the last sensor by index silently picked up a different quantity during development and produced unstable, falsely-good results, so it's rejected explicitly.

### Scene asset resolution

`scene_follow_me.xml` includes the official `robot_walk.xml` (the collision model the walking policy was trained on) from outside the robot directory, so it restates `<compiler meshdir=...>` pointing back at the robot assets.

That tag **must stay after the `<include>`**: MuJoCo resolves `meshdir` against the top-level file and applies the *last* `<compiler>` it parses. Placing it before the include lets the robot's own `meshdir` win and the meshes fail to load. Since a stray compiler tag could also silently change joint units, a test compiles the demo scene and compares joint and control ranges against `scene_walk.xml` rather than merely asserting the file loads.

## Measured validation

A 44 s / 2,200-step rollout driven by the stock `alpha_walking` policy:

| Metric | Result |
|---|---|
| Duration | 44.0 s / 2,200 control steps, all 7 phases |
| Duck turn yaw Δ | **+86.4° / −84.0°** (leader `+90.0° / −90.0°`) |
| Delayed turn starts | **5.44 s** after the leader, at the queued footprint (both turns) |
| Falls | **0** (`fallen_steps = 0`) |
| Trunk height | min **0.114 m**, final **0.116 m** |
| Leader visible in stabilized view | **2,200 / 2,200** steps |
| Leader range | mean 0.857 m (0.519–1.363 m) |

The turn signs are measured from the simulated trunk orientation, not inferred from phase labels or camera projection — that's what makes "the two turns are genuinely opposite" a measurement rather than an assertion.

`run_follow_me.py` writes all of these to the `--metrics` JSON so any run can be re-checked.

## Tests

`tests/test_follow_me_demo.py` adds **28 CPU tests** that need **no policy file, no GPU, and no renderer**:

```bash
uv run --with pytest pytest tests/test_follow_me_demo.py
```

They cover the pure behavior logic (choreography phase order and continuity, opposite turn signs, trail lag and corner retention, queue freezing, yaw wrap-around, controller deadband/asymmetry/proportionality, the reverse exception) and model/path invariants (scene compiles and matches `scene_walk.xml`, required bodies and cameras exist, the leader never collides with the robot, the `STAND` keyframe matches the policy's `DEFAULT_POSE`, the gyro resolves by name, and `--policy` is mandatory).

I checked the tests actually have teeth by mutating the source and confirming they fail: flipping the left-turn sign, making the controller symmetric, removing the deadband, removing the reverse exception, zeroing the trail distance, turning the corner into a stationary pivot, replacing the yaw interpolation with a naive lerp, dropping the trail interpolation, and inverting the proportional gain are each caught.

Full suite on this branch: **182 passed, 1 skipped**.

## What is *not* included

- **No ONNX policy committed.** `--policy` is required and has no default.
- **No video or image files committed.**
- **No `pyproject.toml` / `uv.lock` changes** and no new dependencies. The demo uses `mujoco`, `numpy` and `onnxruntime` (already required); Pillow and imageio are needed only for the optional rendering path, which is skipped entirely under `--no-render`.
- **No changes to any existing file** — the PR is purely additive (7 new files).
- **No private or local paths**; the scene path resolves from `__file__`, so the demo runs from any working directory.

## Limitations

I want these read as part of the contribution, not buried:

- **The leader is a scripted semantic actor.** It follows a fixed choreography and its pose is read directly from the simulator. There is **no real person detector**, no tracking from images, and no perception of any kind.
- **Simulation only.** All numbers above are from MuJoCo. There is **no hardware validation**, and nothing here has been run on a real robot.
- **Gaze is isolated render state.** It exists to make the picture-in-picture watchable and never influences locomotion.
- **The policy is unmodified**, so its turning authority — including the left/right asymmetry compensated above — is a fixed constraint rather than something this PR improves.

## Files

| File | Purpose |
|---|---|
| `scripts/behavior_demos/follow_me/scene_follow_me.xml` | Official walking collision model + animated leader, footprint marker, camera rig |
| `scripts/behavior_demos/follow_me/follow_motion.py` | Leader route, world-space trail, asymmetric controller (no MuJoCo/ONNX imports, so it's unit-testable) |
| `scripts/behavior_demos/follow_me/camera_tracking.py` | Isolated gaze + geometric visibility |
| `scripts/behavior_demos/follow_me/video_overlay.py` | HUD, PiP, timeline (rendering only) |
| `scripts/behavior_demos/follow_me/run_follow_me.py` | ONNX rollout + metrics |
| `scripts/behavior_demos/follow_me/README.md` | Usage, design notes, limitations |
| `tests/test_follow_me_demo.py` | 28 CPU tests |

## Open questions

1. Is `scripts/behavior_demos/` welcome here, or would you prefer demos live elsewhere (or outside the repo entirely)?
2. Should the demo scene live next to the other scenes in `src/mjlab_microduck/robot/microduck/` instead? I kept it beside the demo to stay self-contained and avoid touching the robot directory, at the cost of the `meshdir` note above.
3. Happy to trim the HUD/video layer entirely if you'd rather keep the demo headless and dependency-light.

## Demo video

Fresh render from commit `131db5c` (44 s, 2,200 frames at 50 fps, 960×640). It shows the delayed world-space footprint target, both genuine opposite turns, the reverse safety exception, and the stabilized head-camera PiP.

https://github.com/user-attachments/assets/3cba8eae-ee3b-4949-b883-cfef53f6f9f9
