### PR TITLE
Add move-away behavior demo (CPU MuJoCo, stock walking policy)

### DIFF
--- a/scripts/behavior_demos/move_away/README.md
+++ b/scripts/behavior_demos/move_away/README.md
@@ -1,0 +1,144 @@
+# move-away — step aside from an approaching person, without losing sight of them
+
+A **CPU MuJoCo behavior demo**, not robot autonomy. It shows how far a stock
+exported walking policy can be pushed by a small scripted supervisor, and it
+doubles as a rehearsal harness for the velocity-command interface the runtime
+uses.
+
+No new policy is trained. An exported walking ONNX is driven by a velocity
+command produced by a state machine:
+
+```
+IDLE -> RETREAT -> TURN -> CLEAR -> DONE
+```
+
+On top of that, an **independent kinematic gaze layer** aims head yaw/pitch at
+the person for the whole sequence, so the person stays centred in the head
+camera even while the robot turns away from them.
+
+## Running it
+
+The policy is a required argument — no policy is committed to this repository:
+
+```bash
+# headless, metrics only
+python scripts/behavior_demos/move_away/run_demo.py --policy path/to/walking.onnx
+
+# machine-readable summary
+python scripts/behavior_demos/move_away/run_demo.py --policy path/to/walking.onnx --json
+
+# render annotated frames (adds imageio + Pillow)
+python scripts/behavior_demos/move_away/run_demo.py \
+    --policy path/to/walking.onnx --render-dir /tmp/move_away_frames --fps 50
+ffmpeg -framerate 50 -i /tmp/move_away_frames/f%05d.png \
+    -c:v libx264 -pix_fmt yuv420p -movflags +faststart move_away.mp4
+```
+
+The demo uses `src/mjlab_microduck/robot/microduck/scene_move_away.xml`, which is
+`scene.xml` plus a scripted mocap "person" prop.
+
+## Measured behavior
+
+With the stock `alpha_walking` policy, defaults, 22 s:
+
+| metric | value |
+| --- | --- |
+| final state | `DONE`, upright |
+| person visible | 1100 / 1100 control steps (`lost_steps=0`) |
+| max off-axis angle | 2.3° from the camera centre |
+| heading change | +82.8° (90° commanded) |
+| trunk height | z = 0.116 (nominal), min 0.114 |
+
+Also checked: `--turn-sign -1` mirrors the maneuver (−96.5°), a faster person
+(`--person-speed 0.20`) keeps 1100/1100 visibility, and a longer run
+(`--seconds 28`) stays upright at 1400/1400.
+
+## MEASURED constants — do not change blindly
+
+These come from sweeps against this scene and the stock walking policy. They are
+observations, not cosmetic tuning.
+
+- **The backward gait does not engage continuously.** Commanding `vx > -0.30`
+  makes the policy step in place (net displacement < 5 mm over 8 s). Backward
+  walking engages from about `vx = -0.32` and stays upright through at least
+  `-0.45`. `VX_RETREAT = -0.36` sits inside that band.
+- **Heading must be closed-loop in every walking state.** Unopposed, the gait
+  drifts hard: at `vx = -0.36` with `wz = 0` the robot ends 8 s at yaw ≈ −55°.
+  With `YAW_KP = 2.0`, `WZ_MAX = 0.8`, the same command holds heading to ~4–6°.
+- **The `wz` sign is normal** — positive `wz` yields a positive (left) yaw rate —
+  when the policy is fed the real `imu_ang_vel` gyro. See the note below.
+- **The turn converges, so it is tracked rather than cut early.** Commanding a
+  +90° heading offset reaches +84° at 12 s and +87° at 20 s without winding up,
+  so `TURN` exits on a tolerance (`TURN_TOL = 15°`) with `TURN_MAX = 8 s` as a
+  safety fallback.
+- `CMD_TAU = 0.08` — command low-pass. 0.25 is too slow to start the gait.
+- `RETREAT_D = 1.15 m` with the person starting at 1.60 m gives ~1.7 s of margin.
+
+### Read the gyro sensor by name, and check the name
+
+`mujoco.mj_name2id` returns `-1` for an unknown sensor, and `model.sensor_adr[-1]`
+is a **valid index** — the last sensor. So a mistyped sensor name does not raise:
+it silently feeds a completely different quantity into the policy's
+`base_ang_vel` slot.
+
+An earlier version of this demo looked up `imu_gyro`, which does not exist in
+these models, and therefore fed `root_angmom` (subtree angular momentum, kg·m²/s)
+into a slot the policy expects to hold rad/s. The robot still walked and the
+resulting video looked plausible, but every "measured" gait constant derived from
+it described that corrupted observation rather than the robot. `runtime.py`
+therefore resolves the sensor through `sensor_address()`, which raises on an
+unknown name, and `tests/test_move_away_demo.py` locks the behavior in.
+
+## Perception
+
+Perception is a **ray cast** from the head camera to the person, not
+segmentation. Segmentation is unusable here: the camera sits INSIDE the robot's
+own jaw geometry, so every pixel/ray hits `jaw_soft` first and the person is
+never visible. The ray cast skips the robot's own bodies and answers the real
+question — is the person inside the field of view and unoccluded?
+
+**Optical-frame correction.** The `head_camera` quaternion exported in the MJCF
+is `[0 0 -1 0]`, which points the optical `-Z` axis backwards into the robot's
+own CAD while the robot walks towards `+X`; rendering from it shows internal
+geometry. The demo applies a −90° local-Z rotation to the in-memory `MjModel`
+only, so optical `-Z` follows the head's forward axis and `+Y` follows world up.
+This affects rendering and perception only, never physics, and the committed
+MJCF is left untouched.
+
+## Why the gaze layer is kinematic
+
+The head is a large fraction of the robot's mass. Driving it physically while the
+stock walking policy runs makes the robot fall — that policy was never trained to
+compensate an externally imposed head trajectory. So the demo:
+
+1. advances locomotion physics and policy inference in the primary `MjData`,
+   unchanged;
+2. poses head yaw/pitch in a separate `MjData` copy used only for perception and
+   rendering;
+3. never feeds that pose back into the locomotion dynamics.
+
+This mirrors the gaze/locomotion split a real robot would use, and it makes
+explicit that the demo claims no physical head-control stability.
+
+## Limitations
+
+- **The "person" is scripted, not perceived.** It is a mocap prop moving on a
+  fixed straight path, and its position is read from simulator state. There is no
+  detector, no tracker and no real sensing; the visibility test is geometric.
+- **Gaze is kinematic only.** Head pose is applied in an isolated `MjData` copy.
+  This demo makes **no claim** about physical head-control stability while
+  walking, and the numbers above do not support one.
+- **Sim only, CPU only.** Nothing here has been validated on hardware.
+- The constants were measured against one exported walking policy in this scene;
+  another policy will need its own sweep.
+
+## Files
+
+- `controller.py` — the state machine and velocity-command law. Pure Python, no
+  MuJoCo/ONNX, fully unit-tested.
+- `gaze.py` — camera-frame maths and the head visual servo.
+- `perception.py` — field-of-view + ray-cast occlusion test.
+- `runtime.py` — scene path, default pose, observation layout, safe sensor lookup.
+- `run_demo.py` — CLI entry point, simulation loop and optional rendering.
+
+Tests live in `tests/test_move_away_demo.py` and run on CPU without a policy.

--- a/scripts/behavior_demos/move_away/__init__.py
+++ b/scripts/behavior_demos/move_away/__init__.py
@@ -1,0 +1,30 @@
+"""Move-away: a CPU MuJoCo behavior demo built on a stock walking policy."""
+
+from .controller import MoveAwayController, wrap_angle
+from .gaze import GazeState, bearing_elevation, camera_axes, in_frustum
+from .perception import PersonTracker, optical_frame_quat
+from .runtime import (
+    CTRL_HZ,
+    DEFAULT_POSE,
+    GYRO_SENSOR,
+    SCENE_XML,
+    build_observation,
+    sensor_address,
+)
+
+__all__ = [
+    "CTRL_HZ",
+    "DEFAULT_POSE",
+    "GYRO_SENSOR",
+    "SCENE_XML",
+    "GazeState",
+    "MoveAwayController",
+    "PersonTracker",
+    "bearing_elevation",
+    "build_observation",
+    "camera_axes",
+    "in_frustum",
+    "optical_frame_quat",
+    "sensor_address",
+    "wrap_angle",
+]

