### PR TITLE
Add follow-me-among-others CPU behavior demo (color-selective crowd following)

### DIFF
--- a/scripts/behavior_demos/follow_me_among_others/README.md
+++ b/scripts/behavior_demos/follow_me_among_others/README.md
@@ -1,0 +1,133 @@
+# follow-me-among-others
+
+A **CPU MuJoCo behavior demo**: the robot repeatedly searches a moving crowd
+through its head camera, acquires a requested shirt color, follows that
+person's queued footsteps, and stops.
+
+```text
+BLUE -> GREEN -> RED -> BLUE
+SEARCH -> FOUND -> FOLLOW -> STOP   (once per selection)
+```
+
+This is **not** a trained policy, a new task, or robot autonomy. It drives the
+*stock exported walking policy* with a twist command produced by a geometric
+controller, so it needs no GPU, no training run and no new weights. Nothing in
+`src/` changes except one added scene.
+
+## Run it
+
+Bring your own walking policy — there is no default weights path:
+
+```bash
+uv run --with imageio --with pillow \
+    scripts/behavior_demos/follow_me_among_others/run_demo.py \
+    --policy /path/to/walking.onnx --no-render --metrics /tmp/fmao.json
+```
+
+`--no-render` needs neither `imageio` nor `pillow`; both are only imported when
+frames are actually written. To also render the HUD:
+
+```bash
+uv run --with imageio --with pillow \
+    scripts/behavior_demos/follow_me_among_others/run_demo.py \
+    --policy /path/to/walking.onnx --out /tmp/fmao-frames --fps 50
+```
+
+The process exits non-zero if any acceptance gate fails, so it works as a
+regression check and not just a video generator.
+
+Useful flags: `--targets BLUE,GREEN` (any order/length of BLUE/GREEN/RED),
+`--seconds`, `--xml`, `--quiet`.
+
+## What is real, and what is a proxy
+
+Being precise about this matters more than the demo itself.
+
+**Genuinely simulated.** The physics and the camera geometry. The robot walks
+with the real policy at 50 Hz through the real BAM actuators. The head camera
+sits where the model puts it, the search sweep really rotates the view, and
+acquisition requires the target to be inside the camera frustum and within 8°
+of the crosshair.
+
+**A proxy.** Color recognition. The simulator supplies each actor's identity and
+world pose, and `camera.py` tests known shirt/head sample points against the
+frustum. There is **no RGB classifier**: swapping the identity lookup for
+onboard vision is separate work. The picture-in-picture view is rendered for
+inspection only — no pixel of it is fed back into any decision.
+
+**Frustum-only visibility.** The test does not ray-cast for mutual occlusion,
+so a person standing directly behind another still counts as visible. This is
+the gate the published numbers were measured with; adding occlusion changes
+acquisition timing and would require re-measuring the whole sequence.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `crowd.py` | pedestrian routes, footstep queues, state machine, controller |
+| `camera.py` | color-selective search sweep and tracking (needs `mujoco`) |
+| `metrics.py` | acceptance gates and the metrics summary |
+| `overlay.py` | HUD/PiP composition (needs `pillow`) |
+| `run_demo.py` | rollout entry point |
+
+`crowd.py` and `metrics.py` import no `mujoco`, which is why the state machine,
+the color gate and every acceptance threshold are unit-tested on CPU with no
+model, policy or renderer:
+
+```bash
+uv run --with pytest pytest tests/test_follow_me_among_others_*.py
+```
+
+The scene lives at
+`src/mjlab_microduck/robot/microduck/scene_follow_me_among_others.xml` and
+includes the official `robot_walk.xml`. The five pedestrians are mocap bodies
+with `contype="0" conaffinity="0"` geoms: they are scenery, so they can never
+push the robot, and following is not an artifact of being bumped.
+
+## Behavior details
+
+- **Five people, all moving.** Blue, green and red are selectable; yellow and
+  purple are distractors. Each walks an independent elliptical lane with its own
+  direction, speed, phase and unsynchronised wobble. Nobody freezes or teleports
+  to make acquisition easier — a unit test asserts this over the full rollout.
+- **Following means trailing, not mirroring.** During `FOLLOW` the robot walks
+  toward the selected person's queued world-space footprint 0.55 m back along
+  *that person's own path*, interpolated by arc length.
+- **Zero locomotion outside FOLLOW.** In `SEARCH`, `FOUND`, `STOP` and `DONE`
+  the command is exactly `(0, 0, 0)`, and the run reports the maximum.
+- **Gait onset is a real threshold.** The controller holds `vx = 0.24` while
+  turning. A smaller command produces a valid ONNX action but no visible
+  locomotion — that is how the original RED hand-off failed, and the
+  "did it actually move" gates exist to catch it.
+
+## Measured validation
+
+60 s, 3000 control steps at 50 Hz, CPU only, stock walking policy.
+
+| Selection | Target | Search | Found | Follow | Stop | Search time |
+|---:|---|---:|---:|---:|---:|---:|
+| 1 | Blue | `0.00 s` | `2.44 s` | `3.44 s` | `12.44 s` | `2.44 s` |
+| 2 | Green | `13.94 s` | `16.50 s` | `17.50 s` | `26.50 s` | `2.56 s` |
+| 3 | Red | `28.00 s` | `29.34 s` | `30.34 s` | `39.34 s` | `1.34 s` |
+| 4 | Blue | `40.84 s` | `41.92 s` | `42.92 s` | `51.92 s` | `1.08 s` |
+
+Acceptance gates, all enforced in `metrics.check_gates`:
+
+- completed targets exactly `BLUE -> GREEN -> RED -> BLUE`, 4/4 cycles;
+- every `FOUND` occurs while the requested color is visible;
+- `wrong_color_locks = 0`;
+- target visible for **100%** of control steps during `FOLLOW`;
+- every follow segment travels ≥ `0.40 m`, displaces ≥ `0.30 m`, and measurably
+  approaches its target;
+- maximum stationary-state command `0.0`;
+- `fallen_steps = 0`, minimum trunk height `0.1135 m` (above the `0.09 m`
+  fallen threshold), final `0.1163 m` back at nominal.
+
+Mean selected-person range during following is `0.929 m`. Queued-footprint RMSE
+is `1.028 m` — this includes the deliberately long first Blue approach rather
+than only the settled tail of each interval. In the Red segment the robot
+travels `1.249 m`, displaces `0.718 m`, and reduces its queued-footprint error
+from `0.397 m` to a minimum of `0.202 m`.
+
+Because the demo is deterministic and headless, the whole 60 s rollout
+reproduces in about two seconds on a laptop CPU.

--- a/scripts/behavior_demos/follow_me_among_others/__init__.py
+++ b/scripts/behavior_demos/follow_me_among_others/__init__.py
@@ -1,0 +1,10 @@
+"""Follow-me-among-others: a CPU MuJoCo behavior demo.
+
+Drives the stock exported walking policy with a geometric twist controller so
+the robot can search a moving crowd for a requested shirt color, follow that
+person, and stop. No training, no new weights, no GPU.
+
+``camera`` and ``run_demo`` import ``mujoco``; ``crowd`` and ``metrics`` are
+pure Python + numpy so the state machine, gating and acceptance thresholds can
+be tested without a model or a policy.
+"""

--- a/scripts/behavior_demos/follow_me_among_others/camera.py
+++ b/scripts/behavior_demos/follow_me_among_others/camera.py
@@ -1,0 +1,259 @@
+"""Color-selective search sweep and target tracking from the head camera.
+
+Scope, stated plainly: this is a **semantic proxy for color recognition**, not a
+vision model. The simulator supplies each actor's identity and world pose, and
+this module tests known shirt/head sample points against the camera frustum.
+What is genuinely simulated is the *geometry* — where the head camera
+physically sits, where it is pointing, whether the requested person is inside
+the field of view, and how far off the crosshair they are. Replacing the
+identity lookup with an onboard RGB classifier is a separate piece of work;
+nothing here trains or evaluates one.
+
+The visibility test is deliberately frustum-only: it does NOT ray-cast for
+mutual occlusion between pedestrians, so a person standing directly behind
+another still counts as visible. This is the gate the published metrics were
+measured with. Occlusion rejection is a reasonable extension, but it changes
+acquisition timing and would need the whole sequence re-measured, so it is
+called out as a limitation instead of being switched on untested.
+"""
+
+import math
+
+import mujoco
+import numpy as np
+
+from .crowd import COLORS, wrap
+
+
+class CrowdCameraSearch:
+    """Search for one shirt color, then keep that pedestrian centered.
+
+    Locomotion physics stays authoritative in the caller's ``data``. Head pose
+    and the stabilized optical view live in an isolated ``MjData`` used only for
+    perception and rendering, so gazing around can never perturb the walking
+    state that the policy is controlling.
+    """
+
+    # Actuator indices for the head chain (see AGENTS.md joint layout: 5-8 are
+    # neck_pitch, head_pitch, head_yaw, head_roll). Resolved to joint ids via
+    # the model rather than assumed, so this stays correct on models where
+    # passive joints interleave.
+    HEAD_PITCH_ACT = 6
+    HEAD_YAW_ACT = 7
+    HEAD_ROLL_ACT = 8
+
+    # One full panoramic sweep per this many seconds during SEARCH.
+    SWEEP_SECONDS = 4.5
+
+    # Vertical sample offsets relative to the torso centre: torso, upper torso,
+    # head. A crowded scene cannot be judged by a single torso-centre ray —
+    # another pedestrian may cover exactly that pixel while the colored shirt
+    # and head remain plainly visible. Any clear sample is sufficient.
+    SAMPLE_OFFSETS_Z = (-0.06, 0.08, 0.20)
+
+    # Maximum yaw slew per control step while tracking, so the head turns
+    # toward the target instead of teleporting onto it.
+    MAX_AIM_YAW_STEP = math.radians(5.0)
+    MAX_AIM_PITCH_STEP = math.radians(3.0)
+
+    def __init__(self, model, data, qpos_idx, trunk_id, pip_size=(260, 190)):
+        self.model = model
+        self.gaze_data = mujoco.MjData(model)
+        self.qpos_idx = qpos_idx
+        self.trunk_id = trunk_id
+        self.pip_w, self.pip_h = pip_size
+
+        self.head_pitch_joint = int(model.actuator_trnid[self.HEAD_PITCH_ACT, 0])
+        self.head_yaw_joint = int(model.actuator_trnid[self.HEAD_YAW_ACT, 0])
+        self.head_cam = model.camera("head_camera").id
+        self.follow_cam = model.camera("follow_camera").id
+        rig = model.body("follow_camera_rig")
+        self.follow_mocap = int(model.body_mocapid[rig.id])
+
+        self.people = {
+            color: int(model.body_mocapid[model.body(f"person_{color.lower()}").id])
+            for color in COLORS
+        }
+
+        # MuJoCo cameras look along -Z. The upstream head camera is exported
+        # with its own optical convention, so align the frame before copying
+        # its physical position onto the stabilized rig.
+        model.cam_quat[self.head_cam] = np.array(
+            [math.sqrt(0.5), 0.0, 0.0, -math.sqrt(0.5)], dtype=np.float64
+        )
+        mujoco.mj_forward(model, data)
+
+        self.gaze_pitch = float(data.qpos[qpos_idx[self.HEAD_PITCH_ACT]])
+        self.gaze_yaw = float(data.qpos[qpos_idx[self.HEAD_YAW_ACT]])
+        self.view_yaw = 0.0
+        self.view_pitch = math.radians(8.0)
+
+        vertical_half = math.radians(float(model.cam_fovy[self.follow_cam])) * 0.5
+        self.tan_v = math.tan(vertical_half)
+        self.tan_h = (self.pip_w / self.pip_h) * self.tan_v
+
+        self.samples = 0
+        self.target_visible_steps = 0
+        self.search_steps = 0
+        self.search_target_visible_steps = 0
+        self.max_target_off_axis = 0.0
+
+    def _pose_gaze(self, data, duck_yaw: float) -> None:
+        """Copy authoritative physics into the gaze clone and aim the head."""
+        mujoco.mj_copyData(self.gaze_data, self.model, data)
+        yaw_lo, yaw_hi = self.model.jnt_range[self.head_yaw_joint]
+        pitch_lo, pitch_hi = self.model.jnt_range[self.head_pitch_joint]
+        # The demanded view direction is absolute; the servo can only deliver
+        # the part of it that fits inside the real neck range.
+        relative = wrap(self.view_yaw - duck_yaw)
+        self.gaze_yaw = float(np.clip(relative, yaw_lo + 0.03, yaw_hi - 0.03))
+        self.gaze_pitch = float(
+            np.clip(-self.view_pitch, pitch_lo + 0.04, pitch_hi - 0.04)
+        )
+        self.gaze_data.qpos[self.qpos_idx[self.HEAD_YAW_ACT]] = self.gaze_yaw
+        self.gaze_data.qpos[self.qpos_idx[self.HEAD_PITCH_ACT]] = self.gaze_pitch
+        self.gaze_data.qpos[self.qpos_idx[self.HEAD_ROLL_ACT]] = 0.0
+        mujoco.mj_forward(self.model, self.gaze_data)
+
+    def _orient_rig(self) -> None:
+        """Place the stabilized rig at the physical eye, aimed at the view."""
+        eye = self.gaze_data.cam_xpos[self.head_cam].copy()
+        cp = math.cos(self.view_pitch)
+        forward = np.array(
+            [
+                cp * math.cos(self.view_yaw),
+                cp * math.sin(self.view_yaw),
+                math.sin(self.view_pitch),
+            ],
+            dtype=np.float64,
+        )
+        forward /= np.linalg.norm(forward)
+        world_up = np.array([0.0, 0.0, 1.0])
+        right = np.cross(forward, world_up)
+        right /= max(float(np.linalg.norm(right)), 1e-9)
+        up = np.cross(right, forward)
+        up /= max(float(np.linalg.norm(up)), 1e-9)
+        rotation = np.column_stack((right, up, -forward))
+        quaternion = np.empty(4, dtype=np.float64)
+        mujoco.mju_mat2Quat(quaternion, rotation.ravel())
+        self.gaze_data.mocap_pos[self.follow_mocap] = eye
+        self.gaze_data.mocap_quat[self.follow_mocap] = quaternion
+        mujoco.mj_forward(self.model, self.gaze_data)
+
+    def _person_target(self, color: str) -> np.ndarray:
+        target = self.gaze_data.mocap_pos[self.people[color]].copy()
+        target[2] += 0.03
+        return target
+
+    def _aim_toward(self, target, max_yaw_step=None) -> None:
+        """Slew the view toward a point at a bounded rate (no teleporting)."""
+        if max_yaw_step is None:
+            max_yaw_step = self.MAX_AIM_YAW_STEP
+        eye = self.gaze_data.cam_xpos[self.head_cam]
+        delta = target - eye
+        desired_yaw = math.atan2(float(delta[1]), float(delta[0]))
+        desired_pitch = math.atan2(float(delta[2]), float(np.linalg.norm(delta[:2])))
+        self.view_yaw = wrap(
+            self.view_yaw
+            + float(
+                np.clip(wrap(desired_yaw - self.view_yaw), -max_yaw_step, max_yaw_step)
+            )
+        )
+        self.view_pitch += float(
+            np.clip(
+                desired_pitch - self.view_pitch,
+                -self.MAX_AIM_PITCH_STEP,
+                self.MAX_AIM_PITCH_STEP,
+            )
+        )
+
+    def _visibility(self, color: str) -> tuple[bool, float, float]:
+        """Frustum test for one person. Returns (visible, off_axis, range).
+
+        No occlusion rejection: see the module docstring.
+        """
+        center = self._person_target(color)
+        eye = self.gaze_data.cam_xpos[self.follow_cam].copy()
+        rotation = self.gaze_data.cam_xmat[self.follow_cam].reshape(3, 3)
+        right, up, forward = rotation[:, 0], rotation[:, 1], -rotation[:, 2]
+        visible = False
+        best_off_axis = math.pi
+        center_distance = float(np.linalg.norm(center - eye))
+        for z_offset in self.SAMPLE_OFFSETS_Z:
+            target = center + np.array([0.0, 0.0, z_offset])
+            delta = target - eye
+            distance = float(np.linalg.norm(delta))
+            unit = delta / max(distance, 1e-9)
+            depth = float(np.dot(delta, forward))
+            image_x = float(np.dot(delta, right))
+            image_y = float(np.dot(delta, up))
+            in_fov = (
+                depth > 0.0
+                and abs(image_x) <= depth * self.tan_h
+                and abs(image_y) <= depth * self.tan_v
+            )
+            off_axis = math.acos(float(np.clip(np.dot(unit, forward), -1.0, 1.0)))
+            best_off_axis = min(best_off_axis, off_axis)
+            if in_fov:
+                visible = True
+        return visible, best_off_axis, center_distance
+
+    def update(self, data, *, target_color, mode, mode_elapsed, duck_yaw) -> dict:
+        """Advance perception one control step and report what is visible."""
+        self._pose_gaze(data, duck_yaw)
+        target = self._person_target(target_color)
+
+        if mode == "SEARCH":
+            # One complete panoramic sweep, starting behind the robot. The
+            # sweep is open-loop: it does not steer toward the answer, so the
+            # measured search durations reflect where the person actually was.
+            self.view_yaw = wrap(
+                duck_yaw - math.pi + 2.0 * math.pi * mode_elapsed / self.SWEEP_SECONDS
+            )
+            self.view_pitch = math.radians(9.0)
+            self.search_steps += 1
+        else:
+            self._aim_toward(target)
+
+        self._pose_gaze(data, duck_yaw)
+        self._orient_rig()
+
+        visible_colors = []
+        target_visible = False
+        target_off_axis = math.pi
+        target_distance = float("nan")
+        # Every color is evaluated, including distractors, so the demo can
+        # report "the camera saw yellow and did not lock onto it".
+        for color in COLORS:
+            visible, off_axis, distance = self._visibility(color)
+            if visible:
+                visible_colors.append(color)
+            if color == target_color:
+                target_visible = visible
+                target_off_axis = off_axis
+                target_distance = distance
+
+        self.samples += 1
+        if target_visible:
+            self.target_visible_steps += 1
+            if mode == "SEARCH":
+                self.search_target_visible_steps += 1
+        self.max_target_off_axis = max(
+            self.max_target_off_axis,
+            target_off_axis if math.isfinite(target_off_axis) else 0.0,
+        )
+        return {
+            "target_color": target_color,
+            "mode": mode,
+            "target_visible": target_visible,
+            "target_off_axis": target_off_axis,
+            "target_distance": target_distance,
+            "visible_colors": visible_colors,
+            "view_yaw": self.view_yaw,
+            "view_pitch": self.view_pitch,
+            "gaze_yaw": self.gaze_yaw,
+        }
+
+    @property
+    def camera_id(self) -> int:
+        return self.follow_cam