--- a/scripts/behavior_demos/move_away/controller.py
+++ b/scripts/behavior_demos/move_away/controller.py
@@ -1,0 +1,152 @@
+"""Pure state machine + velocity-command law for the move-away demo.
+
+Deliberately free of MuJoCo, ONNX and numpy so the whole decision layer can be
+unit-tested on CPU without a policy file or a physics step (see
+``tests/test_move_away_demo.py``).
+
+The behaviour is four states:
+
+    IDLE     person not yet close enough / not visible -> stand still
+    RETREAT  walk straight backward, holding the initial heading closed-loop
+    TURN     keep walking backward while tracking a heading offset by TURN_TARGET
+    CLEAR    keep walking backward on the new heading
+    DONE     stop
+
+Everything the demo knows about the gait was MEASURED in this repo against
+``scene_move_away.xml`` + the stock walking policy, driving the policy with the
+``imu_ang_vel`` sensor (see ``README.md`` in this directory for the sweeps).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+# --- measured gait constants -------------------------------------------------
+# The backward gait does NOT engage continuously: commanding vx > -0.30 makes
+# the policy step in place (net displacement < 5 mm over 8 s). Backward walking
+# engages from about vx = -0.32 and stays upright through at least -0.45.
+# -0.36 sits comfortably inside that band.
+VX_RETREAT: float = -0.36
+
+# Heading is held closed-loop in EVERY walking state. Left unopposed the gait
+# drifts: at vx = -0.36 with wz = 0 the robot ends 8 s at yaw = -55 deg. With
+# this controller the same command holds the heading to within ~6 deg.
+# MEASURED: the wz sign is NORMAL (positive wz -> positive/left yaw rate) when
+# the policy is fed the real `imu_ang_vel` gyro.
+YAW_KP: float = 2.0
+WZ_MAX: float = 0.8
+
+# Turn target and the tolerance that counts as "arrived". The heading is tracked
+# as an absolute setpoint rather than cut early: with a real gyro the closed
+# loop converges (+90 deg commanded -> +84 deg at 12 s, +87 deg at 20 s) instead
+# of overshooting, so no early cut is needed.
+TURN_TARGET: float = math.radians(90.0)
+TURN_TOL: float = math.radians(15.0)
+
+# Command low-pass time constant. 0.25 s is too slow to start the gait.
+CMD_TAU: float = 0.08
+
+# Timings.
+RETREAT_HOLD: float = 5.0
+CLEAR_HOLD: float = 2.5
+TURN_MAX: float = 8.0
+
+# Trigger distance. The person is scripted to start at 1.60 m, so the duck
+# reacts with roughly 1.7 s of margin.
+RETREAT_D: float = 1.15
+
+STATES = ("IDLE", "RETREAT", "TURN", "CLEAR", "DONE")
+
+
+def wrap_angle(a: float) -> float:
+    """Wrap an angle to [-pi, pi)."""
+    return (a + math.pi) % (2.0 * math.pi) - math.pi
+
+
+def clamp(value: float, lo: float, hi: float) -> float:
+    return min(max(value, lo), hi)
+
+
+@dataclass
+class MoveAwayController:
+    """State machine producing a ``(vx, vy, wz)`` twist command.
+
+    The controller is driven by :meth:`update`, which takes the measured
+    absolute trunk heading (rad, world frame), the planar distance to the
+    person (m) and whether the person is currently visible.
+    """
+
+    ctrl_hz: float = 50.0
+    retreat_distance: float = RETREAT_D
+    retreat_hold: float = RETREAT_HOLD
+    clear_hold: float = CLEAR_HOLD
+    turn_max: float = TURN_MAX
+    turn_target: float = TURN_TARGET
+    turn_tol: float = TURN_TOL
+    vx_retreat: float = VX_RETREAT
+    yaw_kp: float = YAW_KP
+    wz_max: float = WZ_MAX
+    cmd_tau: float = CMD_TAU
+    turn_sign: float = 1.0
+
+    state: str = "IDLE"
+    state_t: float = 0.0
+    yaw_ref: float | None = None
+    turned: float = 0.0
+    command: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+
+    @property
+    def dt(self) -> float:
+        return 1.0 / self.ctrl_hz
+
+    @property
+    def heading_setpoint(self) -> float:
+        """Absolute heading the controller is currently steering towards."""
+        if self.yaw_ref is None:
+            return 0.0
+        if self.state in ("TURN", "CLEAR"):
+            return self.yaw_ref + self.turn_sign * self.turn_target
+        return self.yaw_ref
+
+    def _transition(self, distance: float, visible: bool) -> None:
+        if self.state == "IDLE":
+            # Detection is line-of-sight AND range, never range alone.
+            if visible and distance < self.retreat_distance:
+                self.state = "RETREAT"
+        elif self.state == "RETREAT":
+            if self.state_t >= self.retreat_hold:
+                self.state = "TURN"
+        elif self.state == "TURN":
+            reached = abs(abs(self.turned) - self.turn_target) <= self.turn_tol
+            if reached or self.state_t >= self.turn_max:
+                self.state = "CLEAR"
+        elif self.state == "CLEAR" and self.state_t >= self.clear_hold:
+            self.state = "DONE"
+
+    def update(self, yaw: float, distance: float, visible: bool) -> tuple[float, float, float]:
+        """Advance one control tick and return the filtered ``(vx, vy, wz)``."""
+        if self.yaw_ref is None:
+            self.yaw_ref = yaw
+        self.turned = wrap_angle(yaw - self.yaw_ref)
+
+        self.state_t += self.dt
+        previous = self.state
+        self._transition(distance, visible)
+        if self.state != previous:
+            self.state_t = 0.0
+
+        if self.state in ("RETREAT", "TURN", "CLEAR"):
+            error = wrap_angle(self.heading_setpoint - yaw)
+            target = [
+                self.vx_retreat,
+                0.0,
+                clamp(self.yaw_kp * error, -self.wz_max, self.wz_max),
+            ]
+        else:
+            target = [0.0, 0.0, 0.0]
+
+        alpha = self.dt / self.cmd_tau
+        for i in range(3):
+            self.command[i] += alpha * (target[i] - self.command[i])
+        return tuple(self.command)  # type: ignore[return-value]

--- a/scripts/behavior_demos/move_away/gaze.py
+++ b/scripts/behavior_demos/move_away/gaze.py
@@ -1,0 +1,115 @@
+"""Isolated kinematic gaze layer for the move-away demo.
+
+Why this is kinematic and not physical
+--------------------------------------
+The head is a large fraction of microduck's mass. Driving it physically while
+the stock walking policy is running makes the robot fall: that policy was never
+trained to compensate an externally imposed head trajectory. So this layer:
+
+1. leaves locomotion physics and policy inference untouched in the primary
+   ``MjData``;
+2. poses head yaw/pitch in a SEPARATE ``MjData`` copy used only for perception
+   and rendering;
+3. never feeds that pose back into the locomotion dynamics.
+
+That mirrors the gaze/locomotion split a real robot would use, and it makes
+clear that this demo claims NO physical head-control stability.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+# Keep the commanded joint angles this far from their hard limits.
+HEAD_YAW_MARGIN: float = math.radians(3.0)
+HEAD_PITCH_MARGIN: float = math.radians(5.0)
+
+
+def camera_axes(cam_xmat: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``(forward, right, up)`` for a MuJoCo camera rotation matrix.
+
+    MuJoCo cameras look down their local ``-Z`` with local ``+Y`` as image-up.
+    """
+    rot = np.asarray(cam_xmat, dtype=np.float64).reshape(3, 3)
+    return -rot[:, 2], rot[:, 0], rot[:, 1]
+
+
+def bearing_elevation(
+    to_target: np.ndarray,
+    forward: np.ndarray,
+    right: np.ndarray,
+    up: np.ndarray,
+) -> tuple[float, float]:
+    """Angles from the optical axis to ``to_target``.
+
+    Returns ``(bearing, elevation)`` in radians, bearing positive to the
+    camera's LEFT so it can be added directly to a yaw joint.
+    """
+    vec = np.asarray(to_target, dtype=np.float64)
+    norm = float(np.linalg.norm(vec))
+    unit = vec / norm if norm > 1e-9 else vec
+    fwd = float(np.dot(unit, forward))
+    bearing = math.atan2(-float(np.dot(unit, right)), fwd)
+    elevation = math.atan2(float(np.dot(unit, up)), fwd)
+    return bearing, elevation
+
+
+def in_frustum(
+    to_target: np.ndarray,
+    forward: np.ndarray,
+    right: np.ndarray,
+    up: np.ndarray,
+    tan_half_h: float,
+    tan_half_v: float,
+) -> bool:
+    """True when ``to_target`` falls inside the camera's rectangular frustum."""
+    vec = np.asarray(to_target, dtype=np.float64)
+    depth = float(np.dot(vec, forward))
+    if depth <= 0.0:
+        return False
+    return (
+        abs(float(np.dot(vec, right))) <= depth * tan_half_h
+        and abs(float(np.dot(vec, up))) <= depth * tan_half_v
+    )
+
+
+@dataclass
+class GazeState:
+    """Head yaw/pitch setpoints for the isolated gaze layer.
+
+    ``yaw_limits`` / ``pitch_limits`` are the model's joint ranges; the
+    setpoints are kept a margin away from them so the render never shows a
+    joint jammed against a hard stop.
+    """
+
+    yaw: float
+    pitch: float
+    yaw_limits: tuple[float, float]
+    pitch_limits: tuple[float, float]
+    tau: float = 0.02
+    dt: float = 0.02
+
+    def step(self, bearing: float, elevation: float) -> tuple[float, float]:
+        """Servo the head towards a target at ``(bearing, elevation)``.
+
+        Both angles are measured from the CURRENT optical axis, so this is a
+        relative visual-servo correction rather than an absolute pointing
+        command.
+        """
+        yaw_lo, yaw_hi = self.yaw_limits
+        pitch_lo, pitch_hi = self.pitch_limits
+        desired_yaw = min(
+            max(self.yaw + bearing, yaw_lo + HEAD_YAW_MARGIN), yaw_hi - HEAD_YAW_MARGIN
+        )
+        # A positive head_pitch command points the camera DOWN, hence the minus.
+        desired_pitch = min(
+            max(self.pitch - elevation, pitch_lo + HEAD_PITCH_MARGIN),
+            pitch_hi - HEAD_PITCH_MARGIN,
+        )
+        alpha = min(1.0, self.dt / self.tau) if self.tau > 0.0 else 1.0
+        self.yaw += alpha * (desired_yaw - self.yaw)
+        self.pitch += alpha * (desired_pitch - self.pitch)
+        return self.yaw, self.pitch

--- a/scripts/behavior_demos/move_away/perception.py
+++ b/scripts/behavior_demos/move_away/perception.py
@@ -1,0 +1,134 @@
+"""Head-camera perception for the move-away demo.
+
+Perception is a RAY CAST from the head camera to the person, not segmentation
+rendering. Segmentation is unusable here: the camera sits INSIDE the robot's own
+jaw geometry, so every pixel/ray hits ``jaw_soft`` first and the person is never
+visible. The ray cast skips the robot's own bodies and answers the question that
+actually matters: is the person inside the field of view AND unoccluded?
+"""
+
+from __future__ import annotations
+
+import math
+
+import mujoco
+import numpy as np
+
+from .gaze import bearing_elevation, camera_axes, in_frustum
+
+# Small step so the first ray starts off the camera site itself.
+SELF_SKIP = 0.02
+# Maximum self-geometry hits to walk through before giving up.
+MAX_RAY_STEPS = 8
+
+
+def body_subtree(model: mujoco.MjModel, root: int) -> set[int]:
+    """All body ids in the subtree rooted at ``root`` (inclusive)."""
+    subtree = {root}
+    for body in range(model.nbody):
+        parent = body
+        while parent > 0:
+            if parent == root:
+                subtree.add(body)
+                break
+            parent = model.body_parentid[parent]
+    return subtree
+
+
+def optical_frame_quat() -> np.ndarray:
+    """The -90 deg local-Z rotation that fixes the exported head camera.
+
+    The ``head_camera`` quaternion exported by the upstream MJCF is
+    ``[0 0 -1 0]``, which points the optical ``-Z`` axis along world ``-X`` —
+    backwards, into the robot's own CAD — while the robot walks towards ``+X``.
+    Rendering from it shows internal geometry instead of the scene ahead.
+
+    This correction makes optical ``-Z`` follow the head's forward axis and
+    ``+Y`` follow world up. It is applied to the demo's in-memory ``MjModel``
+    only: it changes rendering and perception, never physics, and it does not
+    modify the committed MJCF.
+    """
+    return np.array([math.sqrt(0.5), 0.0, 0.0, -math.sqrt(0.5)], dtype=np.float64)
+
+
+class PersonTracker:
+    """Field-of-view + occlusion test for the scripted person prop."""
+
+    def __init__(
+        self,
+        model: mujoco.MjModel,
+        camera_name: str = "head_camera",
+        person_body: str = "person",
+        robot_root_body: str = "trunk_base",
+        aspect: float = 1.0,
+    ) -> None:
+        self.model = model
+        self.camera_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, camera_name)
+        if self.camera_id < 0:
+            raise ValueError(f"camera {camera_name!r} not found in the model")
+        person_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, person_body)
+        if person_id < 0:
+            raise ValueError(f"body {person_body!r} not found in the model")
+        root_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, robot_root_body)
+        if root_id < 0:
+            raise ValueError(f"body {robot_root_body!r} not found in the model")
+
+        self.person_body_id = person_id
+        self.person_mocap_id = int(model.body_mocapid[person_id])
+        if self.person_mocap_id < 0:
+            raise ValueError(f"body {person_body!r} is not a mocap body")
+        self.person_tree = body_subtree(model, person_id)
+        self.self_bodies = body_subtree(model, root_id)
+
+        half_v = math.radians(float(model.cam_fovy[self.camera_id])) * 0.5
+        self.tan_half_v = math.tan(half_v)
+        self.tan_half_h = aspect * self.tan_half_v
+
+    def look(self, data: mujoco.MjData) -> dict:
+        """Evaluate visibility of the person from the current camera pose."""
+        eye = data.cam_xpos[self.camera_id].copy()
+        forward, right, up = camera_axes(data.cam_xmat[self.camera_id])
+        to_person = data.mocap_pos[self.person_mocap_id].copy() - eye
+        distance = float(np.linalg.norm(to_person))
+        unit = to_person / max(distance, 1e-9)
+
+        visible_in_fov = in_frustum(
+            to_person, forward, right, up, self.tan_half_h, self.tan_half_v
+        )
+        bearing, elevation = bearing_elevation(to_person, forward, right, up)
+        off_axis = math.acos(float(np.clip(np.dot(unit, forward), -1.0, 1.0)))
+
+        occluded = False
+        if visible_in_fov:
+            occluded = self._occluded(data, eye, unit, distance)
+
+        return {
+            "visible": visible_in_fov and not occluded,
+            "in_fov": visible_in_fov,
+            "occluded": occluded,
+            "distance": distance,
+            "bearing": bearing,
+            "elevation": elevation,
+            "off_axis": off_axis,
+        }
+
+    def _occluded(
+        self, data: mujoco.MjData, eye: np.ndarray, unit: np.ndarray, distance: float
+    ) -> bool:
+        geom_id = np.zeros(1, dtype=np.int32)
+        travelled = SELF_SKIP
+        for _ in range(MAX_RAY_STEPS):
+            origin = eye + unit * travelled
+            hit = mujoco.mj_ray(self.model, data, origin, unit, None, 1, -1, geom_id)
+            if geom_id[0] < 0 or hit < 0.0:
+                return False  # clear line of sight
+            body = int(self.model.geom_bodyid[int(geom_id[0])])
+            if body in self.person_tree:
+                return False  # we can see them
+            if body in self.self_bodies:
+                travelled += hit + 0.005  # our own head: step past it
+                if travelled >= distance:
+                    return False
+                continue
+            return travelled + hit < distance - 0.02
+        return False