--- a/scripts/behavior_demos/follow_me_among_others/crowd.py
+++ b/scripts/behavior_demos/follow_me_among_others/crowd.py
@@ -1,0 +1,409 @@
+"""Pedestrian routes, footstep queues and the SEARCH/FOUND/FOLLOW/STOP machine.
+
+This module is deliberately free of any ``mujoco`` import: everything here is
+plain geometry and bookkeeping, so it runs (and is unit-tested) on CPU without
+a model, a policy or a renderer. ``animate_crowd`` touches MuJoCo structures but
+only through duck-typed attribute access, which keeps it testable with stubs.
+"""
+
+import math
+from bisect import bisect_right
+from dataclasses import dataclass
+
+import numpy as np
+
+# Control rate of the exported policies (50 Hz, see AGENTS.md).
+CTRL_HZ = 50.0
+
+# Arc length by which the robot trails the selected pedestrian. The robot walks
+# toward where that person *was* 0.55 m ago along their own path, not toward
+# their current pose, which is what makes the motion read as "following".
+TRAIL_DISTANCE = 0.55
+
+COLORS = ("BLUE", "GREEN", "RED", "YELLOW", "PURPLE")
+
+# BLUE/GREEN/RED can be requested; YELLOW/PURPLE only ever act as moving
+# distractors, so a demo that locks onto them is a bug, not a variation.
+SELECTABLE_COLORS = ("BLUE", "GREEN", "RED")
+DISTRACTOR_COLORS = ("YELLOW", "PURPLE")
+
+# The requested demo sequence. BLUE appears twice on purpose: re-acquiring a
+# color that was already followed once exercises the full search path again
+# instead of letting the controller keep a latched target.
+TARGET_SEQUENCE = ("BLUE", "GREEN", "RED", "BLUE")
+
+
+def wrap(angle: float) -> float:
+    """Wrap an angle to the half-open interval [-pi, pi)."""
+    return (angle + math.pi) % (2.0 * math.pi) - math.pi
+
+
+@dataclass(frozen=True)
+class PersonState:
+    """World-space pose of one pedestrian at one instant."""
+
+    color: str
+    pos: np.ndarray
+    yaw: float
+    velocity: np.ndarray
+    moving: bool = True
+
+
+@dataclass(frozen=True)
+class TrailState:
+    """A point queued a fixed arc length behind one pedestrian."""
+
+    pos: np.ndarray
+    yaw: float
+    path_s: float
+    leader_path_s: float
+
+
+def _ellipse(
+    color: str,
+    t: float,
+    *,
+    center: tuple[float, float],
+    radii: tuple[float, float],
+    omega: float,
+    phase: float,
+    wobble: float = 0.0,
+) -> PersonState:
+    """A smooth closed pedestrian route with a small independent wobble.
+
+    The wobble frequencies (0.17 / 0.11 Hz) are intentionally unrelated to the
+    lap rate, so the five routes never phase-lock into a formation that would
+    make color acquisition artificially easy.
+    """
+    angle = phase + omega * t
+    rx, ry = radii
+    pos = np.array(
+        [
+            center[0] + rx * math.cos(angle) + wobble * math.sin(0.17 * t + phase),
+            center[1] + ry * math.sin(angle) + 0.5 * wobble * math.sin(0.11 * t),
+        ],
+        dtype=np.float64,
+    )
+    velocity = np.array(
+        [
+            -rx * omega * math.sin(angle) + 0.17 * wobble * math.cos(0.17 * t + phase),
+            ry * omega * math.cos(angle) + 0.055 * wobble * math.cos(0.11 * t),
+        ],
+        dtype=np.float64,
+    )
+    yaw = math.atan2(float(velocity[1]), float(velocity[0]))
+    return PersonState(color, pos, yaw, velocity, True)
+
+
+def crowd_trajectory(t: float) -> dict[str, PersonState]:
+    """Five logical but deliberately unsynchronised walking routes.
+
+    Every person keeps walking for the whole rollout: nobody freezes, waits or
+    teleports to help the robot acquire them.
+    """
+    return {
+        "BLUE": _ellipse(
+            "BLUE",
+            t,
+            center=(1.80, 0.75),
+            radii=(0.52, 0.25),
+            omega=0.080,
+            phase=0.10,
+            wobble=0.025,
+        ),
+        "GREEN": _ellipse(
+            "GREEN",
+            t,
+            center=(0.92, 0.52),
+            radii=(0.46, 0.24),
+            omega=-0.073,
+            phase=1.75,
+            wobble=0.030,
+        ),
+        "RED": _ellipse(
+            "RED",
+            t,
+            center=(1.20, 1.15),
+            radii=(0.56, 0.24),
+            omega=0.068,
+            phase=3.75,
+            wobble=0.020,
+        ),
+        "YELLOW": _ellipse(
+            "YELLOW",
+            t,
+            center=(0.82, 1.00),
+            radii=(0.62, 0.20),
+            omega=-0.092,
+            phase=5.05,
+            wobble=0.035,
+        ),
+        "PURPLE": _ellipse(
+            "PURPLE",
+            t,
+            center=(0.90, -1.00),
+            radii=(0.52, 0.22),
+            omega=0.087,
+            phase=2.75,
+            wobble=0.028,
+        ),
+    }
+
+
+class FootstepTrail:
+    """Interpolate a point a fixed arc length behind one pedestrian.
+
+    Samples are appended in monotonically increasing arc length, so the lookup
+    for ``path_s - gap`` is a binary search plus a linear interpolation. Before
+    the person has walked ``gap`` metres, the queue extrapolates backwards along
+    their initial heading rather than clamping onto their start position.
+    """
+
+    def __init__(self, initial: PersonState, gap: float = TRAIL_DISTANCE):
+        self.gap = gap
+        self.path_s = 0.0
+        self.previous_pos = initial.pos.copy()
+        virtual_start = initial.pos - gap * np.array(
+            [math.cos(initial.yaw), math.sin(initial.yaw)]
+        )
+        self.distances = [-gap, 0.0]
+        self.positions = [virtual_start, initial.pos.copy()]
+        self.yaws = [initial.yaw, initial.yaw]
+
+    def update(self, person: PersonState) -> TrailState:
+        delta = float(np.linalg.norm(person.pos - self.previous_pos))
+        if delta > 1e-8:
+            self.path_s += delta
+            self.distances.append(self.path_s)
+            self.positions.append(person.pos.copy())
+            self.yaws.append(person.yaw)
+        self.previous_pos = person.pos.copy()
+
+        target_s = self.path_s - self.gap
+        upper = min(
+            max(bisect_right(self.distances, target_s), 1), len(self.distances) - 1
+        )
+        lower = upper - 1
+        span = self.distances[upper] - self.distances[lower]
+        fraction = 0.0 if span <= 1e-10 else (target_s - self.distances[lower]) / span
+        pos = self.positions[lower] + fraction * (
+            self.positions[upper] - self.positions[lower]
+        )
+        yaw = wrap(
+            self.yaws[lower] + fraction * wrap(self.yaws[upper] - self.yaws[lower])
+        )
+        return TrailState(pos, yaw, target_s, self.path_s)
+
+
+class SearchFollowStateMachine:
+    """Enforce SEARCH -> FOUND -> FOLLOW -> STOP for each requested target.
+
+    The machine owns *when* the robot may follow; it never looks at pedestrian
+    ground truth itself. The only way out of ``SEARCH`` is a camera report in
+    which the requested color is inside the field of view and within
+    ``FOUND_CONE`` of the crosshair, which is what makes a distractor crossing
+    the view harmless.
+    """
+
+    FOUND_SECONDS = 1.0
+    FOLLOW_SECONDS = 9.0
+    STOP_SECONDS = 1.5
+
+    # A minimum dwell keeps the first frame of a sweep from counting as a
+    # search; the maximum turns "never acquired" into a loud failure instead of
+    # a rollout that silently stands still.
+    MIN_SEARCH_SECONDS = 0.4
+    MAX_SEARCH_SECONDS = 8.0
+
+    FOUND_CONE = math.radians(8.0)
+
+    def __init__(self, sequence: tuple[str, ...] = TARGET_SEQUENCE):
+        if not sequence:
+            raise ValueError("target sequence must not be empty")
+        unknown = [color for color in sequence if color not in SELECTABLE_COLORS]
+        if unknown:
+            raise ValueError(f"targets must be selectable colors, got {unknown}")
+        self.sequence = tuple(sequence)
+        self.index = 0
+        self.state = "SEARCH"
+        self.state_since = 0.0
+        self.cycles: list[dict] = []
+        self.current = {
+            "selection": 1,
+            "target": self.sequence[0],
+            "search_start_s": 0.0,
+        }
+
+    @property
+    def target(self) -> str:
+        return self.sequence[min(self.index, len(self.sequence) - 1)]
+
+    @property
+    def done(self) -> bool:
+        return self.index >= len(self.sequence)
+
+    @property
+    def follows_now(self) -> bool:
+        """True only while locomotion is allowed."""
+        return self.state == "FOLLOW" and not self.done
+
+    def update(self, t: float, camera: dict) -> tuple[str, str, bool]:
+        """Advance one control step. Returns (state, target, changed)."""
+        if self.done:
+            return "DONE", self.sequence[-1], False
+
+        elapsed = t - self.state_since
+        changed = False
+
+        if self.state == "SEARCH":
+            seen = camera.get("target_visible", False)
+            centered = camera.get("target_off_axis", math.pi) < self.FOUND_CONE
+            if elapsed >= self.MIN_SEARCH_SECONDS and seen and centered:
+                self.state = "FOUND"
+                self.current["found_s"] = t
+                self.current["search_duration_s"] = elapsed
+                changed = True
+            elif elapsed >= self.MAX_SEARCH_SECONDS:
+                raise RuntimeError(
+                    f"camera failed to find {self.target} in {elapsed:.2f}s"
+                )
+        elif self.state == "FOUND" and elapsed >= self.FOUND_SECONDS:
+            self.state = "FOLLOW"
+            self.current["follow_start_s"] = t
+            changed = True
+        elif self.state == "FOLLOW" and elapsed >= self.FOLLOW_SECONDS:
+            self.state = "STOP"
+            self.current["stop_s"] = t
+            changed = True
+        elif self.state == "STOP" and elapsed >= self.STOP_SECONDS:
+            self.current["cycle_end_s"] = t
+            self.cycles.append(dict(self.current))
+            self.index += 1
+            if self.done:
+                return "DONE", self.sequence[-1], True
+            self.state = "SEARCH"
+            self.current = {
+                "selection": self.index + 1,
+                "target": self.target,
+                "search_start_s": t,
+            }
+            changed = True
+
+        if changed:
+            self.state_since = t
+        return self.state, self.target, changed
+
+
+class CrowdFollowController:
+    """Walk toward the selected pedestrian's queued world-space footprint.
+
+    Emits a twist command for the stock walking policy; it does not touch
+    joints. Outside ``FOLLOW`` the command is exactly zero, which is what the
+    ``stationary_state_command_max`` gate measures.
+    """
+
+    # Measured gait-onset command for the stock walking policy. The policy has
+    # a hard onset threshold: a smaller vx produces a valid ONNX action but no
+    # visible locomotion, which is exactly how the RED hand-off first failed.
+    # Keep the walking command during large heading changes instead of slowing
+    # down to turn, so every target switch actually initiates gait.
+    WALK_VX = 0.24
+
+    # Inside this radius the robot is already on the queued footprint; pushing
+    # forward would overshoot into the person.
+    ARRIVED_RADIUS = 0.14
+
+    # Heading deadband: below this the robot is aimed well enough to just walk.
+    YAW_DEADBAND = math.radians(4.0)
+
+    # Empirically tuned, deliberately asymmetric turn gains: this robot's stock
+    # gait yaws faster to the right than to the left, so equal gains produced
+    # unequal turns. These are the values used for the published metrics —
+    # changing them changes the measured follow segments.
+    YAW_GAIN = 1.25
+    LEFT_WZ_MIN, LEFT_WZ_MAX = 0.60, 1.00
+    RIGHT_WZ_MIN, RIGHT_WZ_MAX = 0.18, 0.32
+
+    def __init__(self):
+        self.command = np.zeros(3, dtype=np.float32)
+
+    def update(
+        self,
+        active: bool,
+        trail: TrailState,
+        duck_pos: np.ndarray,
+        duck_yaw: float,
+    ) -> tuple[np.ndarray, dict]:
+        error = trail.pos - np.asarray(duck_pos[:2], dtype=np.float64)
+        distance = float(np.linalg.norm(error))
+        # Far away, steer at the queued footprint; on top of it, adopt the
+        # person's heading instead of chasing a numerically noisy bearing.
+        desired_yaw = (
+            math.atan2(float(error[1]), float(error[0]))
+            if distance > 0.10
+            else trail.yaw
+        )
+        yaw_error = wrap(desired_yaw - duck_yaw)
+
+        if not active:
+            raw = (0.0, 0.0, 0.0)
+        else:
+            vx = 0.0 if distance < self.ARRIVED_RADIUS else self.WALK_VX
+            if abs(yaw_error) < self.YAW_DEADBAND:
+                wz = 0.0
+            elif yaw_error > 0.0:
+                wz = min(
+                    self.LEFT_WZ_MAX,
+                    max(self.LEFT_WZ_MIN, self.YAW_GAIN * yaw_error),
+                )
+            else:
+                wz = -min(
+                    self.RIGHT_WZ_MAX,
+                    max(self.RIGHT_WZ_MIN, self.YAW_GAIN * -yaw_error),
+                )
+            raw = (vx, 0.0, wz)
+
+        # Applied unfiltered: upstream policies are trained without an action
+        # low-pass, and adding smoothing on only one side breaks transfer
+        # (see AGENTS.md, "Policies are UNFILTERED").
+        self.command = np.asarray(raw, dtype=np.float32)
+        return self.command.copy(), {
+            "target_pos": trail.pos,
+            "error": distance,
+            "desired_yaw": desired_yaw,
+            "yaw_error": yaw_error,
+            "spatial_lag": trail.leader_path_s - trail.path_s,
+        }
+
+
+def animate_crowd(model, data, crowd: dict[str, PersonState], t: float) -> None:
+    """Pose all pedestrians and animate independent gait phases.
+
+    The people are mocap bodies with collision-free geoms, so they are scenery:
+    they never push the robot, and posing them cannot perturb the walking state.
+    """
+    for order, (color, person) in enumerate(crowd.items()):
+        prefix = color.lower()
+        body = model.body(f"person_{prefix}")
+        mocap = int(model.body_mocapid[body.id])
+        # Offsetting each person's gait phase keeps the crowd from marching in
+        # lockstep, which would look like one rigid object to the camera.
+        phase_t = t + 0.73 * order
+        data.mocap_pos[mocap, :2] = person.pos
+        data.mocap_pos[mocap, 2] = 0.36 + 0.006 * abs(
+            math.sin(2.0 * math.pi * 1.15 * phase_t)
+        )
+        data.mocap_quat[mocap] = np.array(
+            [math.cos(person.yaw / 2.0), 0.0, 0.0, math.sin(person.yaw / 2.0)]
+        )
+        stride = math.radians(24.0) * math.sin(2.0 * math.pi * 1.15 * phase_t)
+        values = {
+            f"{prefix}_hip_l": stride,
+            f"{prefix}_hip_r": -stride,
+            f"{prefix}_shoulder_l": -0.65 * stride,
+            f"{prefix}_shoulder_r": 0.65 * stride,
+        }
+        for name, value in values.items():
+            joint = model.joint(name).id
+            data.qpos[int(model.jnt_qposadr[joint])] = value
+            data.qvel[int(model.jnt_dofadr[joint])] = 0.0