--- a/scripts/behavior_demos/move_away/run_demo.py
+++ b/scripts/behavior_demos/move_away/run_demo.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Move aside from an approaching person without losing sight of them.
+
+A CPU MuJoCo behavior demo. No new policy is trained: a stock exported walking
+policy is driven by a velocity command produced by a small state machine, and an
+independent kinematic gaze layer keeps the person centred in the head camera.
+
+    IDLE -> RETREAT -> TURN -> CLEAR -> DONE
+
+Run it headless (metrics only) or render frames:
+
+    python scripts/behavior_demos/move_away/run_demo.py --policy path/to/walking.onnx
+    python scripts/behavior_demos/move_away/run_demo.py \
+        --policy path/to/walking.onnx --render-dir /tmp/move_away_frames
+
+Rendering additionally needs `imageio` and `Pillow`, which the demo imports
+lazily so the headless path stays dependency-light.
+
+See README.md in this directory for the measured constants and the limitations
+this demo does NOT claim to have solved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+if __package__ in (None, ""):  # allow `python scripts/behavior_demos/move_away/run_demo.py`
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from move_away.controller import MoveAwayController
+    from move_away.gaze import GazeState
+    from move_away.perception import PersonTracker, optical_frame_quat
+    from move_away.runtime import (
+        CTRL_HZ,
+        DEFAULT_POSE,
+        GYRO_SENSOR,
+        HEAD_PITCH_ACT,
+        HEAD_YAW_ACT,
+        SCENE_XML,
+        actuator_indices,
+        build_observation,
+        quat_rotate_inverse,
+        sensor_address,
+    )
+else:
+    from .controller import MoveAwayController
+    from .gaze import GazeState
+    from .perception import PersonTracker, optical_frame_quat
+    from .runtime import (
+        CTRL_HZ,
+        DEFAULT_POSE,
+        GYRO_SENSOR,
+        HEAD_PITCH_ACT,
+        HEAD_YAW_ACT,
+        SCENE_XML,
+        actuator_indices,
+        build_observation,
+        quat_rotate_inverse,
+        sensor_address,
+    )
+
+PIP_W, PIP_H = 225, 165
+NOMINAL_TRUNK_Z = 0.116
+FALLEN_TRUNK_Z = 0.09
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--policy",
+        required=True,
+        type=Path,
+        help="Path to an exported walking policy (.onnx). Required: no policy "
+        "is bundled with the repository.",
+    )
+    parser.add_argument("--scene", type=Path, default=SCENE_XML, help="Scene XML to load.")
+    parser.add_argument("--seconds", type=float, default=22.0, help="Simulated duration.")
+    parser.add_argument("--person-speed", type=float, default=0.12, help="Person speed (m/s).")
+    parser.add_argument("--person-x0", type=float, default=1.60, help="Person start x (m).")
+    parser.add_argument("--warmup", type=float, default=1.5, help="Seconds before the person moves.")
+    parser.add_argument("--turn-sign", type=float, default=1.0, help="+1 turns left, -1 right.")
+    parser.add_argument("--render-dir", type=Path, default=None, help="Write PNG frames here.")
+    parser.add_argument("--fps", type=int, default=50, help="Frame rate when rendering.")
+    parser.add_argument("--width", type=int, default=960, help="Render width.")
+    parser.add_argument("--height", type=int, default=640, help="Render height.")
+    parser.add_argument("--json", action="store_true", help="Print the summary as JSON.")
+    parser.add_argument("--quiet", action="store_true", help="Suppress per-second progress.")
+    return parser.parse_args(argv)
+
+
+def run(args: argparse.Namespace) -> dict:
+    """Run the behavior and return a summary dict of measured outcomes."""
+    import onnxruntime as ort
+
+    if not args.policy.is_file():
+        raise SystemExit(f"policy not found: {args.policy}")
+    if not args.scene.is_file():
+        raise SystemExit(f"scene not found: {args.scene}")
+
+    model = mujoco.MjModel.from_xml_path(str(args.scene))
+    data = mujoco.MjData(model)
+    gaze_data = mujoco.MjData(model)  # isolated kinematic head-tracking state
+    mujoco.mj_resetData(model, data)
+
+    nu = model.nu
+    qpos_idx, qvel_idx = actuator_indices(model)
+    gyro_adr = sensor_address(model, GYRO_SENSOR)
+    trunk = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "trunk_base")
+    head_yaw_joint = int(model.actuator_trnid[HEAD_YAW_ACT, 0])
+    head_pitch_joint = int(model.actuator_trnid[HEAD_PITCH_ACT, 0])
+
+    # Fix the exported camera's optical frame in memory only (never on disk).
+    head_cam = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, "head_camera")
+    model.cam_quat[head_cam] = optical_frame_quat()
+
+    tracker = PersonTracker(model, aspect=PIP_W / PIP_H)
+
+    for slot, value in enumerate(qpos_idx):
+        data.qpos[value] = DEFAULT_POSE[slot]
+    data.ctrl[:] = DEFAULT_POSE[:nu]
+    mujoco.mj_forward(model, data)
+
+    session = ort.InferenceSession(str(args.policy), providers=["CPUExecutionProvider"])
+    in_name = session.get_inputs()[0].name
+    out_name = session.get_outputs()[0].name
+    obs_dim = int(session.get_inputs()[0].shape[1])
+    command_dim = obs_dim - (3 + 3 + nu * 3)
+    if command_dim < 3:
+        raise SystemExit(
+            f"policy expects a {obs_dim}D observation, which leaves no room for a "
+            f"3D twist command with {nu} actuated joints"
+        )
+
+    controller = MoveAwayController(ctrl_hz=CTRL_HZ, turn_sign=args.turn_sign)
+    gaze = GazeState(
+        yaw=float(DEFAULT_POSE[HEAD_YAW_ACT]),
+        pitch=float(DEFAULT_POSE[HEAD_PITCH_ACT]),
+        yaw_limits=tuple(model.jnt_range[head_yaw_joint]),
+        pitch_limits=tuple(model.jnt_range[head_pitch_joint]),
+        tau=1.0 / CTRL_HZ,
+        dt=1.0 / CTRL_HZ,
+    )
+
+    last_action = np.zeros(nu, dtype=np.float32)
+    decimation = max(1, round((1.0 / CTRL_HZ) / model.opt.timestep))
+    total_steps = int(args.seconds * CTRL_HZ)
+    frame_every = max(1, round(CTRL_HZ / args.fps))
+
+    renderer = pip_renderer = camera = None
+    if args.render_dir is not None:
+        renderer, pip_renderer, camera = _make_renderers(model, args)
+
+    lost_steps = 0
+    max_off_axis = 0.0
+    min_trunk_z = float("inf")
+    transitions: list[dict] = []
+    frames = 0
+
+    for step in range(total_steps):
+        t = step / CTRL_HZ
+
+        # The person walks straight in from +x and keeps coming. The robot's
+        # forward axis (and therefore its head camera) faces +x.
+        moving_for = max(0.0, t - args.warmup)
+        data.mocap_pos[tracker.person_mocap_id][0] = args.person_x0 - args.person_speed * moving_for
+
+        # --- isolated kinematic gaze layer --------------------------------
+        # Copy the physical state, pose the head THERE, and use that copy for
+        # perception and rendering only. The walking policy keeps its original
+        # head dynamics, which is what keeps it upright.
+        mujoco.mj_copyData(gaze_data, model, data)
+        gaze_data.qpos[qpos_idx[HEAD_PITCH_ACT]] = gaze.pitch
+        gaze_data.qpos[qpos_idx[HEAD_YAW_ACT]] = gaze.yaw
+        mujoco.mj_forward(model, gaze_data)
+
+        pre = tracker.look(gaze_data)
+        gaze.step(pre["bearing"], pre["elevation"])
+        gaze_data.qpos[qpos_idx[HEAD_PITCH_ACT]] = gaze.pitch
+        gaze_data.qpos[qpos_idx[HEAD_YAW_ACT]] = gaze.yaw
+        mujoco.mj_forward(model, gaze_data)
+
+        view = tracker.look(gaze_data)
+        if not view["visible"]:
+            lost_steps += 1
+        max_off_axis = max(max_off_axis, view["off_axis"])
+
+        # --- heading: ABSOLUTE, never integrated ---------------------------
+        forward = data.xmat[trunk].reshape(3, 3)[:, 0]
+        yaw = math.atan2(forward[1], forward[0])
+
+        planar = data.mocap_pos[tracker.person_mocap_id][:2] - data.xpos[trunk][:2]
+        distance = float(np.linalg.norm(planar))
+
+        previous_state = controller.state
+        twist = controller.update(yaw, distance, view["visible"])
+        if controller.state != previous_state:
+            transitions.append(
+                {
+                    "t": round(t, 2),
+                    "from": previous_state,
+                    "to": controller.state,
+                    "distance": round(distance, 3),
+                    "turned_deg": round(math.degrees(controller.turned), 1),
+                }
+            )
+            if not args.quiet:
+                print(
+                    f"  t={t:5.2f}s  {previous_state} -> {controller.state}"
+                    f"  (dist={distance:.3f} turned={math.degrees(controller.turned):+.1f} deg)"
+                )
+
+        gyro = data.sensordata[gyro_adr : gyro_adr + 3].astype(np.float32)
+        quat = data.xquat[trunk].astype(np.float32)
+        gravity = quat_rotate_inverse(quat, np.array([0.0, 0.0, -1.0], dtype=np.float32))
+        joint_pos = data.qpos[qpos_idx].astype(np.float32) - DEFAULT_POSE[:nu]
+        joint_vel = data.qvel[qvel_idx].astype(np.float32)
+
+        obs = build_observation(
+            gyro,
+            gravity,
+            joint_pos,
+            joint_vel,
+            last_action,
+            np.asarray(twist, dtype=np.float32),
+            command_dim,
+        )
+        action = session.run([out_name], {in_name: obs.reshape(1, -1)})[0]
+        action = action.squeeze(0).astype(np.float32)
+        last_action = action.copy()
+        data.ctrl[:] = DEFAULT_POSE[:nu] + action
+
+        for _ in range(decimation):
+            mujoco.mj_step(model, data)
+            min_trunk_z = min(min_trunk_z, float(data.xpos[trunk][2]))
+
+        if renderer is not None and step % frame_every == 0:
+            _render_frame(
+                model,
+                data,
+                gaze_data,
+                gaze,
+                qpos_idx,
+                renderer,
+                pip_renderer,
+                camera,
+                trunk,
+                tracker,
+                head_cam,
+                controller,
+                view,
+                twist,
+                t,
+                distance,
+                yaw,
+                args,
+                frames,
+            )
+            frames += 1
+
+        if not args.quiet and step % int(CTRL_HZ) == 0:
+            pos = data.xpos[trunk]
+            print(
+                f"  t={t:5.1f}s {controller.state:7s} d={distance:.3f} "
+                f"turned={math.degrees(controller.turned):+7.1f} deg "
+                f"pos=({pos[0]:+.3f},{pos[1]:+.3f},{pos[2]:.3f}) "
+                f"cmd=(vx={twist[0]:+.2f}, wz={twist[2]:+.2f}) "
+                f"sees={'Y' if view['visible'] else 'N'}"
+            )
+
+    position = data.xpos[trunk]
+    return {
+        "final_state": controller.state,
+        "turned_deg": round(math.degrees(controller.turned), 1),
+        "final_position": [round(float(v), 3) for v in position],
+        "trunk_z": round(float(position[2]), 3),
+        "min_trunk_z": round(min_trunk_z, 3),
+        "upright": bool(position[2] > FALLEN_TRUNK_Z),
+        "control_steps": total_steps,
+        "visible_steps": total_steps - lost_steps,
+        "lost_steps": lost_steps,
+        "max_off_axis_deg": round(math.degrees(max_off_axis), 1),
+        "frames": frames,
+        "transitions": transitions,
+    }
+
+
+def _make_renderers(model: mujoco.MjModel, args: argparse.Namespace):
+    """Build the main renderer, the duck's-eye PiP renderer and the camera.
+
+    A separate ``Renderer`` is needed for the inset because each one caches its
+    framebuffer size.
+    """
+    args.render_dir.mkdir(parents=True, exist_ok=True)
+    renderer = mujoco.Renderer(model, height=args.height, width=args.width)
+    pip_renderer = mujoco.Renderer(model, height=PIP_H, width=PIP_W)
+    camera = mujoco.MjvCamera()
+    mujoco.mjv_defaultCamera(camera)
+    camera.distance = 1.9
+    camera.elevation = -16
+    camera.azimuth = 128
+    return renderer, pip_renderer, camera
+
+
+def _render_frame(
+    model,
+    data,
+    gaze_data,
+    gaze,
+    qpos_idx,
+    renderer,
+    pip_renderer,
+    camera,
+    trunk,
+    tracker,
+    head_cam,
+    controller,
+    view,
+    twist,
+    t,
+    distance,
+    yaw,
+    args,
+    frame_index,
+) -> None:
+    """Write one annotated PNG frame with a duck's-eye picture-in-picture."""
+    import imageio.v2 as imageio
+    from PIL import Image, ImageDraw
+
+    mujoco.mj_copyData(gaze_data, model, data)
+    gaze_data.qpos[qpos_idx[HEAD_PITCH_ACT]] = gaze.pitch
+    gaze_data.qpos[qpos_idx[HEAD_YAW_ACT]] = gaze.yaw
+    mujoco.mj_forward(model, gaze_data)
+
+    person = data.mocap_pos[tracker.person_mocap_id]
+    camera.lookat[:] = 0.5 * (data.xpos[trunk] + person)
+    renderer.update_scene(gaze_data, camera=camera)
+    image = Image.fromarray(renderer.render())
+    draw = ImageDraw.Draw(image)
+
+    visible = view["visible"]
+    ok = (120, 255, 140)
+    bad = (255, 120, 120)
+    trunk_z = float(data.xpos[trunk][2])
+    label = {
+        "IDLE": "IDLE - standing, watching",
+        "RETREAT": "RETREAT - walking BACKWARD, holding heading",
+        "TURN": "TURN - walking backward + turning",
+        "CLEAR": "CLEAR - backward on the new heading",
+        "DONE": "DONE - stopped",
+    }[controller.state]
+
+    draw.rectangle([0, 0, args.width, 114], fill=(0, 0, 0))
+    draw.text((10, 6), f"t={t:6.2f}s   {label}", fill=(255, 255, 0))
+    draw.text(
+        (10, 24),
+        f"person dist={distance:.3f} m   SEES PERSON: {'YES' if visible else 'NO '}"
+        f"  (off-axis {math.degrees(view['off_axis']):.0f} deg)"
+        + ("" if visible else "  << OUT OF VIEW / OCCLUDED"),
+        fill=ok if visible else bad,
+    )
+    draw.text(
+        (10, 42),
+        f"CMD   vx={twist[0]:+.3f} (neg=backward)   wz={twist[2]:+.3f}",
+        fill=(255, 255, 255),
+    )
+    draw.text(
+        (10, 60),
+        f"heading={math.degrees(yaw):+7.1f} deg   "
+        f"turned {math.degrees(controller.turned):+6.1f} / "
+        f"{math.degrees(controller.turn_target):.0f} deg",
+        fill=(255, 255, 255),
+    )
+    draw.text(
+        (10, 78),
+        f"trunk z={trunk_z:.3f} (nominal {NOMINAL_TRUNK_Z:.3f})  "
+        f"{'*** FALLEN ***' if trunk_z < FALLEN_TRUNK_Z else 'upright'}",
+        fill=bad if trunk_z < FALLEN_TRUNK_Z else ok,
+    )
+    draw.text(
+        (10, 96),
+        "gaze is KINEMATIC and isolated - it does not drive the walking policy",
+        fill=(170, 170, 170),
+    )
+
+    # Duck's-eye PiP: literally what the head camera sees.
+    pip_renderer.update_scene(gaze_data, camera=head_cam)
+    pip = Image.fromarray(pip_renderer.render())
+    x0, y0 = args.width - PIP_W - 12, 124
+    draw.rectangle([x0 - 3, y0 - 20, x0 + PIP_W + 3, y0 + PIP_H + 3], fill=(0, 0, 0))
+    draw.text((x0, y0 - 17), "DUCK'S-EYE VIEW (head camera)", fill=ok if visible else bad)
+    image.paste(pip, (x0, y0))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle(
+        [x0 - 1, y0 - 1, x0 + PIP_W, y0 + PIP_H],
+        outline=ok if visible else bad,
+        width=2,
+    )
+
+    imageio.imwrite(str(args.render_dir / f"f{frame_index:05d}.png"), np.asarray(image))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = run(args)
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(
+            f"final_state={summary['final_state']} "
+            f"turned={summary['turned_deg']:+.1f}deg "
+            f"trunk_z={summary['trunk_z']:.3f} "
+            f"({'upright' if summary['upright'] else 'FALLEN'}) "
+            f"visible={summary['visible_steps']}/{summary['control_steps']} "
+            f"max_off_axis={summary['max_off_axis_deg']:.1f}deg "
+            f"frames={summary['frames']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/behavior_demos/move_away/runtime.py
+++ b/scripts/behavior_demos/move_away/runtime.py
@@ -1,0 +1,108 @@
+"""Scene/policy plumbing for the move-away demo.
+
+Holds the pieces that must agree with the rest of the repo: where the scene
+lives, the default pose, and the observation layout the exported ONNX policies
+expect.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+# Repo root is four levels up: scripts/behavior_demos/move_away/<this file>.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCENE_XML = (
+    REPO_ROOT
+    / "src"
+    / "mjlab_microduck"
+    / "robot"
+    / "microduck"
+    / "scene_move_away.xml"
+)
+
+# Control rate the policies are trained and deployed at.
+CTRL_HZ = 50.0
+
+# The gyro observation MUST come from this sensor. `mj_name2id` returns -1 for
+# an unknown name, and `model.sensor_adr[-1]` is a VALID index (the last
+# sensor), so a typo here does not raise — it silently feeds a different
+# quantity into the policy. That failure mode produced a plausible-looking but
+# wrong demo, so the name is asserted at load time.
+GYRO_SENSOR = "imu_ang_vel"
+
+# STAND2 pose, identical to HOME_FRAME in microduck_constants.py and to the
+# STAND keyframe in the scenes. Actions are offsets from this pose and joint
+# observations are relative to it.
+DEFAULT_POSE = np.array(
+    [
+        0.0,  # left_hip_yaw
+        -0.0873,  # left_hip_roll
+        -0.4579,  # left_hip_pitch
+        -0.0049,  # left_knee
+        0.4530,  # left_ankle
+        0.3491,  # neck_pitch
+        0.3491,  # head_pitch
+        0.0,  # head_yaw
+        0.0,  # head_roll
+        0.0,  # right_hip_yaw
+        0.0873,  # right_hip_roll
+        0.4579,  # right_hip_pitch
+        0.0049,  # right_knee
+        -0.4530,  # right_ankle
+    ],
+    dtype=np.float32,
+)
+
+HEAD_PITCH_ACT = 6
+HEAD_YAW_ACT = 7
+
+
+def quat_rotate_inverse(quat: np.ndarray, vec: np.ndarray) -> np.ndarray:
+    """Rotate ``vec`` by the inverse of quaternion ``[w, x, y, z]``."""
+    w = quat[0]
+    xyz = quat[1:4]
+    t = np.cross(xyz, vec) * 2.0
+    return vec - w * t + np.cross(xyz, t)
+
+
+def sensor_address(model: mujoco.MjModel, name: str) -> int:
+    """Resolve a sensor's address, refusing to silently accept a bad name."""
+    sensor_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, name)
+    if sensor_id < 0:
+        raise ValueError(f"sensor {name!r} not found in the model")
+    return int(model.sensor_adr[sensor_id])
+
+
+def actuator_indices(model: mujoco.MjModel) -> tuple[list[int], list[int]]:
+    """qpos and qvel indices of every actuated joint, in actuator order."""
+    qpos_idx = [int(model.jnt_qposadr[model.actuator_trnid[i, 0]]) for i in range(model.nu)]
+    qvel_idx = [int(model.jnt_dofadr[model.actuator_trnid[i, 0]]) for i in range(model.nu)]
+    return qpos_idx, qvel_idx
+
+
+def build_observation(
+    gyro: np.ndarray,
+    projected_gravity: np.ndarray,
+    joint_pos_rel: np.ndarray,
+    joint_vel: np.ndarray,
+    last_action: np.ndarray,
+    twist: np.ndarray,
+    command_dim: int,
+) -> np.ndarray:
+    """Assemble the actor observation vector.
+
+    Layout (must match the exported policy):
+    ``[base_ang_vel(3), projected_gravity(3), joint_pos(14), joint_vel(14),
+    last_action(14), command(command_dim)]``. The command block is
+    ``[twist(3), head_pose(4), body_pose(6)]`` on 61D policies; this demo only
+    writes the twist slot and ZERO-PADS the rest, which is the documented
+    convention for a task that does not use a slot.
+    """
+    command = np.zeros(command_dim, dtype=np.float32)
+    command[0:3] = twist
+    return np.concatenate(
+        [gyro, projected_gravity, joint_pos_rel, joint_vel, last_action, command]
+    ).astype(np.float32)

--- a/src/mjlab_microduck/robot/microduck/scene_move_away.xml
+++ b/src/mjlab_microduck/robot/microduck/scene_move_away.xml
@@ -1,0 +1,70 @@
+<mujoco model="scene_move_away">
+    <!-- scene.xml + a scripted "person" prop, used by the move-away behavior
+         demo (scripts/behavior_demos/move_away/). The person is a MOCAP body:
+         kinematically scripted by the demo script and never dynamically
+         simulated, so it walks its path regardless of what the robot does, and
+         it adds no degrees of freedom (nq is unchanged, so the keyframes below
+         stay valid). Its geoms are contype/conaffinity="0" — it is a visual and
+         ray-cast target only, it cannot push the robot over. -->
+    <include file="robot_allcollisions.xml" />
+
+    <visual>
+        <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
+        <rgba haze="0.15 0.25 0.35 1" />
+        <global azimuth="160" elevation="-20" offwidth="1280" offheight="960" />
+    </visual>
+
+    <asset>
+        <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512"
+            height="3072" />
+        <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4"
+            rgb2="0.1 0.2 0.3"
+            markrgb="0.8 0.8 0.8" width="300" height="300" />
+        <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5"
+            reflectance="0.2" />
+        <material name="skinmat" rgba="0.85 0.65 0.5 1" />
+        <material name="shirtmat" rgba="0.2 0.35 0.7 1" />
+        <material name="boxmat" rgba="0.75 0.55 0.3 1" />
+    </asset>
+
+    <worldbody>
+        <light pos="0 0 3.5" dir="0 0 -1" directional="true" />
+        <geom name="floor" size="0 0 0.05" pos="0 0 0" type="plane" material="groundplane" />
+
+        <!-- Scaled to the robot's world (its trunk sits at z=0.12), so this
+             stand-in is ~0.75 m tall rather than human-sized. -->
+        <body name="person" mocap="true" pos="1.6 0 0.36">
+            <geom name="person_torso" type="capsule" fromto="0 0 -0.10 0 0 0.16"
+                  size="0.075" material="shirtmat" contype="0" conaffinity="0" />
+            <geom name="person_head" type="sphere" pos="0 0 0.25" size="0.062"
+                  material="skinmat" contype="0" conaffinity="0" />
+            <geom name="person_leg_l" type="capsule" fromto="0 0.035 -0.10 0 0.045 -0.36"
+                  size="0.032" material="shirtmat" contype="0" conaffinity="0" />
+            <geom name="person_leg_r" type="capsule" fromto="0 -0.035 -0.10 0 -0.045 -0.36"
+                  size="0.032" material="shirtmat" contype="0" conaffinity="0" />
+            <!-- a carried box, held out in front at chest height -->
+            <geom name="person_box" type="box" pos="-0.16 0 0.02" size="0.10 0.13 0.09"
+                  material="boxmat" contype="0" conaffinity="0" />
+            <geom name="person_arm_l" type="capsule" fromto="0 0.07 0.10 -0.12 0.09 0.04"
+                  size="0.026" material="skinmat" contype="0" conaffinity="0" />
+            <geom name="person_arm_r" type="capsule" fromto="0 -0.07 0.10 -0.12 -0.09 0.04"
+                  size="0.026" material="skinmat" contype="0" conaffinity="0" />
+        </body>
+    </worldbody>
+
+    <keyframe>
+        <key name="INIT" qpos="0 0 0.12 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0" ctrl="0 0 0 0 0 0 0 0 0 0 0 0 0 0"/>
+        <!-- STAND2 pose, identical to scene.xml (matches HOME_FRAME). -->
+        <key name="STAND" qpos="
+        0 0 0.12 1 0 0 0
+
+        0 -0.08726646259971647 -0.457924 -0.004940 0.452984
+        0.3490658503988659 0.3490658503988659 0 0
+        0 0.08726646259971647 0.457924 0.004940 -0.452984"
+         ctrl="
+        0 -0.08726646259971647 -0.457924 -0.004940 0.452984
+        0.3490658503988659 0.3490658503988659 0 0
+        0 0.08726646259971647 0.457924 0.004940 -0.452984"
+        />
+    </keyframe>
+</mujoco>