--- a/scripts/behavior_demos/follow_me_among_others/metrics.py
+++ b/scripts/behavior_demos/follow_me_among_others/metrics.py
@@ -1,0 +1,182 @@
+"""Acceptance gates and the metrics summary for the crowd-following demo.
+
+Kept apart from the runner so the gates can be unit-tested against synthetic
+rollouts on CPU, with no model, policy or renderer involved. A demo whose
+success criteria can only be checked by running the demo is not validated.
+"""
+
+import math
+from itertools import pairwise
+
+import numpy as np
+
+# --- Acceptance thresholds -------------------------------------------------
+# A FOLLOW segment must produce real locomotion, not a policy that emits a
+# command and stands there. Both a path-length and a net-displacement floor are
+# required: walking in a circle passes the first and fails the second.
+MIN_FOLLOW_PATH_M = 0.40
+MIN_FOLLOW_DISPLACEMENT_M = 0.30
+
+# ...and it must actually close distance on its target at some point, so that
+# "moved" cannot be satisfied by wandering away.
+MIN_FOLLOW_APPROACH_M = 0.05
+
+# Trunk height below which the robot counts as fallen (nominal is ~0.116 m).
+FALLEN_TRUNK_Z_M = 0.09
+
+# States in which the locomotion command must be exactly zero.
+STATIONARY_STATES = ("SEARCH", "FOUND", "STOP", "DONE")
+
+
+def follow_segment_metrics(records, sequence):
+    """Per-selection FOLLOW statistics, in requested order."""
+    follow_rows = [r for r in records if r["state"] == "FOLLOW"]
+    segments = []
+    for selection_index, target_color in enumerate(sequence, start=1):
+        rows = [r for r in follow_rows if r["selection"] == selection_index]
+        if not rows:
+            raise RuntimeError(
+                f"selection {selection_index} ({target_color}) never followed"
+            )
+        positions = [np.asarray(r["duck_xy"], dtype=np.float64) for r in rows]
+        path_distance = sum(
+            float(np.linalg.norm(b - a)) for a, b in pairwise(positions)
+        )
+        segments.append(
+            {
+                "selection": selection_index,
+                "target": target_color,
+                "path_distance_m": path_distance,
+                "net_displacement_m": float(
+                    np.linalg.norm(positions[-1] - positions[0])
+                ),
+                "start_error_m": rows[0]["follow_error_m"],
+                "end_error_m": rows[-1]["follow_error_m"],
+                "min_error_m": min(r["follow_error_m"] for r in rows),
+                "start_yaw_error_deg": rows[0]["yaw_error_deg"],
+                "end_yaw_error_deg": rows[-1]["yaw_error_deg"],
+            }
+        )
+    return segments
+
+
+def segment_moved(segment) -> bool:
+    return (
+        segment["path_distance_m"] >= MIN_FOLLOW_PATH_M
+        and segment["net_displacement_m"] >= MIN_FOLLOW_DISPLACEMENT_M
+    )
+
+
+def segment_approached(segment) -> bool:
+    return segment["min_error_m"] <= segment["start_error_m"] - MIN_FOLLOW_APPROACH_M
+
+
+def summarize(
+    *,
+    records,
+    transitions,
+    cycles,
+    sequence,
+    duration_s,
+    control_steps,
+    frames,
+    trail_distance_m,
+    camera_stats,
+):
+    """Build the metrics dictionary written next to a rollout."""
+    follow_rows = [r for r in records if r["state"] == "FOLLOW"]
+    if not follow_rows:
+        raise RuntimeError("rollout contains no FOLLOW steps")
+    segments = follow_segment_metrics(records, sequence)
+
+    return {
+        "duration_s": duration_s,
+        "control_steps": control_steps,
+        "frames": frames,
+        "target_sequence_requested": list(sequence),
+        "target_sequence_completed": [c["target"] for c in cycles],
+        "pattern": ["SEARCH", "FOUND", "FOLLOW", "STOP"],
+        "cycles_completed": len(cycles),
+        "cycles": cycles,
+        "follow_by_selection": segments,
+        "all_follow_segments_moved": all(segment_moved(s) for s in segments),
+        "all_follow_segments_approached": all(segment_approached(s) for s in segments),
+        "transitions": transitions,
+        "trail_distance_m": trail_distance_m,
+        "follow_rmse_m": math.sqrt(
+            sum(r["follow_error_m"] ** 2 for r in follow_rows) / len(follow_rows)
+        ),
+        "follow_max_m": max(r["follow_error_m"] for r in follow_rows),
+        "person_range_follow_mean_m": sum(r["person_range_m"] for r in follow_rows)
+        / len(follow_rows),
+        "person_range_follow_min_m": min(r["person_range_m"] for r in follow_rows),
+        "person_range_follow_max_m": max(r["person_range_m"] for r in follow_rows),
+        "search_duration_mean_s": sum(c["search_duration_s"] for c in cycles)
+        / len(cycles),
+        "search_duration_max_s": max(c["search_duration_s"] for c in cycles),
+        # Every FOUND transition must coincide with a step in which the camera
+        # actually reported the requested color visible.
+        "found_while_target_visible": all(
+            any(
+                r["target_visible"]
+                for r in records
+                if r["target"] == cycle["target"]
+                and abs(r["t"] - cycle["found_s"]) < 0.04
+            )
+            for cycle in cycles
+        ),
+        # Any completed cycle whose target differs from the requested color at
+        # that position is a wrong-color lock.
+        "wrong_color_locks": sum(
+            cycle["target"] != sequence[index] for index, cycle in enumerate(cycles)
+        ),
+        "camera_target_visible_follow_pct": 100.0
+        * sum(r["target_visible"] for r in follow_rows)
+        / len(follow_rows),
+        "stationary_state_command_max": max(
+            float(np.linalg.norm(r["command"]))
+            for r in records
+            if r["state"] in STATIONARY_STATES
+        ),
+        "min_trunk_z_m": min(r["trunk_z_m"] for r in records),
+        "final_trunk_z_m": records[-1]["trunk_z_m"],
+        "fallen_steps": sum(r["trunk_z_m"] < FALLEN_TRUNK_Z_M for r in records),
+        **camera_stats,
+    }
+
+
+def check_gates(summary, sequence) -> list[str]:
+    """Return the list of violated acceptance gates (empty means pass)."""
+    failures = []
+    if summary["target_sequence_completed"] != list(sequence):
+        failures.append(
+            f"completed sequence {summary['target_sequence_completed']} != "
+            f"requested {list(sequence)}"
+        )
+    if summary["cycles_completed"] != len(sequence):
+        failures.append(
+            f"{summary['cycles_completed']} cycles completed, expected {len(sequence)}"
+        )
+    if not summary["found_while_target_visible"]:
+        failures.append("a FOUND transition happened while the target was not visible")
+    if summary["wrong_color_locks"] != 0:
+        failures.append(f"wrong_color_locks={summary['wrong_color_locks']}")
+    if summary["camera_target_visible_follow_pct"] < 100.0:
+        failures.append(
+            "target not visible for 100% of FOLLOW steps "
+            f"({summary['camera_target_visible_follow_pct']:.1f}%)"
+        )
+    if not summary["all_follow_segments_moved"]:
+        failures.append("a FOLLOW segment did not produce locomotion")
+    if not summary["all_follow_segments_approached"]:
+        failures.append("a FOLLOW segment never approached its target")
+    if summary["stationary_state_command_max"] != 0.0:
+        failures.append(
+            "non-zero locomotion command in a stationary state "
+            f"({summary['stationary_state_command_max']})"
+        )
+    if summary["fallen_steps"] != 0:
+        failures.append(f"fallen_steps={summary['fallen_steps']}")
+    if summary["min_trunk_z_m"] <= FALLEN_TRUNK_Z_M:
+        failures.append(f"min trunk z={summary['min_trunk_z_m']:.4f} m")
+    return failures