--- a/tests/test_move_away_demo.py
+++ b/tests/test_move_away_demo.py
@@ -1,0 +1,372 @@
+"""CPU tests for the move-away behavior demo.
+
+These cover the pure decision/control layer and the model invariants the demo
+relies on. None of them needs a policy file, a GPU, or a rendering context: the
+state machine and gaze maths are plain Python/numpy, and the model checks only
+compile the MJCF.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import pytest
+
+# The demo lives under scripts/, which is not an installed package.
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts" / "behavior_demos"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from move_away.controller import (
+    RETREAT_D,
+    VX_RETREAT,
+    WZ_MAX,
+    MoveAwayController,
+    wrap_angle,
+)
+from move_away.gaze import (
+    HEAD_PITCH_MARGIN,
+    HEAD_YAW_MARGIN,
+    GazeState,
+    bearing_elevation,
+    camera_axes,
+    in_frustum,
+)
+from move_away.perception import body_subtree, optical_frame_quat
+from move_away.runtime import (
+    DEFAULT_POSE,
+    GYRO_SENSOR,
+    HEAD_PITCH_ACT,
+    HEAD_YAW_ACT,
+    SCENE_XML,
+    build_observation,
+    sensor_address,
+)
+
+# --- state machine -----------------------------------------------------------
+
+
+def _drive(controller, steps, yaw=0.0, distance=5.0, visible=True):
+    """Run the controller for `steps` ticks at a fixed observation."""
+    out = None
+    for _ in range(steps):
+        out = controller.update(yaw, distance, visible)
+    return out
+
+
+def test_idle_until_person_is_close_and_visible():
+    c = MoveAwayController()
+    _drive(c, 10, distance=RETREAT_D + 0.2)
+    assert c.state == "IDLE"
+    # Close enough but NOT visible must not trigger: detection is
+    # line-of-sight AND range, never range alone.
+    _drive(c, 10, distance=RETREAT_D - 0.2, visible=False)
+    assert c.state == "IDLE"
+    _drive(c, 1, distance=RETREAT_D - 0.2, visible=True)
+    assert c.state == "RETREAT"
+
+
+def test_full_state_sequence_is_reached_in_order():
+    c = MoveAwayController()
+    seen = [c.state]
+    yaw = 0.0
+    for _ in range(int(30.0 * c.ctrl_hz)):
+        # Follow the heading setpoint closely so TURN can complete.
+        yaw += 0.25 * wrap_angle(c.heading_setpoint - yaw)
+        c.update(yaw, 0.5, True)
+        if c.state != seen[-1]:
+            seen.append(c.state)
+    assert seen == ["IDLE", "RETREAT", "TURN", "CLEAR", "DONE"]
+
+
+def test_idle_and_done_command_zero_velocity():
+    c = MoveAwayController()
+    assert _drive(c, 5, distance=9.0) == (0.0, 0.0, 0.0)
+    c.state = "DONE"
+    out = _drive(c, 200, distance=0.5)
+    assert all(abs(v) < 1e-3 for v in out)
+
+
+def test_retreat_commands_backward_velocity_inside_the_measured_band():
+    c = MoveAwayController()
+    _drive(c, 1, distance=0.5)
+    assert c.state == "RETREAT"
+    vx, vy, _ = _drive(c, 100, distance=0.5)
+    # MEASURED: the backward gait does not engage above about -0.30.
+    assert vx < -0.30
+    assert vx == pytest.approx(VX_RETREAT, abs=0.02)
+    assert vy == 0.0
+
+
+def test_heading_hold_opposes_drift_with_the_correct_sign():
+    # A positive wz command produces a positive (left) yaw rate when the policy
+    # is fed the real gyro, so drifting right (yaw < 0) must command wz > 0.
+    c = MoveAwayController()
+    _drive(c, 1, distance=0.5)
+    assert c.state == "RETREAT"
+    c.yaw_ref = 0.0
+    _, _, wz_right = _drive(c, 20, yaw=math.radians(-20.0), distance=0.5)
+    assert wz_right > 0.0
+    c2 = MoveAwayController()
+    _drive(c2, 1, distance=0.5)
+    c2.yaw_ref = 0.0
+    _, _, wz_left = _drive(c2, 20, yaw=math.radians(20.0), distance=0.5)
+    assert wz_left < 0.0
+
+
+def test_yaw_command_is_clamped():
+    c = MoveAwayController()
+    _drive(c, 1, distance=0.5)
+    c.yaw_ref = 0.0
+    _, _, wz = _drive(c, 400, yaw=math.radians(-170.0), distance=0.5)
+    assert abs(wz) <= WZ_MAX + 1e-6
+
+
+def test_turn_sign_selects_the_heading_setpoint_direction():
+    left = MoveAwayController(turn_sign=1.0)
+    right = MoveAwayController(turn_sign=-1.0)
+    for c in (left, right):
+        c.yaw_ref = 0.0
+        c.state = "TURN"
+    assert left.heading_setpoint > 0.0
+    assert right.heading_setpoint < 0.0
+    assert left.heading_setpoint == pytest.approx(-right.heading_setpoint)
+
+
+def test_turn_falls_through_on_the_safety_timeout():
+    # If the heading never converges the demo must not hang in TURN forever.
+    c = MoveAwayController()
+    _drive(c, 1, distance=0.5)
+    _drive(c, int(c.retreat_hold * c.ctrl_hz) + 2, distance=0.5)
+    assert c.state == "TURN"
+    _drive(c, int(c.turn_max * c.ctrl_hz) + 2, yaw=0.0, distance=0.5)
+    assert c.state == "CLEAR"
+
+
+def test_command_is_low_pass_filtered_not_stepped():
+    c = MoveAwayController()
+    first = c.update(0.0, 0.5, True)
+    assert c.state == "RETREAT"
+    # One tick must not jump to the full commanded speed.
+    assert abs(first[0]) < abs(VX_RETREAT)
+
+
+def test_wrap_angle_folds_into_pi_range():
+    assert wrap_angle(math.radians(370.0)) == pytest.approx(math.radians(10.0))
+    assert wrap_angle(math.radians(-190.0)) == pytest.approx(math.radians(170.0))
+    for a in (0.0, 1.0, -1.0, 3.0, -3.0, 7.0):
+        assert -math.pi <= wrap_angle(a) < math.pi
+
+
+# --- gaze maths --------------------------------------------------------------
+
+
+def _camera_matrix(forward, up):
+    """Build a MuJoCo camera xmat whose optical -Z is `forward`, +Y is `up`."""
+    forward = np.asarray(forward, dtype=np.float64)
+    forward = forward / np.linalg.norm(forward)
+    up = np.asarray(up, dtype=np.float64)
+    up = up - np.dot(up, forward) * forward
+    up = up / np.linalg.norm(up)
+    right = np.cross(forward, up)
+    return np.column_stack([right, up, -forward]).reshape(9)
+
+
+def test_camera_axes_follow_mujoco_optical_convention():
+    fwd, right, up = camera_axes(_camera_matrix([1, 0, 0], [0, 0, 1]))
+    assert np.allclose(fwd, [1, 0, 0], atol=1e-9)
+    assert np.allclose(up, [0, 0, 1], atol=1e-9)
+    # Looking along +x with +z up, image-right is -y (checked against the real
+    # model in test_head_camera_optical_correction_... below).
+    assert np.allclose(right, [0, -1, 0], atol=1e-9)
+    assert np.allclose(np.cross(fwd, up), right, atol=1e-9)
+
+
+def test_bearing_is_positive_to_the_cameras_left():
+    fwd, right, up = camera_axes(_camera_matrix([1, 0, 0], [0, 0, 1]))
+    # camera looks along +x with +z up, so its left is +y
+    bearing, elevation = bearing_elevation(np.array([1.0, 1.0, 0.0]), fwd, right, up)
+    assert bearing == pytest.approx(math.radians(45.0))
+    assert elevation == pytest.approx(0.0, abs=1e-9)
+
+
+def test_elevation_is_positive_above_the_optical_axis():
+    fwd, right, up = camera_axes(_camera_matrix([1, 0, 0], [0, 0, 1]))
+    _, elevation = bearing_elevation(np.array([1.0, 0.0, 1.0]), fwd, right, up)
+    assert elevation == pytest.approx(math.radians(45.0))
+
+
+def test_frustum_rejects_targets_behind_and_outside():
+    fwd, right, up = camera_axes(_camera_matrix([1, 0, 0], [0, 0, 1]))
+    tan_h = tan_v = math.tan(math.radians(22.5))
+    assert in_frustum(np.array([2.0, 0.0, 0.0]), fwd, right, up, tan_h, tan_v)
+    # directly behind the camera
+    assert not in_frustum(np.array([-2.0, 0.0, 0.0]), fwd, right, up, tan_h, tan_v)
+    # 60 deg off axis horizontally
+    far_side = np.array([1.0, math.tan(math.radians(60.0)), 0.0])
+    assert not in_frustum(far_side, fwd, right, up, tan_h, tan_v)
+
+
+def test_gaze_servo_reduces_the_pointing_error():
+    gaze = GazeState(
+        yaw=0.0, pitch=0.0, yaw_limits=(-2.9, 2.9), pitch_limits=(-1.5, 1.5), tau=0.02, dt=0.02
+    )
+    yaw, _ = gaze.step(math.radians(20.0), 0.0)
+    assert yaw == pytest.approx(math.radians(20.0), abs=1e-6)
+
+
+def test_gaze_pitch_sign_matches_the_actuator_convention():
+    # A positive head_pitch command points the camera DOWN, so a target ABOVE
+    # the axis (positive elevation) must DECREASE the pitch setpoint.
+    gaze = GazeState(
+        yaw=0.0, pitch=0.0, yaw_limits=(-2.9, 2.9), pitch_limits=(-1.5, 1.5), tau=0.02, dt=0.02
+    )
+    _, pitch = gaze.step(0.0, math.radians(15.0))
+    assert pitch < 0.0
+
+
+def test_gaze_setpoints_stay_inside_the_joint_limits_with_margin():
+    gaze = GazeState(
+        yaw=0.0, pitch=0.0, yaw_limits=(-0.5, 0.5), pitch_limits=(-0.4, 0.4), tau=0.02, dt=0.02
+    )
+    for _ in range(200):
+        gaze.step(math.radians(90.0), math.radians(-90.0))
+    assert gaze.yaw <= 0.5 - HEAD_YAW_MARGIN + 1e-9
+    assert gaze.pitch <= 0.4 - HEAD_PITCH_MARGIN + 1e-9
+    for _ in range(400):
+        gaze.step(math.radians(-90.0), math.radians(90.0))
+    assert gaze.yaw >= -0.5 + HEAD_YAW_MARGIN - 1e-9
+    assert gaze.pitch >= -0.4 + HEAD_PITCH_MARGIN - 1e-9
+
+
+# --- observation contract ----------------------------------------------------
+
+
+def test_observation_layout_and_zero_padded_command_block():
+    nu = 14
+    gyro = np.arange(3, dtype=np.float32)
+    gravity = np.arange(3, dtype=np.float32) + 10.0
+    joint_pos = np.arange(nu, dtype=np.float32) + 100.0
+    joint_vel = np.arange(nu, dtype=np.float32) + 200.0
+    last_action = np.arange(nu, dtype=np.float32) + 300.0
+    twist = np.array([-0.36, 0.0, 0.2], dtype=np.float32)
+
+    obs = build_observation(gyro, gravity, joint_pos, joint_vel, last_action, twist, 13)
+
+    # 3 + 3 + 14 + 14 + 14 + 13 = 61, the shared policy-family layout.
+    assert obs.shape == (61,)
+    assert obs.dtype == np.float32
+    assert np.allclose(obs[0:3], gyro)
+    assert np.allclose(obs[3:6], gravity)
+    assert np.allclose(obs[6:20], joint_pos)
+    assert np.allclose(obs[20:34], joint_vel)
+    assert np.allclose(obs[34:48], last_action)
+    assert np.allclose(obs[48:51], twist)
+    # head_pose(4) + body_pose(6) are ZERO-PADDED, never dropped.
+    assert np.allclose(obs[51:61], 0.0)
+
+
+# --- model invariants (compile the MJCF, no policy needed) -------------------
+
+
+@pytest.fixture(scope="module")
+def scene_model():
+    return mujoco.MjModel.from_xml_path(str(SCENE_XML))
+
+
+def test_demo_scene_path_resolves_inside_the_repo():
+    assert SCENE_XML.is_file(), SCENE_XML
+    assert SCENE_XML.name == "scene_move_away.xml"
+
+
+def test_scene_keeps_the_14_actuator_layout_and_adds_no_dof(scene_model):
+    # The person is a MOCAP body: it must not add degrees of freedom, otherwise
+    # the keyframes' qpos sizes break and the obs layout shifts.
+    assert scene_model.nu == 14
+    assert scene_model.nq == 21  # freejoint(7) + 14 servos
+    names = [
+        mujoco.mj_id2name(scene_model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
+        for i in range(scene_model.nu)
+    ]
+    assert names[HEAD_PITCH_ACT] == "head_pitch"
+    assert names[HEAD_YAW_ACT] == "head_yaw"
+    assert len(DEFAULT_POSE) == scene_model.nu
+
+
+def test_person_is_a_non_colliding_mocap_prop(scene_model):
+    person = mujoco.mj_name2id(scene_model, mujoco.mjtObj.mjOBJ_BODY, "person")
+    assert person >= 0
+    assert int(scene_model.body_mocapid[person]) >= 0
+    geoms = [g for g in range(scene_model.ngeom) if scene_model.geom_bodyid[g] == person]
+    assert geoms, "the person prop has no geoms"
+    for g in geoms:
+        # contype/conaffinity 0: the prop can never push the robot over.
+        assert scene_model.geom_contype[g] == 0
+        assert scene_model.geom_conaffinity[g] == 0
+
+
+def test_gyro_sensor_name_exists_and_is_not_the_fallback(scene_model):
+    # REGRESSION: mj_name2id returns -1 for an unknown sensor, and
+    # model.sensor_adr[-1] is a VALID index (the last sensor). A typo
+    # therefore does NOT raise, it silently feeds a different quantity into
+    # the policy's angular-velocity slot. Assert the name resolves, and that
+    # it is not accidentally the last sensor in the model.
+    assert mujoco.mj_name2id(scene_model, mujoco.mjtObj.mjOBJ_SENSOR, GYRO_SENSOR) >= 0
+    adr = sensor_address(scene_model, GYRO_SENSOR)
+    assert adr != scene_model.sensor_adr[-1]
+    with pytest.raises(ValueError):
+        sensor_address(scene_model, "definitely_not_a_sensor")
+
+
+def test_head_camera_optical_correction_points_along_the_robot_forward_axis(scene_model):
+    # The MJCF's exported head_camera quaternion points optical -Z BACKWARDS,
+    # into the robot's own geometry. The demo corrects it in memory; verify the
+    # correction actually aligns the optical axis with the trunk's +X forward.
+    data = mujoco.MjData(scene_model)
+    qpos_idx = [
+        int(scene_model.jnt_qposadr[scene_model.actuator_trnid[i, 0]])
+        for i in range(scene_model.nu)
+    ]
+    for slot, address in enumerate(qpos_idx):
+        data.qpos[address] = DEFAULT_POSE[slot]
+    cam = mujoco.mj_name2id(scene_model, mujoco.mjtObj.mjOBJ_CAMERA, "head_camera")
+    trunk = mujoco.mj_name2id(scene_model, mujoco.mjtObj.mjOBJ_BODY, "trunk_base")
+
+    mujoco.mj_forward(scene_model, data)
+    trunk_forward = data.xmat[trunk].reshape(3, 3)[:, 0]
+    before, _, _ = camera_axes(data.cam_xmat[cam])
+    assert float(np.dot(before, trunk_forward)) < -0.9  # points backwards
+
+    original = scene_model.cam_quat[cam].copy()
+    try:
+        scene_model.cam_quat[cam] = optical_frame_quat()
+        mujoco.mj_forward(scene_model, data)
+        after, _, up = camera_axes(data.cam_xmat[cam])
+        assert float(np.dot(after, trunk_forward)) > 0.99
+        assert float(up[2]) > 0.99  # image-up follows world up
+        # Same handedness the pure-maths test above asserts.
+        _, real_right, _ = camera_axes(data.cam_xmat[cam])
+        assert np.allclose(np.cross(after, up), real_right, atol=1e-6)
+    finally:
+        scene_model.cam_quat[cam] = original
+
+
+def test_body_subtree_collects_the_whole_robot_and_the_person(scene_model):
+    trunk = mujoco.mj_name2id(scene_model, mujoco.mjtObj.mjOBJ_BODY, "trunk_base")
+    person = mujoco.mj_name2id(scene_model, mujoco.mjtObj.mjOBJ_BODY, "person")
+    robot = body_subtree(scene_model, trunk)
+    people = body_subtree(scene_model, person)
+    assert trunk in robot and person in people
+    # The two sets must be disjoint, otherwise the ray cast would skip the
+    # person as "our own body" and never see them.
+    assert not (robot & people)
+    assert 0 not in robot  # never treat the world body as part of the robot
+
+
+def test_default_pose_matches_the_scene_stand_keyframe(scene_model):
+    key = mujoco.mj_name2id(scene_model, mujoco.mjtObj.mjOBJ_KEY, "STAND")
+    assert key >= 0, "scene_move_away.xml must keep the STAND keyframe"
+    stand_ctrl = scene_model.key_ctrl[key]
+    assert np.allclose(stand_ctrl, DEFAULT_POSE, atol=1e-4)


### PR DESCRIPTION
## Problem / use case

A common request for a small robot sharing floor space with people: when
someone walks towards it, get out of the way — but keep watching them, so the
robot can react if they change direction and so a human observer can tell the
robot has noticed them.

This PR adds that as a **CPU MuJoCo behavior demo**, not as production robot
autonomy. It shows how far a stock exported walking policy can be pushed with a
scripted supervisor, and it doubles as a rehearsal harness for the
velocity-command interface the runtime drives, in the spirit of
`scripts/infer_policy.py`.

**No new policy is trained, and no policy file is committed** — `--policy` is a
required argument.

## Implementation

Self-contained under `scripts/behavior_demos/move_away/`:

| file | role |
| --- | --- |
| `controller.py` | state machine + velocity-command law. Pure Python (no MuJoCo/ONNX/numpy) so it is fully unit-testable |
| `gaze.py` | camera-frame maths and the head visual servo |
| `perception.py` | field-of-view test + ray-cast occlusion check |
| `runtime.py` | scene path, default pose, observation layout, safe sensor lookup |
| `run_demo.py` | CLI entry point, simulation loop, optional rendering |
| `README.md` | measured constants, limitations, usage |

The behavior is `IDLE → RETREAT → TURN → CLEAR → DONE`. Heading is held
closed-loop in every walking state; the absolute trunk heading is measured each
tick and never integrated.

Also adds `src/mjlab_microduck/robot/microduck/scene_move_away.xml`: `scene.xml`
plus a scripted **mocap** "person" prop. It is a mocap body with
`contype/conaffinity="0"`, so it adds **no degrees of freedom** (`nq` stays 21,
the keyframes stay valid) and it can never push the robot over. It follows the
existing `scene_ball.xml` pattern, so the `robot_allcollisions.xml` include
resolves the same way as the other scenes.

The observation is assembled as
`[base_ang_vel(3), projected_gravity(3), joint_pos(14), joint_vel(14), last_action(14), command(13)]`
= 61D. The demo writes only the `twist` slot and **zero-pads** `head_pose(4)` and
`body_pose(6)` rather than dropping them, per the shared-layout convention in
`AGENTS.md`.

`pyproject.toml` is unchanged. The headless path needs only `mujoco`,
`numpy` and `onnxruntime`, all already dependencies; `imageio`/`Pillow` are
imported lazily inside the rendering helper, so `--render-dir` is the only path
that needs them.

### One finding worth flagging

An earlier iteration of this demo looked up a gyro sensor named `imu_gyro`,
which **does not exist** in these models. `mujoco.mj_name2id` returns `-1` for an
unknown name, and `model.sensor_adr[-1]` is a *valid* index — the last sensor. So
the lookup did not raise: it silently fed `root_angmom` (subtree angular
momentum, kg·m²/s) into the slot the policy expects to hold rad/s.

The robot still walked and the rendered result looked plausible, which is what
makes this failure mode nasty. But every gait constant tuned against it described
the corrupted observation rather than the robot — including a "the `wz` sign is
inverted" conclusion that is simply not true with a real gyro.

Everything in this PR was re-measured against `imu_ang_vel`, and the constants
changed materially as a result:

| | against the bad observation | re-measured |
| --- | --- | --- |
| retreat speed | `vx = -0.28` | `vx = -0.36` (gait does not engage above ≈ −0.30) |
| `wz` sign | reported inverted | **normal**, with real closed-loop authority |
| turn | open-loop, cut early at 45° | closed-loop, tracked to a 15° tolerance |

`runtime.sensor_address()` now raises on an unknown sensor name, and a
regression test pins it.

## Validation

Measured with a stock exported walking policy, defaults, 22 s:

| metric | value |
| --- | --- |
| final state | `DONE`, upright |
| person visible | **1100 / 1100** control steps (`lost_steps = 0`) |
| max off-axis angle | **2.3°** from camera centre |
| heading change | **+82.8°** (90° commanded) |
| trunk height | **z = 0.116** (nominal), min 0.114 |

Robustness spot-checks: `--turn-sign -1` mirrors the maneuver (−96.5°, still
1100/1100 visible); `--person-speed 0.20` keeps 1100/1100; `--seconds 28` stays
upright at 1400/1400. Rendered frames were inspected visually — the
picture-in-picture head-camera view keeps the person centred through the turn.

## Limitations — explicitly not claimed

- **The "person" is scripted, not perceived.** A mocap prop on a fixed straight
  path, its position read from simulator state. No detector, no tracker, no real
  sensing; the visibility test is purely geometric.
- **Gaze is kinematic only.** Head pose is applied in an isolated `MjData` copy
  used solely for perception and rendering, and is never fed back into the
  locomotion dynamics. The head is a large fraction of body mass and this policy
  was never trained to compensate an externally imposed head trajectory — driving
  it physically makes the robot fall. **This PR makes no claim of physical
  head-control stability while walking**, and the numbers above do not support
  one.
- **Sim only, CPU only.** Nothing here has been validated on hardware.
- Constants were measured against one exported walking policy in this scene;
  another policy would need its own sweep.
- The head-camera optical-frame correction (the MJCF exports a quaternion whose
  optical `-Z` points backwards into the robot's own CAD) is applied to the
  **in-memory** `MjModel` only. The committed MJCF is untouched — worth a
  maintainer opinion on whether the exported camera quaternion should be fixed
  upstream instead.

## Test plan

`tests/test_move_away_demo.py` — 25 tests, all CPU, **no policy file, no GPU and
no rendering context required**:

- **State machine**: IDLE holds until the person is both close *and* visible
  (range alone must not trigger); full `IDLE→RETREAT→TURN→CLEAR→DONE` ordering;
  IDLE/DONE command exactly zero velocity; retreat speed stays inside the
  measured engagement band; heading-hold sign opposes drift correctly; `wz`
  clamping; `turn_sign` direction; the `TURN_MAX` safety timeout; command
  low-pass filtering; angle wrapping.
- **Gaze maths**: MuJoCo optical-frame convention and handedness; bearing sign;
  elevation sign; frustum rejection behind and off-axis; servo error reduction;
  the head-pitch sign convention; joint-limit margins.
- **Observation contract**: exact 61D layout with the command block zero-padded.
- **Model invariants** (compile the MJCF only): the scene path resolves; 14
  actuators and `nq == 21` (the prop adds no DoF); the person is a
  non-colliding mocap body; the gyro sensor name resolves and is not the
  `sensor_adr[-1]` fallback, and a bad name raises; the optical correction
  aligns the camera with the trunk forward axis; robot and person body subtrees
  are disjoint; `DEFAULT_POSE` matches the scene's `STAND` keyframe.

```
$ python -m pytest tests/test_move_away_demo.py -q
25 passed

$ python -m pytest tests/ -q
179 passed, 1 skipped
```

`ruff check` is clean on the added files. (`ruff format` was deliberately not
run — the existing tree does not conform to its defaults, so applying it here
would produce unrelated churn.)

## Not included

No ONNX policy, no video and no GIF are committed — only text files.

## Demo video

Fresh render from commit `39506fff` after the `imu_ang_vel` sensor fix and controller re-measurement (22 s, 1,100 frames at 50 fps, 960×640). This is not the earlier render made with the invalid sensor lookup.

https://github.com/user-attachments/assets/9dffbdf4-9560-4493-af9a-f5784f16b40a