--- a/scripts/behavior_demos/follow_me_among_others/overlay.py
+++ b/scripts/behavior_demos/follow_me_among_others/overlay.py
@@ -1,0 +1,192 @@
+"""HUD overlay: camera PiP, active target, state pipeline and progress badges.
+
+Imported lazily by the runner, so ``--no-render`` never requires Pillow.
+"""
+
+import math
+
+from PIL import Image, ImageDraw, ImageFont
+
+PIP_W, PIP_H = 260, 190
+
+COLOR_RGB = {
+    "BLUE": (55, 115, 255),
+    "GREEN": (45, 220, 100),
+    "RED": (255, 70, 75),
+    "YELLOW": (255, 210, 55),
+    "PURPLE": (190, 90, 245),
+}
+STATE_RGB = {
+    "SEARCH": (255, 210, 75),
+    "FOUND": (75, 255, 150),
+    "FOLLOW": (90, 190, 255),
+    "STOP": (255, 105, 110),
+    "DONE": (180, 255, 180),
+}
+PIPELINE = ("SEARCH", "FOUND", "FOLLOW", "STOP")
+
+# Candidate monospace faces, tried in order. Pillow's default bitmap font is a
+# fine fallback: the overlay is diagnostic, so it must never be the reason a
+# headless machine cannot render.
+_FONT_CANDIDATES = (
+    "/System/Library/Fonts/SFNSMono.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+)
+
+
+def _font(size: int = 14):
+    for path in _FONT_CANDIDATES:
+        try:
+            return ImageFont.truetype(path, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def compose(
+    main_rgb,
+    pip_rgb,
+    *,
+    t,
+    total_seconds,
+    state,
+    state_elapsed,
+    selection,
+    target,
+    sequence,
+    duck_pos,
+    follow,
+    command,
+    camera,
+    min_height,
+    completed_cycles,
+):
+    image = Image.fromarray(main_rgb)
+    pip = Image.fromarray(pip_rgb)
+    draw = ImageDraw.Draw(image)
+    font, small, tiny = _font(14), _font(12), _font(11)
+    width, height = image.size
+    accent = COLOR_RGB[target]
+    state_color = STATE_RGB[state]
+    total = len(sequence)
+
+    draw.rectangle([0, 0, width, 132], fill=(4, 8, 14))
+    draw.text(
+        (12, 8),
+        f"FOLLOW-ME - AMONG OTHERS   t={t:05.2f}s",
+        fill=accent,
+        font=font,
+    )
+    draw.text(
+        (12, 31),
+        f"SELECTION {selection}/{total}   TARGET: {target:<5}   STATE: {state}",
+        fill=state_color,
+        font=small,
+    )
+    visible = ", ".join(camera["visible_colors"]) or "NONE"
+    draw.text(
+        (12, 52),
+        f"camera sees: {visible:<25} target off-axis="
+        f"{math.degrees(camera['target_off_axis']):5.1f} deg",
+        fill=(230, 238, 248),
+        font=small,
+    )
+    draw.text(
+        (12, 73),
+        f"queued-footprint error={follow['error']:.3f} m   "
+        f"target range={camera['target_distance']:.3f} m   "
+        f"state time={state_elapsed:.2f} s",
+        fill=(230, 238, 248),
+        font=small,
+    )
+    draw.text(
+        (12, 94),
+        f"command vx={command[0]:+.3f} vy={command[1]:+.3f} "
+        f"wz={command[2]:+.3f}   yaw error="
+        f"{math.degrees(follow['yaw_error']):+5.1f} deg",
+        fill=(230, 238, 248),
+        font=small,
+    )
+    stable = duck_pos[2] >= 0.09
+    draw.text(
+        (12, 115),
+        f"trunk z={duck_pos[2]:.3f} m   min={min_height:.3f} m   "
+        f"{'UPRIGHT' if stable else 'FALLEN'}",
+        fill=(145, 255, 165) if stable else (255, 90, 90),
+        font=small,
+    )
+
+    px0, py0 = width - PIP_W - 12, 143
+    border = accent if camera["target_visible"] else (255, 190, 60)
+    draw.rectangle(
+        [px0 - 4, py0 - 24, px0 + PIP_W + 4, py0 + PIP_H + 4], fill=(2, 5, 8)
+    )
+    label = f"SEARCHING {target}" if state == "SEARCH" else f"TRACKING {target}"
+    draw.text((px0, py0 - 21), f"DUCK CAMERA - {label}", fill=border, font=small)
+    image.paste(pip, (px0, py0))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle(
+        [px0 - 1, py0 - 1, px0 + PIP_W, py0 + PIP_H], outline=border, width=3
+    )
+    cx, cy = px0 + PIP_W // 2, py0 + PIP_H // 2
+    draw.line([cx - 9, cy, cx + 9, cy], fill=(255, 245, 95), width=1)
+    draw.line([cx, cy - 9, cx, cy + 9], fill=(255, 245, 95), width=1)
+    if camera["target_visible"]:
+        status = "VISIBLE" if state == "SEARCH" else "LOCKED"
+        draw.text((px0 + 8, py0 + 8), f"{target} {status}", fill=accent, font=small)
+
+    # Make the repeated control pattern explicit for a viewer who never reads
+    # the metrics file.
+    pipe_x, pipe_y = 16, height - 82
+    for idx, name in enumerate(PIPELINE):
+        x = pipe_x + idx * 132
+        active = name == state
+        fill = STATE_RGB[name] if active else (34, 44, 58)
+        draw.rounded_rectangle(
+            [x, pipe_y, x + 108, pipe_y + 30],
+            radius=7,
+            fill=fill,
+            outline=STATE_RGB[name],
+            width=2,
+        )
+        draw.text(
+            (x + 9, pipe_y + 7),
+            name,
+            fill=(5, 10, 16) if active else STATE_RGB[name],
+            font=small,
+        )
+        if idx < len(PIPELINE) - 1:
+            draw.text((x + 112, pipe_y + 7), ">", fill=(170, 185, 205), font=font)
+
+    # Target badges persist so a repeated color is unmistakable.
+    badge_y = height - 36
+    slot = max(1, (width - 32) // max(total, 1))
+    for idx, color in enumerate(sequence):
+        x = 16 + idx * slot
+        finished = idx < completed_cycles
+        active = idx == selection - 1 and state != "DONE"
+        outline = COLOR_RGB[color]
+        fill = outline if active else ((44, 54, 68) if not finished else (24, 90, 55))
+        draw.rounded_rectangle(
+            [x, badge_y, x + min(124, slot - 8), badge_y + 23],
+            radius=6,
+            fill=fill,
+            outline=outline,
+            width=2,
+        )
+        prefix = "OK " if finished else ""
+        draw.text(
+            (x + 8, badge_y + 4),
+            f"{prefix}{idx + 1} {color}",
+            fill=(5, 10, 16) if active else outline,
+            font=tiny,
+        )
+
+    progress_x = 16 + int((width - 32) * min(t / total_seconds, 1.0))
+    draw.line(
+        [progress_x, height - 7, progress_x, height - 2],
+        fill=(255, 255, 255),
+        width=2,
+    )
+    return image

--- a/scripts/behavior_demos/follow_me_among_others/run_demo.py
+++ b/scripts/behavior_demos/follow_me_among_others/run_demo.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Follow-me-among-others: color-selective crowd following in CPU MuJoCo.
+
+A behavior demo, not a trained policy and not robot autonomy. It drives the
+*stock* exported walking policy with a twist command produced by a geometric
+controller, so nothing here needs a GPU, a training run or new weights.
+
+Five pedestrians in blue, green, red, yellow and purple walk continuously on
+independent routes. The robot repeatedly searches the crowd through its head
+camera, acquires the requested shirt color, follows that person's queued
+footsteps 0.55 m back along their own path, and stops:
+
+    BLUE -> GREEN -> RED -> BLUE
+    SEARCH -> FOUND -> FOLLOW -> STOP   (once per selection)
+
+Color recognition is an explicit MuJoCo semantic proxy (actor identity plus
+camera-frustum and occlusion tests), NOT an RGB classifier -- see camera.py.
+
+Usage (from the repo root, with your own exported walking policy):
+
+    uv run --with imageio --with pillow \
+        scripts/behavior_demos/follow_me_among_others/run_demo.py \
+        --policy /path/to/walking.onnx --no-render
+
+Drop --no-render (and pass --out) to also write HUD frames as PNGs.
+"""
+
+import argparse
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import onnxruntime as ort
+
+if __package__ in (None, ""):
+    # Allow `python scripts/behavior_demos/follow_me_among_others/run_demo.py`
+    # as well as `python -m ...`, without requiring an install step.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from follow_me_among_others import metrics as metrics_module
+    from follow_me_among_others.camera import CrowdCameraSearch
+    from follow_me_among_others.crowd import (
+        COLORS,
+        CTRL_HZ,
+        TARGET_SEQUENCE,
+        TRAIL_DISTANCE,
+        CrowdFollowController,
+        FootstepTrail,
+        SearchFollowStateMachine,
+        animate_crowd,
+        crowd_trajectory,
+    )
+else:
+    from . import metrics as metrics_module
+    from .camera import CrowdCameraSearch
+    from .crowd import (
+        COLORS,
+        CTRL_HZ,
+        TARGET_SEQUENCE,
+        TRAIL_DISTANCE,
+        CrowdFollowController,
+        FootstepTrail,
+        SearchFollowStateMachine,
+        animate_crowd,
+        crowd_trajectory,
+    )
+
+# Repo-relative default; overridable with --xml. No absolute paths anywhere.
+DEFAULT_XML = "src/mjlab_microduck/robot/microduck/scene_follow_me_among_others.xml"
+
+# STAND2 pose, identical to HOME_FRAME in microduck_constants.py and to the
+# STAND keyframe in the scene. Actions are offsets from this pose.
+DEFAULT_POSE = np.array(
+    [
+        0.0,
+        -0.0873,
+        -0.4579,
+        -0.0049,
+        0.4530,
+        0.3491,
+        0.3491,
+        0.0,
+        0.0,
+        0.0,
+        0.0873,
+        0.4579,
+        0.0049,
+        -0.4530,
+    ],
+    dtype=np.float32,
+)
+
+# Observation contract shared by every policy in this repo (AGENTS.md):
+# 48 proprioception + 13 command = 61. Unused command slots are zero-padded,
+# never dropped.
+EXPECTED_OBS_DIM = 61
+EXPECTED_COMMAND_DIM = 13
+
+# Matches the action scale used by infer_policy.py for the walking policy.
+ACTION_SCALE = 0.9
+
+# Angular-velocity sensor names accepted, in preference order.
+GYRO_SENSOR_NAMES = ("imu_ang_vel", "gyro", "angular-velocity")
+
+
+def yaw_of_body(data, body_id: int) -> float:
+    forward = data.xmat[body_id].reshape(3, 3)[:, 0]
+    return math.atan2(float(forward[1]), float(forward[0]))
+
+
+def make_observation(
+    data,
+    model,
+    qpos_idx,
+    qvel_idx,
+    trunk_id,
+    gyro_adr,
+    last_action,
+    command,
+    command_dim,
+):
+    """Assemble the 61-D actor observation."""
+    quat = data.xquat[trunk_id].astype(np.float32)
+    w, xyz = quat[0], quat[1:4]
+    gravity_world = np.array([0.0, 0.0, -1.0], dtype=np.float32)
+    cross = np.cross(xyz, gravity_world) * 2.0
+    gravity = gravity_world - w * cross + np.cross(xyz, cross)
+    gyro = data.sensordata[gyro_adr : gyro_adr + 3].astype(np.float32)
+    joint_pos = data.qpos[qpos_idx].astype(np.float32) - DEFAULT_POSE
+    joint_vel = data.qvel[qvel_idx].astype(np.float32)
+    policy_command = np.zeros(command_dim, dtype=np.float32)
+    # Only the twist slots are driven; head_pose and body_pose stay zeroed.
+    policy_command[:3] = command
+    observation = np.concatenate(
+        [gyro, gravity, joint_pos, joint_vel, last_action, policy_command]
+    ).astype(np.float32)
+    if observation.shape != (EXPECTED_OBS_DIM,):
+        raise RuntimeError(
+            f"expected {EXPECTED_OBS_DIM}-D observation, got {observation.shape}"
+        )
+    return observation
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--policy",
+        required=True,
+        help="Path to an exported walking ONNX policy (scripts/export.py).",
+    )
+    parser.add_argument("--xml", default=DEFAULT_XML, help="Scene MJCF.")
+    parser.add_argument("--seconds", type=float, default=60.0)
+    parser.add_argument(
+        "--targets",
+        default=",".join(TARGET_SEQUENCE),
+        help="Comma-separated shirt colors to follow in order.",
+    )
+    parser.add_argument("--metrics", default=None, help="Write the metrics JSON here.")
+    parser.add_argument(
+        "--out", default=None, help="Directory for rendered PNG frames."
+    )
+    parser.add_argument("--width", type=int, default=960)
+    parser.add_argument("--height", type=int, default=640)
+    parser.add_argument("--fps", type=int, default=50)
+    parser.add_argument(
+        "--no-render",
+        action="store_true",
+        help="Skip rendering; metrics and gates are unaffected.",
+    )
+    parser.add_argument("--quiet", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    sequence = tuple(
+        part.strip().upper() for part in args.targets.split(",") if part.strip()
+    )
+    render = not args.no_render
+    if render and not args.out:
+        raise SystemExit("--out is required unless --no-render is given")
+    if render:
+        os.makedirs(args.out, exist_ok=True)
+
+    model = mujoco.MjModel.from_xml_path(args.xml)
+    data = mujoco.MjData(model)
+    mujoco.mj_resetData(model, data)
+    if model.nu != 14:
+        raise RuntimeError(f"expected 14 policy actuators, got {model.nu}")
+
+    qpos_idx = np.array(
+        [int(model.jnt_qposadr[model.actuator_trnid[i, 0]]) for i in range(model.nu)]
+    )
+    qvel_idx = np.array(
+        [int(model.jnt_dofadr[model.actuator_trnid[i, 0]]) for i in range(model.nu)]
+    )
+    for index, address in enumerate(qpos_idx):
+        data.qpos[address] = DEFAULT_POSE[index]
+    data.ctrl[:] = DEFAULT_POSE
+
+    trunk_id = model.body("trunk_base").id
+    people_mocap = {
+        color: int(model.body_mocapid[model.body(f"person_{color.lower()}").id])
+        for color in COLORS
+    }
+    target_mocap = int(model.body_mocapid[model.body("trail_target").id])
+
+    gyro_id = -1
+    for sensor_name in GYRO_SENSOR_NAMES:
+        gyro_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, sensor_name)
+        if gyro_id >= 0:
+            break
+    if gyro_id < 0:
+        raise RuntimeError("no angular-velocity sensor found in model")
+    gyro_adr = int(model.sensor_adr[gyro_id])
+
+    initial_crowd = crowd_trajectory(0.0)
+    animate_crowd(model, data, initial_crowd, 0.0)
+    mujoco.mj_forward(model, data)
+    trails = {color: FootstepTrail(initial_crowd[color]) for color in COLORS}
+
+    session = ort.InferenceSession(args.policy, providers=["CPUExecutionProvider"])
+    input_name = session.get_inputs()[0].name
+    output_name = session.get_outputs()[0].name
+    observation_dim = int(session.get_inputs()[0].shape[1])
+    command_dim = observation_dim - (3 + 3 + model.nu * 3)
+    if observation_dim != EXPECTED_OBS_DIM or command_dim != EXPECTED_COMMAND_DIM:
+        raise RuntimeError(
+            f"policy shape mismatch: observation={observation_dim}, "
+            f"command={command_dim} (expected {EXPECTED_OBS_DIM}/"
+            f"{EXPECTED_COMMAND_DIM}); export with scripts/export.py"
+        )
+
+    decimation = max(1, round((1.0 / CTRL_HZ) / model.opt.timestep))
+    total_steps = int(args.seconds * CTRL_HZ)
+    frame_every = max(1, round(CTRL_HZ / args.fps))
+    controller = CrowdFollowController()
+    machine = SearchFollowStateMachine(sequence)
+    camera_search = CrowdCameraSearch(model, data, qpos_idx, trunk_id)
+    last_action = np.zeros(model.nu, dtype=np.float32)
+    records: list[dict] = []
+    transitions: list[dict] = []
+    frames = 0
+    min_height = float(data.xpos[trunk_id, 2])
+
+    renderer = pip_renderer = compose = None
+    if render:
+        import imageio.v2 as imageio
+
+        from follow_me_among_others.overlay import PIP_H, PIP_W, compose
+
+        renderer = mujoco.Renderer(model, height=args.height, width=args.width)
+        pip_renderer = mujoco.Renderer(model, height=PIP_H, width=PIP_W)
+        camera = mujoco.MjvCamera()
+        mujoco.mjv_defaultCamera(camera)
+        camera.distance = 2.85
+        camera.elevation = -27
+        camera.azimuth = -48
+        camera_lookat = np.array([0.75, 0.0, 0.16], dtype=np.float64)
+
+    if not args.quiet:
+        print(
+            f"follow-me-among-others: {total_steps} steps, "
+            f"targets={'->'.join(sequence)}, lag={TRAIL_DISTANCE:.2f} m, "
+            f"decimation={decimation}, render={render}"
+        )
+
+    for step in range(total_steps):
+        t = step / CTRL_HZ
+        crowd = crowd_trajectory(t)
+        animate_crowd(model, data, crowd, t)
+        mujoco.mj_forward(model, data)
+        trail_states = {color: trails[color].update(crowd[color]) for color in COLORS}
+
+        state = machine.state if not machine.done else "DONE"
+        target = machine.target
+        selection = min(machine.index + 1, len(sequence))
+        state_elapsed = t - machine.state_since
+        duck_pos_before = data.xpos[trunk_id].copy()
+        duck_yaw_before = yaw_of_body(data, trunk_id)
+        active_trail = trail_states[target]
+
+        command, follow = controller.update(
+            state == "FOLLOW", active_trail, duck_pos_before, duck_yaw_before
+        )
+        if state == "FOLLOW":
+            data.mocap_pos[target_mocap] = np.array(
+                [active_trail.pos[0], active_trail.pos[1], 0.012]
+            )
+        else:
+            # Park the marker under the floor when it means nothing.
+            data.mocap_pos[target_mocap] = np.array([0.0, 0.0, -0.10])
+
+        observation = make_observation(
+            data,
+            model,
+            qpos_idx,
+            qvel_idx,
+            trunk_id,
+            gyro_adr,
+            last_action,
+            command,
+            command_dim,
+        )
+        action = (
+            session.run([output_name], {input_name: observation.reshape(1, -1)})[0]
+            .squeeze(0)
+            .astype(np.float32)
+        )
+        last_action = action.copy()
+        data.ctrl[:] = DEFAULT_POSE + ACTION_SCALE * action
+        for _ in range(decimation):
+            mujoco.mj_step(model, data)
+
+        display_t = min(t + 1.0 / CTRL_HZ, args.seconds)
+        display_crowd = crowd_trajectory(display_t)
+        animate_crowd(model, data, display_crowd, display_t)
+        mujoco.mj_forward(model, data)
+        duck_pos = data.xpos[trunk_id].copy()
+        duck_yaw = yaw_of_body(data, trunk_id)
+        min_height = min(min_height, float(duck_pos[2]))
+
+        camera_state = camera_search.update(
+            data,
+            target_color=target,
+            mode=state,
+            mode_elapsed=state_elapsed,
+            duck_yaw=duck_yaw,
+        )
+        follow_error = float(np.linalg.norm(active_trail.pos - duck_pos[:2]))
+        follow["error"] = follow_error
+        person_pos = data.mocap_pos[people_mocap[target], :2]
+        records.append(
+            {
+                "t": display_t,
+                "state": state,
+                "selection": selection,
+                "target": target,
+                "state_elapsed_s": state_elapsed,
+                "target_visible": bool(camera_state["target_visible"]),
+                "target_off_axis_deg": math.degrees(camera_state["target_off_axis"]),
+                "visible_colors": camera_state["visible_colors"],
+                "trail_target_xy": active_trail.pos.tolist(),
+                "follow_error_m": follow_error,
+                "person_range_m": float(np.linalg.norm(person_pos - duck_pos[:2])),
+                "yaw_error_deg": math.degrees(follow["yaw_error"]),
+                "duck_yaw_deg": math.degrees(duck_yaw),
+                "duck_xy": duck_pos[:2].tolist(),
+                "trunk_z_m": float(duck_pos[2]),
+                "command": command.tolist(),
+            }
+        )
+
+        next_state, next_target, changed = machine.update(display_t, camera_state)
+        if changed:
+            transitions.append(
+                {
+                    "t": display_t,
+                    "from": state,
+                    "to": next_state,
+                    "target": next_target,
+                    "selection": min(machine.index + 1, len(sequence)),
+                }
+            )
+            if not args.quiet:
+                print(
+                    f"  t={display_t:5.2f}s {state:10s} -> {next_state:10s} "
+                    f"target={next_target}"
+                )
+
+        if render and step % frame_every == 0:
+            all_positions = np.vstack(
+                [duck_pos[:2], *[display_crowd[color].pos for color in COLORS]]
+            )
+            center = np.array(
+                [
+                    float(np.mean(all_positions[:, 0])),
+                    float(np.mean(all_positions[:, 1])),
+                    0.16,
+                ]
+            )
+            camera_lookat += 0.05 * (center - camera_lookat)
+            camera.lookat[:] = camera_lookat
+            # Render the gaze clone: it carries the same physics plus the head
+            # pose and the stabilized rig.
+            renderer.update_scene(camera_search.gaze_data, camera=camera)
+            pip_renderer.update_scene(
+                camera_search.gaze_data, camera=camera_search.camera_id
+            )
+            image = compose(
+                renderer.render(),
+                pip_renderer.render(),
+                t=display_t,
+                total_seconds=args.seconds,
+                state=state,
+                state_elapsed=state_elapsed,
+                selection=selection,
+                target=target,
+                sequence=sequence,
+                duck_pos=duck_pos,
+                follow=follow,
+                command=command,
+                camera=camera_state,
+                min_height=min_height,
+                completed_cycles=len(machine.cycles),
+            )
+            imageio.imwrite(Path(args.out) / f"f{frames:05d}.png", np.asarray(image))
+            frames += 1
+
+    if not machine.done:
+        raise RuntimeError(
+            f"sequence incomplete after {args.seconds:.1f}s: "
+            f"selection={machine.index + 1}, state={machine.state}"
+        )
+
+    summary = metrics_module.summarize(
+        records=records,
+        transitions=transitions,
+        cycles=machine.cycles,
+        sequence=sequence,
+        duration_s=args.seconds,
+        control_steps=total_steps,
+        frames=frames,
+        trail_distance_m=TRAIL_DISTANCE,
+        camera_stats={
+            "camera_target_visible_steps": camera_search.target_visible_steps,
+            "camera_search_steps": camera_search.search_steps,
+            "camera_search_target_visible_steps": (
+                camera_search.search_target_visible_steps
+            ),
+        },
+    )
+    if args.metrics:
+        Path(args.metrics).write_text(json.dumps(summary, indent=2) + "\n")
+
+    failures = metrics_module.check_gates(summary, sequence)
+    if not args.quiet:
+        print(json.dumps(summary, indent=2))
+    if failures:
+        for failure in failures:
+            print(f"ACCEPTANCE FAILURE: {failure}", file=sys.stderr)
+        return 1
+    if not args.quiet:
+        print(f"all acceptance gates passed ({len(sequence)} selections)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mjlab_microduck/robot/microduck/scene_follow_me_among_others.xml
+++ b/src/mjlab_microduck/robot/microduck/scene_follow_me_among_others.xml
@@ -1,0 +1,109 @@
+<mujoco model="scene_follow_me_among_others">
+    <include file="robot_walk.xml" />
+
+    <visual>
+        <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
+        <rgba haze="0.15 0.25 0.35 1" />
+        <global azimuth="160" elevation="-20" offwidth="1280" offheight="960" />
+    </visual>
+
+    <asset>
+        <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0"
+                 width="512" height="3072" />
+        <texture type="2d" name="groundplane" builtin="checker" mark="edge"
+                 rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3" markrgb="0.8 0.8 0.8"
+                 width="300" height="300" />
+        <material name="groundplane" texture="groundplane" texuniform="true"
+                  texrepeat="5 5" reflectance="0.2" />
+        <material name="skinmat" rgba="0.85 0.65 0.5 1" />
+        <material name="blue_shirt" rgba="0.08 0.30 0.95 1" />
+        <material name="green_shirt" rgba="0.08 0.72 0.25 1" />
+        <material name="red_shirt" rgba="0.90 0.10 0.12 1" />
+        <material name="yellow_shirt" rgba="0.95 0.72 0.08 1" />
+        <material name="purple_shirt" rgba="0.65 0.18 0.88 1" />
+        <material name="trousermat" rgba="0.08 0.12 0.22 1" />
+        <material name="shoemat" rgba="0.04 0.04 0.05 1" />
+        <material name="accentmat" rgba="0.95 0.75 0.12 1" />
+        <material name="trailmat" rgba="0.15 1.0 0.35 0.75" />
+    </asset>
+
+    <worldbody>
+        <light pos="0 0 3.5" dir="0 0 -1" directional="true" />
+        <geom name="floor" size="0 0 0.05" pos="0 0 0" type="plane"
+              material="groundplane" />
+
+        <body name="trail_target" mocap="true" pos="0 0 0.012">
+            <geom name="trail_target_disc" type="cylinder" size="0.030 0.004"
+                  material="trailmat" contype="0" conaffinity="0" />
+        </body>
+        <body name="follow_camera_rig" mocap="true" pos="0 0 0.2">
+            <camera name="follow_camera" fovy="52" />
+        </body>
+
+        <!-- Five independently animated pedestrians. Local +X is forward. -->
+        <body name="person_blue" mocap="true" pos="1.25 0.10 0.36">
+            <geom name="blue_torso" type="capsule" fromto="0 0 -0.10 0 0 0.16" size="0.075" material="blue_shirt" contype="0" conaffinity="0" />
+            <geom name="blue_head" type="sphere" pos="0 0 0.25" size="0.062" material="skinmat" contype="0" conaffinity="0" />
+            <geom name="blue_nose" type="sphere" pos="0.058 0 0.25" size="0.018" material="accentmat" contype="0" conaffinity="0" />
+            <body name="blue_leg_l" pos="0 0.035 -0.10"><joint name="blue_hip_l" type="hinge" axis="0 1 0" range="-35 35" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032" material="trousermat" contype="0" conaffinity="0" /><geom type="capsule" fromto="0 0 -0.26 0.07 0 -0.27" size="0.034" material="shoemat" contype="0" conaffinity="0" /></body>
+            <body name="blue_leg_r" pos="0 -0.035 -0.10"><joint name="blue_hip_r" type="hinge" axis="0 1 0" range="-35 35" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032" material="trousermat" contype="0" conaffinity="0" /><geom type="capsule" fromto="0 0 -0.26 0.07 0 -0.27" size="0.034" material="shoemat" contype="0" conaffinity="0" /></body>
+            <body name="blue_arm_l" pos="0 0.075 0.11"><joint name="blue_shoulder_l" type="hinge" axis="0 1 0" range="-30 30" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025" material="skinmat" contype="0" conaffinity="0" /></body>
+            <body name="blue_arm_r" pos="0 -0.075 0.11"><joint name="blue_shoulder_r" type="hinge" axis="0 1 0" range="-30 30" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025" material="skinmat" contype="0" conaffinity="0" /></body>
+        </body>
+
+        <body name="person_green" mocap="true" pos="0.85 0.55 0.36">
+            <geom name="green_torso" type="capsule" fromto="0 0 -0.10 0 0 0.16" size="0.075" material="green_shirt" contype="0" conaffinity="0" />
+            <geom name="green_head" type="sphere" pos="0 0 0.25" size="0.062" material="skinmat" contype="0" conaffinity="0" />
+            <geom name="green_nose" type="sphere" pos="0.058 0 0.25" size="0.018" material="accentmat" contype="0" conaffinity="0" />
+            <body name="green_leg_l" pos="0 0.035 -0.10"><joint name="green_hip_l" type="hinge" axis="0 1 0" range="-35 35" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032" material="trousermat" contype="0" conaffinity="0" /><geom type="capsule" fromto="0 0 -0.26 0.07 0 -0.27" size="0.034" material="shoemat" contype="0" conaffinity="0" /></body>
+            <body name="green_leg_r" pos="0 -0.035 -0.10"><joint name="green_hip_r" type="hinge" axis="0 1 0" range="-35 35" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032" material="trousermat" contype="0" conaffinity="0" /><geom type="capsule" fromto="0 0 -0.26 0.07 0 -0.27" size="0.034" material="shoemat" contype="0" conaffinity="0" /></body>
+            <body name="green_arm_l" pos="0 0.075 0.11"><joint name="green_shoulder_l" type="hinge" axis="0 1 0" range="-30 30" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025" material="skinmat" contype="0" conaffinity="0" /></body>
+            <body name="green_arm_r" pos="0 -0.075 0.11"><joint name="green_shoulder_r" type="hinge" axis="0 1 0" range="-30 30" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025" material="skinmat" contype="0" conaffinity="0" /></body>
+        </body>
+
+        <body name="person_red" mocap="true" pos="1.10 -0.55 0.36">
+            <geom name="red_torso" type="capsule" fromto="0 0 -0.10 0 0 0.16" size="0.075" material="red_shirt" contype="0" conaffinity="0" />
+            <geom name="red_head" type="sphere" pos="0 0 0.25" size="0.062" material="skinmat" contype="0" conaffinity="0" />
+            <geom name="red_nose" type="sphere" pos="0.058 0 0.25" size="0.018" material="accentmat" contype="0" conaffinity="0" />
+            <body name="red_leg_l" pos="0 0.035 -0.10"><joint name="red_hip_l" type="hinge" axis="0 1 0" range="-35 35" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032" material="trousermat" contype="0" conaffinity="0" /><geom type="capsule" fromto="0 0 -0.26 0.07 0 -0.27" size="0.034" material="shoemat" contype="0" conaffinity="0" /></body>
+            <body name="red_leg_r" pos="0 -0.035 -0.10"><joint name="red_hip_r" type="hinge" axis="0 1 0" range="-35 35" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032" material="trousermat" contype="0" conaffinity="0" /><geom type="capsule" fromto="0 0 -0.26 0.07 0 -0.27" size="0.034" material="shoemat" contype="0" conaffinity="0" /></body>
+            <body name="red_arm_l" pos="0 0.075 0.11"><joint name="red_shoulder_l" type="hinge" axis="0 1 0" range="-30 30" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025" material="skinmat" contype="0" conaffinity="0" /></body>
+            <body name="red_arm_r" pos="0 -0.075 0.11"><joint name="red_shoulder_r" type="hinge" axis="0 1 0" range="-30 30" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025" material="skinmat" contype="0" conaffinity="0" /></body>
+        </body>
+
+        <body name="person_yellow" mocap="true" pos="1.65 0.35 0.36">
+            <geom name="yellow_torso" type="capsule" fromto="0 0 -0.10 0 0 0.16" size="0.075" material="yellow_shirt" contype="0" conaffinity="0" />
+            <geom name="yellow_head" type="sphere" pos="0 0 0.25" size="0.062" material="skinmat" contype="0" conaffinity="0" />
+            <geom name="yellow_nose" type="sphere" pos="0.058 0 0.25" size="0.018" material="accentmat" contype="0" conaffinity="0" />
+            <body name="yellow_leg_l" pos="0 0.035 -0.10"><joint name="yellow_hip_l" type="hinge" axis="0 1 0" range="-35 35" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032" material="trousermat" contype="0" conaffinity="0" /></body>
+            <body name="yellow_leg_r" pos="0 -0.035 -0.10"><joint name="yellow_hip_r" type="hinge" axis="0 1 0" range="-35 35" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032" material="trousermat" contype="0" conaffinity="0" /></body>
+            <body name="yellow_arm_l" pos="0 0.075 0.11"><joint name="yellow_shoulder_l" type="hinge" axis="0 1 0" range="-30 30" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025" material="skinmat" contype="0" conaffinity="0" /></body>
+            <body name="yellow_arm_r" pos="0 -0.075 0.11"><joint name="yellow_shoulder_r" type="hinge" axis="0 1 0" range="-30 30" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025" material="skinmat" contype="0" conaffinity="0" /></body>
+        </body>
+
+        <body name="person_purple" mocap="true" pos="0.55 -0.35 0.36">
+            <geom name="purple_torso" type="capsule" fromto="0 0 -0.10 0 0 0.16" size="0.075" material="purple_shirt" contype="0" conaffinity="0" />
+            <geom name="purple_head" type="sphere" pos="0 0 0.25" size="0.062" material="skinmat" contype="0" conaffinity="0" />
+            <geom name="purple_nose" type="sphere" pos="0.058 0 0.25" size="0.018" material="accentmat" contype="0" conaffinity="0" />
+            <body name="purple_leg_l" pos="0 0.035 -0.10"><joint name="purple_hip_l" type="hinge" axis="0 1 0" range="-35 35" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032" material="trousermat" contype="0" conaffinity="0" /></body>
+            <body name="purple_leg_r" pos="0 -0.035 -0.10"><joint name="purple_hip_r" type="hinge" axis="0 1 0" range="-35 35" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.26" size="0.032" material="trousermat" contype="0" conaffinity="0" /></body>
+            <body name="purple_arm_l" pos="0 0.075 0.11"><joint name="purple_shoulder_l" type="hinge" axis="0 1 0" range="-30 30" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025" material="skinmat" contype="0" conaffinity="0" /></body>
+            <body name="purple_arm_r" pos="0 -0.075 0.11"><joint name="purple_shoulder_r" type="hinge" axis="0 1 0" range="-30 30" damping="1" /><geom type="capsule" fromto="0 0 0 0 0 -0.20" size="0.025" material="skinmat" contype="0" conaffinity="0" /></body>
+        </body>
+    </worldbody>
+
+    <keyframe>
+        <key name="INIT" qpos="0 0 0.12 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+             ctrl="0 0 0 0 0 0 0 0 0 0 0 0 0 0" />
+        <key name="STAND" qpos="
+        0 0 0.12 1 0 0 0
+        0 -0.08726646259971647 -0.457924 -0.004940 0.452984
+        0.3490658503988659 0.3490658503988659 0 0
+        0 0.08726646259971647 0.457924 0.004940 -0.452984
+        0 0 0 0"
+        ctrl="
+        0 -0.08726646259971647 -0.457924 -0.004940 0.452984
+        0.3490658503988659 0.3490658503988659 0 0
+        0 0.08726646259971647 0.457924 0.004940 -0.452984" />
+    </keyframe>
+</mujoco>

--- a/tests/test_follow_me_among_others_color_gate.py
+++ b/tests/test_follow_me_among_others_color_gate.py
@@ -1,0 +1,140 @@
+"""Color-gating tests: the demo must lock onto the requested shirt color only.
+
+These drive the state machine with synthetic camera reports in which the wrong
+colors are visible, centered and closer than the target. Nothing here needs a
+model or a policy — the gate is a pure decision on the camera report, so it is
+tested as one.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / "scripts" / "behavior_demos")
+)
+
+from follow_me_among_others.crowd import (
+    DISTRACTOR_COLORS,
+    SELECTABLE_COLORS,
+    TARGET_SEQUENCE,
+    SearchFollowStateMachine,
+)
+
+CTRL_DT = 1.0 / 50.0
+CONE = SearchFollowStateMachine.FOUND_CONE
+
+
+def report(visible, off_axis_deg, others=()):
+    """One camera report. ``others`` never influences the gate by design."""
+    return {
+        "target_visible": visible,
+        "target_off_axis": math.radians(off_axis_deg),
+        "visible_colors": list(others) + (["TARGET"] if visible else []),
+    }
+
+
+def test_found_cone_is_eight_degrees():
+    assert CONE == pytest.approx(math.radians(8.0))
+
+
+def test_distractors_are_not_selectable_targets():
+    # The two distractor colors must never appear in the requested sequence.
+    assert set(DISTRACTOR_COLORS).isdisjoint(TARGET_SEQUENCE)
+    assert set(TARGET_SEQUENCE) <= set(SELECTABLE_COLORS)
+    assert set(SELECTABLE_COLORS).isdisjoint(DISTRACTOR_COLORS)
+
+
+def test_visible_distractors_alone_never_trigger_found():
+    # Every distractor is visible and dead-centered; the target is not visible.
+    machine = SearchFollowStateMachine(("BLUE",))
+    t = 0.0
+    while t < SearchFollowStateMachine.MAX_SEARCH_SECONDS - 0.1:
+        machine.update(t, report(False, 180.0, others=DISTRACTOR_COLORS))
+        assert machine.state == "SEARCH"
+        t += CTRL_DT
+    assert machine.cycles == []
+
+
+def test_target_visible_but_off_axis_does_not_trigger_found():
+    # Seen, but outside the acquisition cone: looking in roughly the right
+    # direction is not the same as having acquired the person.
+    machine = SearchFollowStateMachine(("GREEN",))
+    t = 0.0
+    while t < 5.0:
+        machine.update(t, report(True, 12.0))
+        assert machine.state == "SEARCH"
+        t += CTRL_DT
+
+
+def test_target_centered_and_visible_triggers_found():
+    machine = SearchFollowStateMachine(("RED",))
+    t = 0.0
+    while machine.state == "SEARCH" and t < 5.0:
+        machine.update(t, report(True, 1.5))
+        t += CTRL_DT
+    assert machine.state == "FOUND"
+    assert machine.current["found_s"] == pytest.approx(
+        SearchFollowStateMachine.MIN_SEARCH_SECONDS, abs=2 * CTRL_DT
+    )
+
+
+def test_acquisition_is_at_the_cone_boundary():
+    # Just inside acquires; just outside does not. Locks the gate value itself.
+    inside = SearchFollowStateMachine(("BLUE",))
+    outside = SearchFollowStateMachine(("BLUE",))
+    t = 0.0
+    while t < 3.0:
+        inside.update(t, report(True, 7.9))
+        outside.update(t, report(True, 8.1))
+        t += CTRL_DT
+    assert inside.state != "SEARCH"
+    assert outside.state == "SEARCH"
+
+
+def test_wrong_color_locks_are_impossible_by_construction():
+    # Whatever the crowd does, a completed cycle records the REQUESTED color:
+    # the machine never adopts a target from what it happens to see.
+    machine = SearchFollowStateMachine()
+    t = 0.0
+    while not machine.done and t < 120.0:
+        machine.update(t, report(True, 0.5, others=("YELLOW", "PURPLE", "RED")))
+        t += CTRL_DT
+    assert machine.done
+    completed = [c["target"] for c in machine.cycles]
+    assert completed == list(TARGET_SEQUENCE)
+    wrong_color_locks = sum(
+        cycle["target"] != TARGET_SEQUENCE[i] for i, cycle in enumerate(machine.cycles)
+    )
+    assert wrong_color_locks == 0
+
+
+def test_target_switches_only_after_a_completed_cycle():
+    # The active target must stay fixed for the whole SEARCH->STOP pipeline,
+    # so a mid-follow distraction cannot swap targets.
+    machine = SearchFollowStateMachine()
+    t = 0.0
+    seen_per_cycle = {}
+    while not machine.done and t < 120.0:
+        completed = len(machine.cycles)
+        seen_per_cycle.setdefault(completed, set()).add(machine.target)
+        machine.update(t, report(True, 0.5, others=DISTRACTOR_COLORS))
+        t += CTRL_DT
+    for completed, targets in seen_per_cycle.items():
+        assert len(targets) == 1, f"target changed mid-cycle {completed}: {targets}"
+
+
+def test_second_blue_selection_requires_a_fresh_search():
+    # Selection 4 repeats BLUE. It must run its own SEARCH, not reuse the lock
+    # from selection 1.
+    machine = SearchFollowStateMachine()
+    t = 0.0
+    while not machine.done and t < 120.0:
+        machine.update(t, report(True, 0.5))
+        t += CTRL_DT
+    first_blue, last_blue = machine.cycles[0], machine.cycles[3]
+    assert first_blue["target"] == last_blue["target"] == "BLUE"
+    assert last_blue["search_start_s"] > first_blue["cycle_end_s"]
+    assert last_blue["search_duration_s"] >= SearchFollowStateMachine.MIN_SEARCH_SECONDS

--- a/tests/test_follow_me_among_others_crowd.py
+++ b/tests/test_follow_me_among_others_crowd.py
@@ -1,0 +1,307 @@
+"""Crowd routes, footstep queues and the follow controller (CPU, no MuJoCo).
+
+Covers the properties the behavior actually depends on: five people who all
+keep moving independently, a queue that trails a fixed arc length behind the
+selected person, and a controller that emits exactly zero outside FOLLOW.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / "scripts" / "behavior_demos")
+)
+
+from follow_me_among_others.crowd import (
+    COLORS,
+    CTRL_HZ,
+    DISTRACTOR_COLORS,
+    SELECTABLE_COLORS,
+    TRAIL_DISTANCE,
+    CrowdFollowController,
+    FootstepTrail,
+    PersonState,
+    TrailState,
+    crowd_trajectory,
+    wrap,
+)
+
+CTRL_DT = 1.0 / CTRL_HZ
+ROLLOUT_SECONDS = 60.0
+
+
+def times(seconds=ROLLOUT_SECONDS, dt=CTRL_DT):
+    return [step * dt for step in range(int(seconds / dt))]
+
+
+# --- crowd -----------------------------------------------------------------
+
+
+def test_exactly_five_people_three_selectable_two_distractors():
+    crowd = crowd_trajectory(0.0)
+    assert set(crowd) == set(COLORS)
+    assert len(crowd) == 5
+    assert len(SELECTABLE_COLORS) == 3
+    assert len(DISTRACTOR_COLORS) == 2
+
+
+def test_trail_distance_is_055_m():
+    assert TRAIL_DISTANCE == pytest.approx(0.55)
+
+
+def test_trajectory_is_deterministic():
+    assert all(
+        np.allclose(crowd_trajectory(7.5)[c].pos, crowd_trajectory(7.5)[c].pos)
+        for c in COLORS
+    )
+
+
+def test_every_person_keeps_moving_for_the_whole_rollout():
+    # Nobody freezes, waits or teleports to make acquisition easier: over every
+    # one-second window, each person covers real ground.
+    samples = {c: [] for c in COLORS}
+    for t in times():
+        crowd = crowd_trajectory(t)
+        for color in COLORS:
+            samples[color].append(crowd[color].pos.copy())
+    for color in COLORS:
+        track = np.asarray(samples[color])
+        steps = np.linalg.norm(np.diff(track, axis=0), axis=1)
+        assert steps.min() > 0.0, f"{color} stopped"
+        whole = (len(steps) // int(CTRL_HZ)) * int(CTRL_HZ)
+        per_second = steps[:whole].reshape(-1, int(CTRL_HZ)).sum(axis=1)
+        assert per_second.min() > 0.01, f"{color} stalled for a second"
+        # No teleports: a single control step never jumps.
+        assert steps.max() < 0.05, f"{color} teleported"
+
+
+def test_people_move_independently_not_as_a_rigid_formation():
+    # Pairwise distances must vary: a crowd that keeps its shape is one object.
+    spans = []
+    for t in times(seconds=40.0, dt=0.2):
+        crowd = crowd_trajectory(t)
+        spans.append(
+            [
+                float(np.linalg.norm(crowd[a].pos - crowd[b].pos))
+                for i, a in enumerate(COLORS)
+                for b in COLORS[i + 1 :]
+            ]
+        )
+    variation = np.asarray(spans).std(axis=0)
+    assert variation.min() > 0.02, "crowd moves as a rigid formation"
+
+
+def test_people_travel_in_different_directions():
+    # Mixed lap directions, so the crowd is not a carousel.
+    crowd = crowd_trajectory(3.0)
+    headings = [crowd[c].yaw for c in COLORS]
+    assert len(set(np.round(headings, 3))) == len(COLORS)
+
+
+def test_yaw_follows_the_velocity_direction():
+    for t in (0.0, 4.2, 19.7):
+        for person in crowd_trajectory(t).values():
+            expected = math.atan2(float(person.velocity[1]), float(person.velocity[0]))
+            assert wrap(person.yaw - expected) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_people_stay_within_a_bounded_arena():
+    for t in times(seconds=ROLLOUT_SECONDS, dt=0.1):
+        for person in crowd_trajectory(t).values():
+            assert np.all(np.abs(person.pos) < 3.0)
+
+
+# --- footstep trail --------------------------------------------------------
+
+
+def test_trail_lags_by_the_configured_arc_length():
+    color = "BLUE"
+    trail = FootstepTrail(crowd_trajectory(0.0)[color])
+    state = None
+    for t in times(seconds=30.0):
+        state = trail.update(crowd_trajectory(t)[color])
+    assert isinstance(state, TrailState)
+    # Once the person has walked further than the gap, the queue is exactly
+    # one gap behind in ARC LENGTH (not straight-line distance).
+    assert state.leader_path_s > TRAIL_DISTANCE
+    assert state.leader_path_s - state.path_s == pytest.approx(TRAIL_DISTANCE)
+
+
+def test_trail_point_is_behind_the_person_not_on_top_of_them():
+    color = "GREEN"
+    trail = FootstepTrail(crowd_trajectory(0.0)[color])
+    for t in times(seconds=30.0):
+        person = crowd_trajectory(t)[color]
+        state = trail.update(person)
+    separation = float(np.linalg.norm(person.pos - state.pos))
+    # Straight-line separation is at most the arc gap, and clearly non-zero.
+    assert 0.05 < separation <= TRAIL_DISTANCE + 1e-9
+
+
+def test_trail_extrapolates_backwards_before_the_gap_is_walked():
+    # At t=0 nobody has walked anywhere; the queue must still yield a sensible
+    # point behind the person rather than their own position.
+    person = crowd_trajectory(0.0)["RED"]
+    trail = FootstepTrail(person)
+    state = trail.update(person)
+    assert float(np.linalg.norm(state.pos - person.pos)) == pytest.approx(
+        TRAIL_DISTANCE, abs=1e-6
+    )
+    assert state.path_s == pytest.approx(-TRAIL_DISTANCE)
+
+
+def test_trail_arc_length_is_monotonic():
+    color = "PURPLE"
+    trail = FootstepTrail(crowd_trajectory(0.0)[color])
+    previous = -math.inf
+    for t in times(seconds=20.0):
+        state = trail.update(crowd_trajectory(t)[color])
+        assert state.leader_path_s >= previous
+        previous = state.leader_path_s
+
+
+def test_each_person_has_an_independent_queue():
+    trails = {c: FootstepTrail(crowd_trajectory(0.0)[c]) for c in COLORS}
+    for t in times(seconds=20.0):
+        crowd = crowd_trajectory(t)
+        states = {c: trails[c].update(crowd[c]) for c in COLORS}
+    lengths = [round(states[c].leader_path_s, 6) for c in COLORS]
+    assert len(set(lengths)) == len(COLORS), "queues are coupled"
+
+
+# --- controller ------------------------------------------------------------
+
+
+def straight_trail(x=1.0, y=0.0, yaw=0.0):
+    return TrailState(np.array([x, y]), yaw, 0.0, TRAIL_DISTANCE)
+
+
+def test_command_is_exactly_zero_when_inactive():
+    controller = CrowdFollowController()
+    for distance in (0.05, 0.5, 3.0):
+        command, _ = controller.update(
+            False, straight_trail(x=distance), np.zeros(3), 0.0
+        )
+        assert np.array_equal(command, np.zeros(3, dtype=np.float32))
+        assert float(np.linalg.norm(command)) == 0.0
+
+
+def test_zero_command_survives_a_previously_active_step():
+    # No filter state may leak a residual command into a stationary state.
+    controller = CrowdFollowController()
+    controller.update(True, straight_trail(), np.zeros(3), 0.0)
+    command, _ = controller.update(False, straight_trail(), np.zeros(3), 0.0)
+    assert float(np.linalg.norm(command)) == 0.0
+
+
+def test_walks_forward_at_the_measured_gait_onset_command():
+    # Below this vx the stock policy emits an action but does not visibly walk.
+    controller = CrowdFollowController()
+    command, info = controller.update(True, straight_trail(), np.zeros(3), 0.0)
+    assert command[0] == pytest.approx(CrowdFollowController.WALK_VX)
+    assert command[1] == 0.0
+    assert info["error"] == pytest.approx(1.0)
+
+
+def test_keeps_walking_while_turning():
+    # The RED hand-off regression: slowing down to turn stalled the gait.
+    controller = CrowdFollowController()
+    for yaw_error_deg in (30.0, 90.0, 150.0, -30.0, -90.0, -150.0):
+        command, _ = controller.update(
+            True,
+            straight_trail(
+                x=math.cos(math.radians(yaw_error_deg)),
+                y=math.sin(math.radians(yaw_error_deg)),
+            ),
+            np.zeros(3),
+            0.0,
+        )
+        assert command[0] == pytest.approx(CrowdFollowController.WALK_VX), (
+            f"gait stalled while turning {yaw_error_deg} deg"
+        )
+        assert abs(command[2]) > 0.0
+
+
+def test_stops_pushing_forward_once_on_the_footprint():
+    controller = CrowdFollowController()
+    command, _ = controller.update(True, straight_trail(x=0.05), np.zeros(3), 0.0)
+    assert command[0] == 0.0
+
+
+def test_turn_direction_matches_the_bearing_error():
+    controller = CrowdFollowController()
+    left, _ = controller.update(True, straight_trail(x=0.0, y=1.0), np.zeros(3), 0.0)
+    right, _ = controller.update(True, straight_trail(x=0.0, y=-1.0), np.zeros(3), 0.0)
+    assert left[2] > 0.0
+    assert right[2] < 0.0
+
+
+def test_no_yaw_command_inside_the_heading_deadband():
+    controller = CrowdFollowController()
+    command, _ = controller.update(True, straight_trail(), np.zeros(3), 0.0)
+    assert command[2] == 0.0
+
+
+def test_yaw_command_stays_within_configured_bounds():
+    controller = CrowdFollowController()
+    for yaw_error_deg in range(-180, 181, 5):
+        angle = math.radians(yaw_error_deg)
+        command, _ = controller.update(
+            True,
+            straight_trail(x=math.cos(angle), y=math.sin(angle)),
+            np.zeros(3),
+            0.0,
+        )
+        wz = float(command[2])
+        if wz > 0.0:
+            assert (
+                CrowdFollowController.LEFT_WZ_MIN
+                <= wz
+                <= CrowdFollowController.LEFT_WZ_MAX
+            )
+        elif wz < 0.0:
+            assert (
+                CrowdFollowController.RIGHT_WZ_MIN
+                <= -wz
+                <= CrowdFollowController.RIGHT_WZ_MAX
+            )
+
+
+def test_lateral_command_is_never_used():
+    # The walking policy is driven in vx/wz only; vy stays zero-padded.
+    controller = CrowdFollowController()
+    for angle in np.linspace(-math.pi, math.pi, 37):
+        command, _ = controller.update(
+            True,
+            straight_trail(x=float(math.cos(angle)), y=float(math.sin(angle))),
+            np.zeros(3),
+            0.0,
+        )
+        assert command[1] == 0.0
+
+
+def test_command_is_float32_three_vector():
+    controller = CrowdFollowController()
+    command, _ = controller.update(True, straight_trail(), np.zeros(3), 0.0)
+    assert command.shape == (3,)
+    assert command.dtype == np.float32
+
+
+def test_returned_command_is_a_copy():
+    # The caller stores this in a record; a shared buffer would rewrite history.
+    controller = CrowdFollowController()
+    first, _ = controller.update(True, straight_trail(), np.zeros(3), 0.0)
+    snapshot = first.copy()
+    controller.update(True, straight_trail(x=0.0, y=1.0), np.zeros(3), 0.0)
+    assert np.array_equal(first, snapshot)
+
+
+def test_person_state_carries_position_and_heading():
+    person = crowd_trajectory(1.0)["YELLOW"]
+    assert isinstance(person, PersonState)
+    assert person.pos.shape == (2,)
+    assert person.moving

--- a/tests/test_follow_me_among_others_invariants.py
+++ b/tests/test_follow_me_among_others_invariants.py
@@ -1,0 +1,416 @@
+"""Acceptance-gate and repo-invariant tests for follow-me-among-others.
+
+Runs without a policy, a renderer or a GPU. Two things are locked here:
+
+1. The acceptance gates reject the failure modes they were written for. A demo
+   whose gates cannot fail is not validating anything, so each gate is shown
+   rejecting a synthetic rollout that violates exactly it.
+2. The demo respects the repo-wide contracts from AGENTS.md: the 61-D
+   observation layout with a 13-D command block, and the documented joint
+   layout for the head chain.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMO_DIR = REPO_ROOT / "scripts" / "behavior_demos"
+sys.path.insert(0, str(DEMO_DIR))
+
+from follow_me_among_others import metrics as metrics_module
+from follow_me_among_others.crowd import CTRL_HZ, TARGET_SEQUENCE
+
+SEQUENCE = TARGET_SEQUENCE
+NOMINAL_TRUNK_Z = 0.116
+
+
+def rollout(
+    *,
+    sequence=SEQUENCE,
+    follow_steps=450,
+    step_m=0.004,
+    trunk_z=NOMINAL_TRUNK_Z,
+    stationary_command=(0.0, 0.0, 0.0),
+    target_visible_in_follow=True,
+    approach=True,
+):
+    """Synthesize a records/cycles pair that passes every gate by default."""
+    records, cycles, transitions = [], [], []
+    t = 0.0
+    dt = 1.0 / CTRL_HZ
+    x = 0.0
+    for selection, target in enumerate(sequence, start=1):
+        cycles.append(
+            {
+                "selection": selection,
+                "target": target,
+                "search_start_s": t,
+                "found_s": t + 0.5,
+                "search_duration_s": 0.5,
+                "follow_start_s": t + 1.5,
+                "stop_s": t + 1.5 + follow_steps * dt,
+                "cycle_end_s": t + 3.0 + follow_steps * dt,
+            }
+        )
+        # One stationary step at the FOUND instant, so the "visible at FOUND"
+        # gate has a record to look at.
+        records.append(
+            {
+                "t": t + 0.5,
+                "state": "FOUND",
+                "selection": selection,
+                "target": target,
+                "target_visible": True,
+                "follow_error_m": 1.0,
+                "person_range_m": 1.0,
+                "yaw_error_deg": 0.0,
+                "duck_xy": [x, 0.0],
+                "trunk_z_m": trunk_z,
+                "command": list(stationary_command),
+            }
+        )
+        t += 1.5
+        start_error = 1.0
+        for step in range(follow_steps):
+            x += step_m
+            error = (
+                start_error - step * step_m if approach else start_error + step * step_m
+            )
+            records.append(
+                {
+                    "t": t,
+                    "state": "FOLLOW",
+                    "selection": selection,
+                    "target": target,
+                    "target_visible": target_visible_in_follow,
+                    "follow_error_m": max(error, 0.05),
+                    "person_range_m": 0.9,
+                    "yaw_error_deg": 0.0,
+                    "duck_xy": [x, 0.0],
+                    "trunk_z_m": trunk_z,
+                    "command": [0.24, 0.0, 0.0],
+                }
+            )
+            t += dt
+        records.append(
+            {
+                "t": t,
+                "state": "STOP",
+                "selection": selection,
+                "target": target,
+                "target_visible": True,
+                "follow_error_m": 0.2,
+                "person_range_m": 0.9,
+                "yaw_error_deg": 0.0,
+                "duck_xy": [x, 0.0],
+                "trunk_z_m": trunk_z,
+                "command": list(stationary_command),
+            }
+        )
+        t += 1.5
+    return records, cycles, transitions
+
+
+def summarize(records, cycles, transitions, sequence=SEQUENCE):
+    return metrics_module.summarize(
+        records=records,
+        transitions=transitions,
+        cycles=cycles,
+        sequence=sequence,
+        duration_s=60.0,
+        control_steps=len(records),
+        frames=0,
+        trail_distance_m=0.55,
+        camera_stats={
+            "camera_target_visible_steps": 0,
+            "camera_search_steps": 0,
+            "camera_search_target_visible_steps": 0,
+        },
+    )
+
+
+# --- the happy path --------------------------------------------------------
+
+
+def test_nominal_rollout_passes_every_gate():
+    summary = summarize(*rollout())
+    assert metrics_module.check_gates(summary, SEQUENCE) == []
+    assert summary["cycles_completed"] == 4
+    assert summary["target_sequence_completed"] == list(SEQUENCE)
+    assert summary["wrong_color_locks"] == 0
+    assert summary["camera_target_visible_follow_pct"] == 100.0
+    assert summary["stationary_state_command_max"] == 0.0
+    assert summary["fallen_steps"] == 0
+
+
+# --- each gate must be able to fail ----------------------------------------
+
+
+def test_gate_rejects_locomotion_in_a_stationary_state():
+    # The "zero locomotion when not following" claim.
+    summary = summarize(*rollout(stationary_command=(0.01, 0.0, 0.0)))
+    failures = metrics_module.check_gates(summary, SEQUENCE)
+    assert any("stationary" in f for f in failures)
+    assert summary["stationary_state_command_max"] > 0.0
+
+
+def test_gate_rejects_a_follow_segment_that_never_moved():
+    # The RED regression: a command is emitted but the robot stands still.
+    summary = summarize(*rollout(step_m=0.0001))
+    assert not summary["all_follow_segments_moved"]
+    assert any("locomotion" in f for f in metrics_module.check_gates(summary, SEQUENCE))
+
+
+def test_gate_rejects_a_segment_that_moves_without_approaching():
+    summary = summarize(*rollout(approach=False))
+    assert not summary["all_follow_segments_approached"]
+    assert any("approach" in f for f in metrics_module.check_gates(summary, SEQUENCE))
+
+
+def test_gate_rejects_losing_the_target_during_follow():
+    summary = summarize(*rollout(target_visible_in_follow=False))
+    assert summary["camera_target_visible_follow_pct"] == 0.0
+    assert any("100%" in f for f in metrics_module.check_gates(summary, SEQUENCE))
+
+
+def test_gate_rejects_a_fall():
+    summary = summarize(*rollout(trunk_z=0.05))
+    failures = metrics_module.check_gates(summary, SEQUENCE)
+    assert summary["fallen_steps"] > 0
+    assert any("fallen_steps" in f for f in failures)
+    assert any("trunk z" in f for f in failures)
+
+
+def test_gate_rejects_a_wrong_color_lock():
+    records, cycles, transitions = rollout()
+    cycles[2]["target"] = "YELLOW"  # a distractor was followed instead of RED
+    summary = summarize(records, cycles, transitions)
+    failures = metrics_module.check_gates(summary, SEQUENCE)
+    assert summary["wrong_color_locks"] == 1
+    assert any("wrong_color_locks" in f for f in failures)
+
+
+def test_gate_rejects_an_incomplete_sequence():
+    records, cycles, transitions = rollout(sequence=SEQUENCE[:3])
+    summary = summarize(records, cycles, transitions, sequence=SEQUENCE[:3])
+    # Measured against the full four-selection request, three cycles must fail.
+    failures = metrics_module.check_gates(summary, SEQUENCE)
+    assert any("cycles completed" in f for f in failures)
+
+
+def test_gate_rejects_found_while_target_not_visible():
+    records, cycles, transitions = rollout()
+    for record in records:
+        if record["state"] == "FOUND":
+            record["target_visible"] = False
+    summary = summarize(records, cycles, transitions)
+    assert not summary["found_while_target_visible"]
+    assert any("FOUND" in f for f in metrics_module.check_gates(summary, SEQUENCE))
+
+
+def test_missing_follow_data_is_an_error_not_a_pass():
+    records, cycles, transitions = rollout()
+    records = [
+        r for r in records if not (r["state"] == "FOLLOW" and r["selection"] == 2)
+    ]
+    with pytest.raises(RuntimeError, match="never followed"):
+        summarize(records, cycles, transitions)
+
+
+# --- documented thresholds -------------------------------------------------
+
+
+def test_acceptance_thresholds_are_the_published_ones():
+    assert metrics_module.MIN_FOLLOW_PATH_M == pytest.approx(0.40)
+    assert metrics_module.MIN_FOLLOW_DISPLACEMENT_M == pytest.approx(0.30)
+    assert metrics_module.MIN_FOLLOW_APPROACH_M == pytest.approx(0.05)
+    assert metrics_module.FALLEN_TRUNK_Z_M == pytest.approx(0.09)
+    assert set(metrics_module.STATIONARY_STATES) == {
+        "SEARCH",
+        "FOUND",
+        "STOP",
+        "DONE",
+    }
+
+
+def test_segment_helpers_agree_with_the_thresholds():
+    at_limit = {
+        "path_distance_m": metrics_module.MIN_FOLLOW_PATH_M,
+        "net_displacement_m": metrics_module.MIN_FOLLOW_DISPLACEMENT_M,
+        "start_error_m": 1.0,
+        "min_error_m": 1.0 - metrics_module.MIN_FOLLOW_APPROACH_M,
+    }
+    assert metrics_module.segment_moved(at_limit)
+    assert metrics_module.segment_approached(at_limit)
+    just_under = dict(at_limit, path_distance_m=metrics_module.MIN_FOLLOW_PATH_M - 1e-6)
+    assert not metrics_module.segment_moved(just_under)
+    no_approach = dict(at_limit, min_error_m=1.0)
+    assert not metrics_module.segment_approached(no_approach)
+
+
+# --- repo invariants -------------------------------------------------------
+
+
+def test_observation_contract_is_the_shared_61d_layout():
+    from follow_me_among_others import run_demo
+
+    # 48 proprioception + 13 command; the command block is never dropped.
+    assert run_demo.EXPECTED_OBS_DIM == 61
+    assert run_demo.EXPECTED_COMMAND_DIM == 13
+    assert 3 + 3 + 14 * 3 + run_demo.EXPECTED_COMMAND_DIM == run_demo.EXPECTED_OBS_DIM
+
+
+def test_default_pose_matches_the_home_frame():
+    from follow_me_among_others import run_demo
+
+    order = [
+        "left_hip_yaw",
+        "left_hip_roll",
+        "left_hip_pitch",
+        "left_knee",
+        "left_ankle",
+        "neck_pitch",
+        "head_pitch",
+        "head_yaw",
+        "head_roll",
+        "right_hip_yaw",
+        "right_hip_roll",
+        "right_hip_pitch",
+        "right_knee",
+        "right_ankle",
+    ]
+    assert len(run_demo.DEFAULT_POSE) == len(order) == 14
+
+    # The documented STAND2 pose (HOME_FRAME in microduck_constants.py, and the
+    # STAND keyframe in the scene). Actions are offsets from exactly this, so a
+    # drift here silently biases every observation the policy sees.
+    expected = {
+        "left_hip_yaw": 0.0,
+        "left_hip_roll": -0.0873,
+        "left_hip_pitch": -0.4579,
+        "left_knee": -0.0049,
+        "left_ankle": 0.4530,
+        "neck_pitch": 0.3491,
+        "head_pitch": 0.3491,
+        "head_yaw": 0.0,
+        "head_roll": 0.0,
+        "right_hip_yaw": 0.0,
+        "right_hip_roll": 0.0873,
+        "right_hip_pitch": 0.4579,
+        "right_knee": 0.0049,
+        "right_ankle": -0.4530,
+    }
+    for index, joint in enumerate(order):
+        assert run_demo.DEFAULT_POSE[index] == pytest.approx(
+            expected[joint], abs=1e-4
+        ), joint
+    # Left and right legs mirror each other.
+    assert run_demo.DEFAULT_POSE[order.index("left_hip_pitch")] == pytest.approx(
+        -run_demo.DEFAULT_POSE[order.index("right_hip_pitch")], abs=1e-6
+    )
+
+
+def test_head_actuator_indices_follow_the_documented_joint_layout():
+    from follow_me_among_others.camera import CrowdCameraSearch
+
+    # AGENTS.md: 0-4 left leg, 5-8 neck/head, 9-13 right leg.
+    assert CrowdCameraSearch.HEAD_PITCH_ACT == 6
+    assert CrowdCameraSearch.HEAD_YAW_ACT == 7
+    assert CrowdCameraSearch.HEAD_ROLL_ACT == 8
+
+
+def test_demo_runs_at_the_policy_control_rate():
+    assert CTRL_HZ == 50.0
+
+
+def test_scene_declares_the_five_people_and_the_camera_rig():
+    scene = (
+        REPO_ROOT
+        / "src/mjlab_microduck/robot/microduck/scene_follow_me_among_others.xml"
+    ).read_text()
+    for color in ("blue", "green", "red", "yellow", "purple"):
+        assert f'name="person_{color}"' in scene
+        assert f"{color}_shirt" in scene
+    assert 'name="follow_camera_rig"' in scene
+    assert 'name="follow_camera"' in scene
+    assert 'name="trail_target"' in scene
+    # The demo builds on the official walk model rather than a private copy.
+    assert 'include file="robot_walk.xml"' in scene
+
+
+def test_scene_people_are_non_colliding_scenery():
+    scene = (
+        REPO_ROOT
+        / "src/mjlab_microduck/robot/microduck/scene_follow_me_among_others.xml"
+    ).read_text()
+    # Every pedestrian geom is contype/conaffinity 0: the crowd can never push
+    # the robot, so following is not an artifact of being bumped.
+    person_lines = [
+        line
+        for line in scene.splitlines()
+        if "<geom" in line
+        and any(c in line for c in ("blue_", "green_", "red_", "yellow_", "purple_"))
+    ]
+    assert person_lines
+    for line in person_lines:
+        assert 'contype="0"' in line and 'conaffinity="0"' in line
+
+
+def test_demo_declares_no_hardcoded_local_paths():
+    for path in sorted((DEMO_DIR / "follow_me_among_others").glob("*.py")):
+        source = path.read_text()
+        assert "/Users/" not in source, path
+        assert "/home/" not in source, path
+        assert "/tmp/" not in source, path
+
+
+def test_policy_argument_is_required():
+    from follow_me_among_others import run_demo
+
+    # No default weights path: the user always says which policy to run.
+    with pytest.raises(SystemExit):
+        run_demo.parse_args([])
+    args = run_demo.parse_args(["--policy", "walk.onnx", "--no-render"])
+    assert args.policy == "walk.onnx"
+    assert args.xml.startswith("src/mjlab_microduck/robot/microduck/")
+
+
+def test_no_binary_artifacts_are_committed_with_the_demo():
+    for pattern in ("*.onnx", "*.mp4", "*.png", "*.pt"):
+        assert list(DEMO_DIR.rglob(pattern)) == []
+
+
+def test_make_observation_builds_a_61d_vector_without_a_policy():
+    from follow_me_among_others import run_demo
+
+    class _Data:
+        xquat = np.array([[1.0, 0.0, 0.0, 0.0]])
+        sensordata = np.zeros(16, dtype=np.float64)
+        qpos = np.zeros(32, dtype=np.float64)
+        qvel = np.zeros(32, dtype=np.float64)
+
+    data = _Data()
+    qpos_idx = np.arange(14)
+    qvel_idx = np.arange(14)
+    data.qpos[qpos_idx] = run_demo.DEFAULT_POSE
+    observation = run_demo.make_observation(
+        data,
+        model=None,
+        qpos_idx=qpos_idx,
+        qvel_idx=qvel_idx,
+        trunk_id=0,
+        gyro_adr=0,
+        last_action=np.zeros(14, dtype=np.float32),
+        command=np.array([0.24, 0.0, 0.3], dtype=np.float32),
+        command_dim=13,
+    )
+    assert observation.shape == (61,)
+    assert observation.dtype == np.float32
+    # Joint positions are relative to the default pose, so they vanish here.
+    assert np.allclose(observation[6:20], 0.0)
+    # Twist occupies the first three command slots; the rest is zero-padded.
+    assert observation[48:51] == pytest.approx([0.24, 0.0, 0.3])
+    assert np.allclose(observation[51:], 0.0)

--- a/tests/test_follow_me_among_others_state_machine.py
+++ b/tests/test_follow_me_among_others_state_machine.py
@@ -1,0 +1,165 @@
+"""Pure state-machine tests for the follow-me-among-others behavior demo.
+
+CPU only: no model, no policy, no renderer. The machine is fed synthetic camera
+reports, which is exactly the point — the sequencing logic must be correct
+independently of whether a rollout happens to work.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / "scripts" / "behavior_demos")
+)
+
+from follow_me_among_others.crowd import (
+    SELECTABLE_COLORS,
+    TARGET_SEQUENCE,
+    SearchFollowStateMachine,
+    wrap,
+)
+
+CTRL_DT = 1.0 / 50.0
+
+
+def seen(off_axis_deg=0.0):
+    return {"target_visible": True, "target_off_axis": math.radians(off_axis_deg)}
+
+
+NOT_SEEN = {"target_visible": False, "target_off_axis": math.pi}
+
+
+def drive(machine, camera_for, seconds=90.0, dt=CTRL_DT):
+    """Run the machine forward, recording (t, state, target) per step."""
+    log = []
+    steps = int(seconds / dt)
+    for step in range(steps):
+        t = step * dt
+        state, target = machine.state, machine.target
+        log.append((t, "DONE" if machine.done else state, target))
+        machine.update(t, camera_for(t, machine))
+        if machine.done:
+            break
+    return log
+
+
+def test_requested_sequence_is_blue_green_red_blue():
+    # The repeated BLUE is deliberate: it forces a second full search instead
+    # of letting the controller keep a latched target.
+    assert TARGET_SEQUENCE == ("BLUE", "GREEN", "RED", "BLUE")
+    assert TARGET_SEQUENCE[0] == TARGET_SEQUENCE[3]
+
+
+def test_completes_four_cycles_in_requested_order():
+    machine = SearchFollowStateMachine()
+    drive(machine, lambda t, m: seen())
+    assert machine.done
+    assert len(machine.cycles) == 4
+    assert [c["target"] for c in machine.cycles] == list(TARGET_SEQUENCE)
+
+
+def test_every_cycle_visits_search_found_follow_stop_in_order():
+    machine = SearchFollowStateMachine()
+    log = drive(machine, lambda t, m: seen())
+    for selection, target in enumerate(TARGET_SEQUENCE, start=1):
+        cycle = machine.cycles[selection - 1]
+        assert cycle["target"] == target
+        # Timestamps must be strictly ordered through the whole pipeline.
+        assert (
+            cycle["search_start_s"]
+            < cycle["found_s"]
+            < cycle["follow_start_s"]
+            < cycle["stop_s"]
+            < cycle["cycle_end_s"]
+        )
+    states = [entry[1] for entry in log]
+    # The observed state string sequence, deduplicated, is the pattern repeated.
+    collapsed = [s for i, s in enumerate(states) if i == 0 or s != states[i - 1]]
+    assert collapsed[:4] == ["SEARCH", "FOUND", "FOLLOW", "STOP"]
+    assert collapsed.count("FOLLOW") == 4
+
+
+def test_state_durations_match_configuration():
+    machine = SearchFollowStateMachine()
+    drive(machine, lambda t, m: seen())
+    for cycle in machine.cycles:
+        assert cycle["follow_start_s"] - cycle["found_s"] == pytest.approx(
+            SearchFollowStateMachine.FOUND_SECONDS, abs=2 * CTRL_DT
+        )
+        assert cycle["stop_s"] - cycle["follow_start_s"] == pytest.approx(
+            SearchFollowStateMachine.FOLLOW_SECONDS, abs=2 * CTRL_DT
+        )
+        assert cycle["cycle_end_s"] - cycle["stop_s"] == pytest.approx(
+            SearchFollowStateMachine.STOP_SECONDS, abs=2 * CTRL_DT
+        )
+
+
+def test_follows_only_in_follow_state():
+    machine = SearchFollowStateMachine()
+    t = 0.0
+    while machine.state != "FOLLOW" and t < 10.0:
+        assert not machine.follows_now
+        machine.update(t, seen())
+        t += CTRL_DT
+    assert machine.state == "FOLLOW"
+    assert machine.follows_now
+
+
+def test_minimum_search_dwell_is_enforced():
+    # Even with the target visible and centered from t=0, the machine must not
+    # leave SEARCH before MIN_SEARCH_SECONDS.
+    machine = SearchFollowStateMachine()
+    t = 0.0
+    while t < SearchFollowStateMachine.MIN_SEARCH_SECONDS - CTRL_DT:
+        machine.update(t, seen())
+        assert machine.state == "SEARCH"
+        t += CTRL_DT
+
+
+def test_search_timeout_raises_rather_than_standing_still():
+    # "Never acquired" must be a loud failure, not a silent zero-command
+    # rollout that still writes a metrics file.
+    machine = SearchFollowStateMachine()
+    with pytest.raises(RuntimeError, match="failed to find BLUE"):
+        drive(machine, lambda t, m: NOT_SEEN, seconds=20.0)
+
+
+def test_done_is_terminal_and_idempotent():
+    machine = SearchFollowStateMachine()
+    drive(machine, lambda t, m: seen())
+    assert machine.done
+    for step in range(10):
+        state, target, changed = machine.update(1000.0 + step, seen())
+        assert (state, target, changed) == ("DONE", TARGET_SEQUENCE[-1], False)
+    assert len(machine.cycles) == 4
+
+
+def test_rejects_empty_or_unselectable_sequences():
+    with pytest.raises(ValueError):
+        SearchFollowStateMachine(())
+    # Distractor colors are never valid targets.
+    with pytest.raises(ValueError, match="selectable"):
+        SearchFollowStateMachine(("YELLOW",))
+    with pytest.raises(ValueError):
+        SearchFollowStateMachine(("BLUE", "PURPLE"))
+    for color in SELECTABLE_COLORS:
+        assert SearchFollowStateMachine((color,)).target == color
+
+
+def test_custom_sequence_is_honored():
+    machine = SearchFollowStateMachine(("RED", "RED"))
+    drive(machine, lambda t, m: seen())
+    assert [c["target"] for c in machine.cycles] == ["RED", "RED"]
+
+
+def test_wrap_maps_angles_into_pi_interval():
+    # wrap() normalizes to the half-open interval [-pi, pi).
+    assert wrap(0.0) == pytest.approx(0.0)
+    assert wrap(3.0 * math.pi) == pytest.approx(-math.pi)
+    assert wrap(math.radians(370.0)) == pytest.approx(math.radians(10.0))
+    assert wrap(math.radians(-350.0)) == pytest.approx(math.radians(10.0))
+    for angle in (-10.0, -1.0, 0.3, 2.0, 7.5, 100.0):
+        assert -math.pi <= wrap(angle) < math.pi


### PR DESCRIPTION
## What this is

A **CPU MuJoCo behavior demo**, not a new task and not robot autonomy: the robot repeatedly searches a moving crowd through its head camera, acquires a requested shirt color, follows that person's queued footsteps, and stops.

```text
BLUE → GREEN → RED → BLUE
SEARCH → FOUND → FOLLOW → STOP   (once per selection)
```

It drives the **stock exported walking policy** with a twist command from a geometric controller, so it needs no GPU, no training run and no new weights. It is opened as a draft because the scope decision is yours: this adds a `scripts/behavior_demos/` area that does not exist yet, and I would rather agree on where this belongs than assume.

## Use case

The velocity policy can already walk anywhere; what it lacks is a worked example of *driving* it from a perception-conditioned state machine. This demo is that example, and doubles as a deterministic, headless integration check of the exported-ONNX path: it runs the real 61-D observation contract, the real action scale and the real 50 Hz control loop, and exits non-zero when the behavior degrades. The whole 60 s rollout reproduces in about two seconds on a laptop CPU.

## Implementation

New, self-contained, and additive:

| File | Role |
|---|---|
| `scripts/behavior_demos/follow_me_among_others/crowd.py` | pedestrian routes, footstep queues, state machine, controller |
| `.../camera.py` | color-selective search sweep and tracking |
| `.../metrics.py` | acceptance gates and metrics summary |
| `.../overlay.py` | HUD/PiP composition |
| `.../run_demo.py` | rollout entry point |
| `.../README.md` | usage, scope, measured results |
| `src/mjlab_microduck/robot/microduck/scene_follow_me_among_others.xml` | crowd scene on the official `robot_walk.xml` |

Nothing else under `src/` changes. **`pyproject.toml` and `uv.lock` are untouched**: `mujoco`, `numpy` and `onnxruntime` are already dependencies, and `imageio`/`pillow` are imported lazily inside the render branch only, so `--no-render` runs on the plain project environment. `--policy` is required — no default weights path, no hardcoded local paths anywhere (a test enforces this).

Behavior details worth flagging:

- **Five people, all moving.** Blue/green/red are selectable, yellow/purple are distractors. Each walks an independent elliptical lane with its own direction, speed, phase and unsynchronised wobble; nobody freezes or teleports to ease acquisition. They are mocap bodies with `contype="0" conaffinity="0"`, so the crowd can never push the robot.
- **Following means trailing, not mirroring** — the robot targets the selected person's queued world-space footprint 0.55 m back along *that person's own path*, interpolated by arc length.
- **Zero locomotion outside FOLLOW.** In `SEARCH`/`FOUND`/`STOP`/`DONE` the command is exactly `(0,0,0)`.
- **Gait onset is a real threshold.** The controller holds `vx = 0.24` while turning. A smaller command yields a valid ONNX action but no visible locomotion — that is exactly how the original red hand-off failed, and it is why the movement-acceptance gates exist.
- Perception uses an isolated rendering `MjData`, so gaze never perturbs the authoritative walking state.

## Measured validation

60 s, 3000 control steps at 50 Hz, CPU, stock walking policy.

| Selection | Target | Search | Found | Follow | Stop | Search time |
|---:|---|---:|---:|---:|---:|---:|
| 1 | Blue | `0.00 s` | `2.44 s` | `3.44 s` | `12.44 s` | `2.44 s` |
| 2 | Green | `13.94 s` | `16.50 s` | `17.50 s` | `26.50 s` | `2.56 s` |
| 3 | Red | `28.00 s` | `29.34 s` | `30.34 s` | `39.34 s` | `1.34 s` |
| 4 | Blue | `40.84 s` | `41.92 s` | `42.92 s` | `51.92 s` | `1.08 s` |

- completed sequence exactly `BLUE → GREEN → RED → BLUE`, **4/4 cycles**
- every `FOUND` occurred while the requested color was visible
- **`wrong_color_locks = 0`**
- target visible for **100 %** of control steps during `FOLLOW`
- all follow segments moved (≥ `0.40 m` path, ≥ `0.30 m` displacement) **and** approached their target
- maximum stationary-state command **`0.0`**
- **no falls**: `fallen_steps = 0`, minimum trunk height `0.114 m` (threshold `0.09 m`), final `0.116 m` back at nominal

Mean selected-person range during following `0.929 m`. Queued-footprint RMSE `1.028 m` — this includes the deliberately long first Blue approach rather than only the settled tail of each interval.

**Corrected red segment** (the case that originally exposed the gait-onset threshold): the robot travels `1.249 m`, displaces `0.718 m`, and reduces its queued-footprint error from `0.397 m` to a minimum of `0.202 m`. Before the fix this segment produced a command but no locomotion; it is now covered by an explicit gate rather than by inspection.

## Limitations — please read these as part of the change

- **Color recognition is a MuJoCo semantic proxy, not an RGB classifier.** The simulator supplies each actor's identity and world pose, and the code tests known shirt/head sample points against the camera frustum. The camera *geometry* is real — physical head-camera position, real search sweep, field-of-view test, 8° acquisition cone — but no pixel is classified. Replacing the identity lookup with onboard vision is separate work.
- **Visibility is frustum-only.** It does not ray-cast for mutual occlusion, so a person directly behind another still counts as visible. This is the gate the numbers above were measured with; adding occlusion changes acquisition timing and would require re-measuring the whole sequence, so it is documented rather than switched on untested.
- **Simulation only.** No real-person detector, no hardware validation, no sim2real claim. Nothing here was run on a robot.
- **The picture-in-picture gaze view is rendered for inspection only** and is never fed back into any decision.
- The pedestrians are kinematic scenery, not physically interacting agents.
- The demo depends on the stock walking policy's tuned gait-onset command; a policy with different onset behavior may need `WALK_VX` re-measured.

## Tests

67 new CPU tests, no model / policy / renderer / GPU required:

- `tests/test_follow_me_among_others_state_machine.py` — pure sequencing: four cycles in order, ordered `SEARCH→FOUND→FOLLOW→STOP` timestamps, state durations, minimum search dwell, timeout raising instead of standing still, `DONE` terminal and idempotent, sequence validation.
- `tests/test_follow_me_among_others_color_gate.py` — visible centered distractors never trigger `FOUND`; a visible but off-axis target does not either; acquisition tested either side of the 8° boundary; wrong-color locks impossible by construction; target cannot switch mid-cycle; the repeated Blue requires a fresh search.
- `tests/test_follow_me_among_others_crowd.py` — five independent people who never stop, stall, teleport or move as a rigid formation; trail lags exactly 0.55 m in arc length, sits behind the person, extrapolates before the gap is walked, monotonic and per-person independent; controller emits exact zero when inactive (including right after an active step), keeps walking while turning, respects the deadband and yaw bounds, never uses `vy`.
- `tests/test_follow_me_among_others_invariants.py` — **each acceptance gate is shown rejecting a synthetic rollout that violates exactly it** (stationary-state locomotion, segment that never moved, moved-without-approaching, target lost during follow, fall, wrong-color lock, incomplete sequence, `FOUND` while not visible); plus the 61-D / 13-D command contract, the STAND2 default pose, documented head actuator indices, scene contents, non-colliding crowd geoms, no hardcoded local paths, and no committed binaries.

```
tests/test_follow_me_among_others_*.py   67 passed in 0.22s
pytest tests/                            221 passed, 1 skipped in 3.56s
```

`ruff check` and `ruff format --check` are clean on all new files. After the refactor into this layout, the rollout still reproduces the validated metrics **byte-identically** (0 differences across the full metrics JSON).

## Not included

**No binary policy and no video are committed** — no ONNX, no MP4, no PNG. The demo takes any walking policy you export with `scripts/export.py` via `--policy`.

## Try it

```bash
uv run scripts/behavior_demos/follow_me_among_others/run_demo.py \
    --policy /path/to/walking.onnx --no-render --metrics /tmp/fmao.json
```

Add `--with imageio --with pillow --out <dir>` to render the HUD. The process exits non-zero if any acceptance gate fails.

Happy to move the directory, rename things, drop the overlay, or narrow the scope — whatever fits your conventions.

## Demo video

Fresh full-sequence render from commit `9662cb0` (60 s, 3,000 frames at 50 fps, 960×640; compressed below GitHub's attachment limit). It shows all four `SEARCH → FOUND → FOLLOW → STOP` cycles in the requested `BLUE → GREEN → RED → BLUE` order.

https://github.com/user-attachments/assets/76fc1a6b-fb3a-4eef-855d-28e0995285dc
