### PR TITLE
Add a configurable household step-up training task

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ instead of locally (see [scripts/hf/README.md](scripts/hf/README.md)).
 | `Mjlab-GroundPick-{Flat,Rough}-MicroDuck` | flat/rough | Crouch and touch the ground with the mouth tip, return to stand |
 | `Mjlab-BallKick-Flat-MicroDuck` | flat | Kick a 70 mm / 15 g ball forward (actor is ball-blind) |
 | `Mjlab-Roulade-Flat-MicroDuck` | flat | Forward roll over the head, land back on the feet |
+| `Mjlab-StepUp-MicroDuck` | 0–25 mm step curriculum | Ascend one square-edged step after external alignment |
+| `Mjlab-StepUpFull-MicroDuck` | fixed 25 mm step | Final fine-tuning for a 25 mm household threshold |
 | `Mjlab-Velocity-Flat-MicroDuck-Rollers` | flat | Roller-skate velocity tracking (passive wheels under the feet) |
 | `Mjlab-Velocity-Swizzle-MicroDuck` | flat | Classic symmetric swizzle skating |
 | `Mjlab-RollerCrouch-Flat-MicroDuck` | flat | Crouch while gliding on rollers |

--- a/src/mjlab_microduck/tasks/__init__.py
+++ b/src/mjlab_microduck/tasks/__init__.py
@@ -59,6 +59,12 @@ from .microduck_roller_standup_env_cfg import (
     make_microduck_roller_standup_env_cfg,
     MicroduckRollerStandUpRlCfg,
 )
+from .microduck_step_up_env_cfg import (
+    make_microduck_step_up_env_cfg,
+    make_microduck_step_up_full_env_cfg,
+    MicroduckStepUpRlCfg,
+    MicroduckStepUpFullRlCfg,
+)
 from .microduck_spin_env_cfg import (
     make_microduck_spin_env_cfg,
     MicroduckSpinRlCfg,
@@ -75,6 +81,24 @@ register_mjlab_task(
     env_cfg=make_microduck_velocity_env_cfg(),
     play_env_cfg=make_microduck_velocity_env_cfg(play=True),
     rl_cfg=MicroduckRlCfg,
+    runner_cls=MicroduckOnPolicyRunner,
+)
+
+# Dedicated skill for one camera-aligned 0–25 mm square-edged step curriculum.
+register_mjlab_task(
+    task_id="Mjlab-StepUp-MicroDuck",
+    env_cfg=make_microduck_step_up_env_cfg(),
+    play_env_cfg=make_microduck_step_up_env_cfg(play=True),
+    rl_cfg=MicroduckStepUpRlCfg,
+    runner_cls=MicroduckOnPolicyRunner,
+)
+
+# Fixed-height continuation task for final 25 mm policy tuning.
+register_mjlab_task(
+    task_id="Mjlab-StepUpFull-MicroDuck",
+    env_cfg=make_microduck_step_up_full_env_cfg(),
+    play_env_cfg=make_microduck_step_up_full_env_cfg(play=True),
+    rl_cfg=MicroduckStepUpFullRlCfg,
     runner_cls=MicroduckOnPolicyRunner,
 )
 

--- a/src/mjlab_microduck/tasks/mdp.py
+++ b/src/mjlab_microduck/tasks/mdp.py
@@ -3537,6 +3537,192 @@ def terrain_levels_slope(env: ManagerBasedRlEnv, env_ids: torch.Tensor) -> torch
     return torch.mean(terrain.terrain_levels.float())
 
 
+# ---------------------------------------------------------------------------
+# Step-up skill — one square-edged rise, triggered before the edge.
+# ---------------------------------------------------------------------------
+
+_STEP_UP_FEET_CFG = SceneEntityCfg(
+    "robot", site_names=("left_foot", "right_foot")
+)
+
+
+def _step_up_success_mask(
+    env: ManagerBasedRlEnv,
+    min_forward_distance: float,
+    min_trunk_height: float,
+    min_upright_cos: float,
+    max_lateral_offset: float | None = None,
+    min_foot_forward: float | None = None,
+    min_foot_height: float | None = None,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    feet_cfg: SceneEntityCfg = _STEP_UP_FEET_CFG,
+) -> "torch.Tensor":
+    asset = env.scene[asset_cfg.name]
+    origin = env.scene.terrain.env_origins
+    forward = asset.data.root_link_pos_w[:, 0] - origin[:, 0]
+    lateral = asset.data.root_link_pos_w[:, 1] - origin[:, 1]
+    height = asset.data.root_link_pos_w[:, 2] - origin[:, 2]
+    quat = asset.data.root_link_quat_w
+    upright = 1.0 - 2.0 * (quat[:, 1] ** 2 + quat[:, 2] ** 2)
+    success = (
+        (forward >= min_forward_distance)
+        & (height >= min_trunk_height)
+        & (upright >= min_upright_cos)
+    )
+    if max_lateral_offset is not None:
+        success &= lateral.abs() <= max_lateral_offset
+    if min_foot_forward is not None or min_foot_height is not None:
+        if min_foot_forward is None or min_foot_height is None:
+            raise ValueError(
+                "min_foot_forward and min_foot_height must be provided together"
+            )
+        feet = asset.data.site_pos_w[:, feet_cfg.site_ids]
+        feet_on_upper = (
+            (feet[..., 0] - origin[:, None, 0] >= min_foot_forward)
+            & (feet[..., 2] - origin[:, None, 2] >= min_foot_height)
+        )
+        if max_lateral_offset is not None:
+            feet_on_upper &= (
+                feet[..., 1] - origin[:, None, 1]
+            ).abs() <= max_lateral_offset
+        success &= feet_on_upper.all(dim=1)
+    return success
+
+
+def step_up_success(
+    env: ManagerBasedRlEnv,
+    min_forward_distance: float,
+    min_trunk_height: float,
+    min_upright_cos: float,
+    max_lateral_offset: float | None = None,
+    min_foot_forward: float | None = None,
+    min_foot_height: float | None = None,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    feet_cfg: SceneEntityCfg = _STEP_UP_FEET_CFG,
+) -> "torch.Tensor":
+    """One-frame success reward; paired with ``step_complete`` termination."""
+    return _step_up_success_mask(
+        env,
+        min_forward_distance,
+        min_trunk_height,
+        min_upright_cos,
+        max_lateral_offset,
+        min_foot_forward,
+        min_foot_height,
+        asset_cfg,
+        feet_cfg,
+    ).float()
+
+
+def step_up_complete(
+    env: ManagerBasedRlEnv,
+    min_forward_distance: float,
+    min_trunk_height: float,
+    min_upright_cos: float,
+    max_lateral_offset: float | None = None,
+    min_foot_forward: float | None = None,
+    min_foot_height: float | None = None,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    feet_cfg: SceneEntityCfg = _STEP_UP_FEET_CFG,
+) -> "torch.Tensor":
+    """Terminate only after the trunk is clearly upright on the upper floor."""
+    return _step_up_success_mask(
+        env,
+        min_forward_distance,
+        min_trunk_height,
+        min_upright_cos,
+        max_lateral_offset,
+        min_foot_forward,
+        min_foot_height,
+        asset_cfg,
+        feet_cfg,
+    )
+
+
+def step_up_out_of_bounds(
+    env: ManagerBasedRlEnv,
+    max_lateral_offset: float,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> "torch.Tensor":
+    """Terminate an attempted side bypass before it can earn crossing credit."""
+    asset = env.scene[asset_cfg.name]
+    origin = env.scene.terrain.env_origins
+    lateral = asset.data.root_link_pos_w[:, 1] - origin[:, 1]
+    return lateral.abs() > max_lateral_offset
+
+
+def step_up_forward_velocity(
+    env: ManagerBasedRlEnv,
+    cap: float = 0.6,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> "torch.Tensor":
+    """Reward world-forward motion toward the fixed step, capped for safety."""
+    asset = env.scene[asset_cfg.name]
+    vx = torch.nan_to_num(
+        asset.data.root_link_lin_vel_w[:, 0], nan=0.0, posinf=0.0, neginf=0.0
+    )
+    return torch.clamp(vx, min=0.0, max=cap)
+
+
+def step_up_foot_milestone(
+    env: ManagerBasedRlEnv,
+    min_foot_forward: float,
+    min_foot_height: float,
+    required_feet: int,
+    state_key: str,
+    max_lateral_offset: float | None = None,
+    feet_cfg: SceneEntityCfg = _STEP_UP_FEET_CFG,
+) -> "torch.Tensor":
+    """Pay once when one or both feet clear and land past the edge."""
+    if required_feet < 1:
+        raise ValueError("required_feet must be at least one")
+
+    asset = env.scene[feet_cfg.name]
+    origin = env.scene.terrain.env_origins
+    feet = asset.data.site_pos_w[:, feet_cfg.site_ids]
+    cleared = (
+        (feet[..., 0] - origin[:, None, 0] >= min_foot_forward)
+        & (feet[..., 2] - origin[:, None, 2] >= min_foot_height)
+    )
+    if max_lateral_offset is not None:
+        cleared &= (
+            feet[..., 1] - origin[:, None, 1]
+        ).abs() <= max_lateral_offset
+    reached = cleared.sum(dim=1) >= required_feet
+
+    seen = getattr(env, state_key, None)
+    if seen is None or seen.shape != reached.shape or seen.device != reached.device:
+        seen = torch.zeros_like(reached)
+        setattr(env, state_key, seen)
+    seen[env.episode_length_buf <= 1] = False
+    reward = reached & ~seen
+    seen |= reached
+    return reward.float()
+
+
+def terrain_levels_step_up(
+    env: ManagerBasedRlEnv,
+    env_ids: "torch.Tensor",
+    min_forward_distance: float,
+    min_trunk_height: float,
+    min_upright_cos: float,
+    max_lateral_offset: float | None = None,
+) -> "torch.Tensor":
+    """Promote step height only after an upright upper-floor arrival."""
+    terrain = env.scene.terrain
+    success = _step_up_success_mask(
+        env,
+        min_forward_distance,
+        min_trunk_height,
+        min_upright_cos,
+        max_lateral_offset,
+    )[env_ids]
+    move_up = success
+    move_down = torch.zeros_like(success)
+    terrain.update_env_origins(env_ids, move_up, move_down)
+    return torch.mean(terrain.terrain_levels.float())
+
+
 def velocity_command_ranges_curriculum(
     env: ManagerBasedRlEnv,
     env_ids: torch.Tensor,

--- a/src/mjlab_microduck/tasks/microduck_step_up_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_step_up_env_cfg.py
@@ -1,0 +1,220 @@
+"""Dedicated Microduck skill for ascending one square-edged step up to 25 mm.
+
+The skill is activated by an external camera/controller roughly 20-40 cm
+before the edge. It deliberately keeps the deployable 61D observation and 14D
+action contract, so the runtime can hot-swap it with the normal walking policy.
+"""
+
+import math
+from copy import deepcopy
+
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.managers import CurriculumTermCfg, RewardTermCfg, TerminationTermCfg
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.terrains import TerrainEntityCfg
+from mjlab.terrains.terrain_generator import TerrainGeneratorCfg
+
+from mjlab_microduck.tasks import mdp as microduck_mdp
+from mjlab_microduck.tasks.microduck_velocity_env_cfg import (
+    MicroduckRlCfg,
+    _soften_terrain_contacts,
+    make_microduck_velocity_env_cfg,
+)
+from mjlab_microduck.tasks.step_up_terrain import UpStepTerrainCfg
+
+TILE_SIZE = (3.0, 1.2)
+LOWER_LENGTH = 1.0
+APPROACH_DISTANCE_RANGE = (0.30, 0.30)
+SUCCESS_FORWARD_DISTANCE = 0.50
+SUCCESS_MAX_LATERAL_OFFSET = 0.30
+BYPASS_MAX_LATERAL_OFFSET = 0.34
+# Low enough for the first 5 mm curriculum row; forward distance already
+# proves the robot is past the vertical edge, while this gate rejects a body
+# lying on the upper floor. A final-height gate here would make easy rows
+# impossible to graduate.
+SUCCESS_MIN_TRUNK_HEIGHT = 0.105
+
+
+def make_microduck_step_up_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+    # Start from the rough walking recipe to retain the full sim2real DR,
+    # delays, observation normalization contract and contact solver settings.
+    cfg = make_microduck_velocity_env_cfg(play=play, rough=True)
+
+    generator = TerrainGeneratorCfg(
+        size=TILE_SIZE,
+        border_width=10.0,
+        curriculum=not play,
+        num_rows=10 if not play else 1,
+        num_cols=1,
+        difficulty_range=(0.0, 1.0) if not play else (1.0, 1.0),
+        sub_terrains={
+            "up_step": UpStepTerrainCfg(
+                lower_length=LOWER_LENGTH,
+                approach_distance_range=APPROACH_DISTANCE_RANGE,
+            )
+        },
+        add_lights=False,
+    )
+    cfg.scene.terrain = TerrainEntityCfg(
+        terrain_type="generator",
+        terrain_generator=generator,
+        max_init_terrain_level=0 if not play else None,
+    )
+    cfg.scene.spec_fn = _soften_terrain_contacts
+    cfg.sim.nconmax = 200
+    cfg.sim.mujoco.iterations = 30
+    cfg.sim.mujoco.ls_iterations = 50
+
+    # External vision aligns the robot before switching skills. Training adds
+    # modest reset error so deployment need not be pixel-perfect.
+    cfg.events["reset_base"].params["pose_range"].update(
+        {
+            "x": (-0.02, 0.02),
+            "y": (-0.04, 0.04),
+            "yaw": (-math.radians(12.0), math.radians(12.0)),
+        }
+    )
+
+    # This is an ascent skill, not a general navigation policy. A small range
+    # prevents one brittle, single-speed solution while keeping every rollout
+    # aimed at the edge.
+    command = cfg.commands["twist"]
+    command.rel_standing_envs = 0.0
+    command.rel_heading_envs = 0.0
+    command.rel_turn_in_place_envs = 0.0
+    # The viewer's slider initializes at zero and requires zero to lie inside
+    # its range. Training stays strictly forward-only; play additionally allows
+    # zero so a human can pause safely.
+    command.ranges.lin_vel_x = (0.0, 0.30) if play else (0.30, 0.30)
+    # Viser requires every joystick axis to have a positive display maximum.
+    # These ranges exist only in play; training keeps lateral/yaw exactly zero.
+    command.ranges.lin_vel_y = (-0.10, 0.10) if play else (0.0, 0.0)
+    command.ranges.ang_vel_z = (-0.10, 0.10) if play else (0.0, 0.0)
+
+    # A 25 mm obstacle needs margin beyond the normal 20 mm swing target.
+    # The target is relative to the sensed local terrain under each foot.
+    cfg.rewards["foot_clearance"].params["target_height"] = 0.040
+    cfg.rewards["foot_swing_height"].params["target_height"] = 0.040
+    cfg.rewards["foot_swing_height"].weight = -0.5
+
+    # Skill discovery comes before smoothness.  The inherited -0.1 action-rate
+    # tax outweighed the extremely sparse endpoint signal in the first run and
+    # made a timid gait locally optimal.  Keep a small anti-jitter term, then
+    # tune smoothness in a later sim2real fine-tune after ascent is reliable.
+    cfg.rewards["action_rate_l2"].weight = -0.01
+    cfg.curriculum.pop("action_rate_weight", None)
+
+    # Full-height fine-tuning needs intermediate credit: first keep moving
+    # toward the edge, then reward one foot and both feet reaching the top.
+    # Milestones are one-shot per episode, so stopping on the edge cannot farm
+    # them. The edge is 0.30 m ahead of the spawn origin in this fixed setup.
+    feet_cfg = SceneEntityCfg("robot", site_names=("left_foot", "right_foot"))
+    cfg.rewards["step_forward_velocity"] = RewardTermCfg(
+        func=microduck_mdp.step_up_forward_velocity,
+        weight=4.0,
+        params={"cap": 0.6, "asset_cfg": SceneEntityCfg("robot")},
+    )
+    milestone_params = {
+        "min_foot_forward": 0.32,
+        "min_foot_height": 0.018,
+        "max_lateral_offset": SUCCESS_MAX_LATERAL_OFFSET,
+        "feet_cfg": feet_cfg,
+    }
+    cfg.rewards["one_foot_over_step"] = RewardTermCfg(
+        func=microduck_mdp.step_up_foot_milestone,
+        weight=100.0,
+        params={
+            **deepcopy(milestone_params),
+            "required_feet": 1,
+            "state_key": "_step_up_one_foot_seen",
+        },
+    )
+    cfg.rewards["two_feet_over_step"] = RewardTermCfg(
+        func=microduck_mdp.step_up_foot_milestone,
+        weight=150.0,
+        params={
+            **deepcopy(milestone_params),
+            "required_feet": 2,
+            "state_key": "_step_up_two_feet_seen",
+        },
+    )
+
+    # Strong one-frame endpoint bounty. Success terminates immediately, so it
+    # cannot be farmed by standing forever on the upper floor.
+    success_params = {
+        "min_forward_distance": SUCCESS_FORWARD_DISTANCE,
+        "min_trunk_height": SUCCESS_MIN_TRUNK_HEIGHT,
+        "min_upright_cos": 0.8,
+        "max_lateral_offset": SUCCESS_MAX_LATERAL_OFFSET,
+        "asset_cfg": SceneEntityCfg("robot"),
+    }
+    cfg.rewards["step_up_success"] = RewardTermCfg(
+        func=microduck_mdp.step_up_success,
+        weight=200.0,
+        params=deepcopy(success_params),
+    )
+    cfg.terminations["step_complete"] = TerminationTermCfg(
+        func=microduck_mdp.step_up_complete,
+        time_out=False,
+        params=deepcopy(success_params),
+    )
+    cfg.terminations["step_bypass"] = TerminationTermCfg(
+        func=microduck_mdp.step_up_out_of_bounds,
+        time_out=False,
+        params={
+            "max_lateral_offset": BYPASS_MAX_LATERAL_OFFSET,
+            "asset_cfg": SceneEntityCfg("robot"),
+        },
+    )
+    cfg.episode_length_s = 8.0
+
+    # These walking curricula would re-introduce standing rollouts and widen
+    # head commands, both distractions for a short dedicated ascent skill.
+    for curriculum_name in (
+        "standing_envs",
+        "head_pose_range",
+        "head_pose_bias_weight",
+    ):
+        cfg.curriculum.pop(curriculum_name, None)
+    cfg.events.pop("push_robot", None)
+
+    # Replace the generic terrain curriculum with promotion based on actually
+    # reaching the upper floor upright. Ten rows span a flush warm-up -> 25 mm.
+    cfg.curriculum["terrain_levels"] = CurriculumTermCfg(
+        func=microduck_mdp.terrain_levels_step_up,
+        params={
+            "min_forward_distance": SUCCESS_FORWARD_DISTANCE,
+            "min_trunk_height": SUCCESS_MIN_TRUNK_HEIGHT,
+            "min_upright_cos": 0.8,
+            "max_lateral_offset": SUCCESS_MAX_LATERAL_OFFSET,
+        },
+    )
+
+    return cfg
+
+
+def make_microduck_step_up_full_env_cfg(
+    play: bool = False,
+) -> ManagerBasedRlEnvCfg:
+    """Fixed 25 mm task for final fine-tuning after curriculum pretraining."""
+    cfg = make_microduck_step_up_env_cfg(play=play)
+    generator = cfg.scene.terrain.terrain_generator
+    assert generator is not None
+    generator.curriculum = False
+    generator.num_rows = 1
+    generator.difficulty_range = (1.0, 1.0)
+    cfg.scene.terrain.max_init_terrain_level = None
+    cfg.curriculum.pop("terrain_levels", None)
+    return cfg
+
+
+MicroduckStepUpRlCfg = deepcopy(MicroduckRlCfg)
+MicroduckStepUpRlCfg.experiment_name = "step_up"
+MicroduckStepUpRlCfg.run_name = "step_up_25mm"
+MicroduckStepUpRlCfg.save_interval = 100
+MicroduckStepUpRlCfg.max_iterations = 6_000
+
+MicroduckStepUpFullRlCfg = deepcopy(MicroduckStepUpRlCfg)
+MicroduckStepUpFullRlCfg.experiment_name = "step_up_full"
+MicroduckStepUpFullRlCfg.run_name = "step_up_25mm_full"
+MicroduckStepUpFullRlCfg.max_iterations = 1_000

--- a/src/mjlab_microduck/tasks/step_up_terrain.py
+++ b/src/mjlab_microduck/tasks/step_up_terrain.py
@@ -1,0 +1,85 @@
+"""Procedural lower-floor -> square-edged upper-floor terrain for Microduck."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import mujoco
+import numpy as np
+from mjlab.terrains.terrain_generator import (
+    SubTerrainCfg,
+    TerrainGeometry,
+    TerrainOutput,
+)
+
+# Start on a flush floor so every environment can generate successful
+# endpoint examples before it is asked to negotiate a vertical edge.  The
+# monotonic curriculum then introduces the edge in ~2.8 mm increments.
+STEP_HEIGHT_MIN = 0.0
+STEP_HEIGHT_MAX = 0.025
+
+
+def step_height_by_difficulty(
+    difficulty: float,
+    height_min: float = STEP_HEIGHT_MIN,
+    height_max: float = STEP_HEIGHT_MAX,
+) -> float:
+    """Linearly map curriculum difficulty to step height in metres."""
+    d = float(np.clip(difficulty, 0.0, 1.0))
+    return height_min + d * (height_max - height_min)
+
+
+@dataclass(kw_only=True)
+class UpStepTerrainCfg(SubTerrainCfg):
+    """A lower floor followed by one continuous, vertical-edged upper floor.
+
+    The spawn origin is on the lower floor, a randomized distance before the
+    edge. This represents the Mac/camera switching to the dedicated skill with
+    imperfect distance estimation. The actor itself remains proprioceptive.
+    """
+
+    lower_length: float = 1.0
+    approach_distance_range: tuple[float, float] = (0.20, 0.40)
+    height_min: float = STEP_HEIGHT_MIN
+    height_max: float = STEP_HEIGHT_MAX
+    thickness: float = 0.10
+
+    def function(self, difficulty: float, spec: mujoco.MjSpec, rng) -> TerrainOutput:
+        assert 0.0 < self.lower_length < self.size[0]
+        approach_lo, approach_hi = self.approach_distance_range
+        assert 0.0 < approach_lo <= approach_hi < self.lower_length
+
+        body = spec.body("terrain")
+        tile_length, tile_width = self.size
+        upper_length = tile_length - self.lower_length
+        height = step_height_by_difficulty(difficulty, self.height_min, self.height_max)
+        t = self.thickness
+
+        lower = body.add_geom(
+            type=mujoco.mjtGeom.mjGEOM_BOX,
+            size=(self.lower_length / 2.0, tile_width / 2.0, t / 2.0),
+            pos=(self.lower_length / 2.0, tile_width / 2.0, -t / 2.0),
+        )
+        upper = body.add_geom(
+            type=mujoco.mjtGeom.mjGEOM_BOX,
+            size=(upper_length / 2.0, tile_width / 2.0, t / 2.0),
+            pos=(
+                self.lower_length + upper_length / 2.0,
+                tile_width / 2.0,
+                height - t / 2.0,
+            ),
+        )
+
+        approach_distance = float(rng.uniform(approach_lo, approach_hi))
+        # Terrain-generator world positions are tile CORNERS. Put both the
+        # geometry and spawn at the tile's lateral center, not at its boundary.
+        origin = np.array(
+            [self.lower_length - approach_distance, tile_width / 2.0, 0.0]
+        )
+        return TerrainOutput(
+            origin=origin,
+            geometries=[
+                TerrainGeometry(geom=lower, color=(0.45, 0.45, 0.45, 1.0)),
+                TerrainGeometry(geom=upper, color=(0.58, 0.36, 0.17, 1.0)),
+            ],
+        )

--- a/tests/test_step_up_cfg.py
+++ b/tests/test_step_up_cfg.py
@@ -1,0 +1,87 @@
+from mjlab_microduck.tasks.microduck_step_up_env_cfg import (
+    APPROACH_DISTANCE_RANGE,
+    MicroduckStepUpFullRlCfg,
+    MicroduckStepUpRlCfg,
+    UpStepTerrainCfg,
+    make_microduck_step_up_env_cfg,
+    make_microduck_step_up_full_env_cfg,
+)
+
+
+def test_step_up_uses_curriculum_terrain_and_starts_easy():
+    cfg = make_microduck_step_up_env_cfg()
+    gen = cfg.scene.terrain.terrain_generator
+    assert gen is not None and gen.curriculum is True and gen.num_rows == 10
+    assert cfg.scene.terrain.max_init_terrain_level == 0
+    terrain = next(iter(gen.sub_terrains.values()))
+    assert isinstance(terrain, UpStepTerrainCfg)
+    assert terrain.approach_distance_range == APPROACH_DISTANCE_RANGE
+
+
+def test_play_scene_is_fixed_at_full_25_mm_difficulty():
+    cfg = make_microduck_step_up_env_cfg(play=True)
+    gen = cfg.scene.terrain.terrain_generator
+    assert gen is not None and gen.curriculum is False
+    assert gen.difficulty_range == (1.0, 1.0)
+    assert cfg.commands["twist"].ranges.lin_vel_x == (0.0, 0.30)
+    assert cfg.commands["twist"].ranges.lin_vel_y == (-0.10, 0.10)
+    assert cfg.commands["twist"].ranges.ang_vel_z == (-0.10, 0.10)
+
+
+def test_full_finetune_scene_is_always_25_mm_without_curriculum():
+    cfg = make_microduck_step_up_full_env_cfg()
+    gen = cfg.scene.terrain.terrain_generator
+    assert gen is not None and gen.curriculum is False and gen.num_rows == 1
+    assert gen.difficulty_range == (1.0, 1.0)
+    assert cfg.scene.terrain.max_init_terrain_level is None
+    assert "terrain_levels" not in cfg.curriculum
+
+
+def test_step_skill_is_forward_only_and_keeps_61d_command_slots():
+    cfg = make_microduck_step_up_env_cfg()
+    cmd = cfg.commands["twist"]
+    assert cmd.ranges.lin_vel_x == (0.30, 0.30)
+    assert cmd.ranges.lin_vel_y == (0.0, 0.0)
+    assert cmd.ranges.ang_vel_z == (0.0, 0.0)
+    assert "head_command" in cfg.observations["actor"].terms
+    assert "body_command" in cfg.observations["actor"].terms
+    assert "standing_envs" not in cfg.curriculum
+    assert "push_robot" not in cfg.events
+
+
+def test_skill_discovery_does_not_start_with_a_motion_blocking_tax():
+    cfg = make_microduck_step_up_env_cfg()
+    assert cfg.rewards["action_rate_l2"].weight == -0.01
+    assert "action_rate_weight" not in cfg.curriculum
+
+
+def test_success_is_one_shot_and_requires_upper_floor_arrival():
+    cfg = make_microduck_step_up_env_cfg()
+    assert cfg.rewards["step_up_success"].weight == 200.0
+    assert "step_complete" in cfg.terminations
+    reward_params = cfg.rewards["step_up_success"].params
+    termination_params = cfg.terminations["step_complete"].params
+    assert reward_params == termination_params
+    assert 0.10 <= reward_params["min_trunk_height"] < 0.12
+
+
+def test_full_height_finetune_has_hierarchical_progress_rewards():
+    cfg = make_microduck_step_up_full_env_cfg()
+    assert cfg.rewards["step_forward_velocity"].weight == 4.0
+    assert cfg.rewards["one_foot_over_step"].weight == 100.0
+    assert cfg.rewards["two_feet_over_step"].weight == 150.0
+    assert cfg.rewards["one_foot_over_step"].params["required_feet"] == 1
+    assert cfg.rewards["two_feet_over_step"].params["required_feet"] == 2
+
+
+def test_foot_lift_target_clears_25_mm_with_margin():
+    cfg = make_microduck_step_up_env_cfg()
+    assert cfg.rewards["foot_clearance"].params["target_height"] == 0.040
+    assert cfg.rewards["foot_swing_height"].params["target_height"] == 0.040
+
+
+def test_runner_has_dedicated_experiment_name():
+    assert MicroduckStepUpRlCfg.experiment_name == "step_up"
+    assert MicroduckStepUpRlCfg.max_iterations == 6_000
+    assert MicroduckStepUpFullRlCfg.experiment_name == "step_up_full"
+    assert MicroduckStepUpFullRlCfg.max_iterations == 1_000

--- a/tests/test_step_up_rewards.py
+++ b/tests/test_step_up_rewards.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+
+import torch
+
+from mjlab_microduck.tasks.mdp import (
+    _step_up_success_mask,
+    step_up_foot_milestone,
+    step_up_out_of_bounds,
+)
+
+
+class _Scene(dict):
+    def __init__(self, robot, terrain):
+        super().__init__(robot=robot)
+        self.terrain = terrain
+
+
+def _fake_env(feet: torch.Tensor, episode_lengths: torch.Tensor):
+    robot = SimpleNamespace(data=SimpleNamespace(site_pos_w=feet))
+    terrain = SimpleNamespace(env_origins=torch.zeros(feet.shape[0], 3))
+    return SimpleNamespace(
+        scene=_Scene(robot, terrain),
+        episode_length_buf=episode_lengths,
+    )
+
+
+def _feet_cfg():
+    return SimpleNamespace(name="robot", site_ids=[0, 1])
+
+
+def test_foot_milestone_is_paid_only_once_per_episode():
+    feet = torch.tensor([[[0.34, 0.0, 0.025], [0.20, 0.0, 0.0]]])
+    env = _fake_env(feet, torch.tensor([2]))
+    kwargs = {
+        "min_foot_forward": 0.32,
+        "min_foot_height": 0.018,
+        "required_feet": 1,
+        "state_key": "_one_foot_seen",
+        "feet_cfg": _feet_cfg(),
+    }
+    assert step_up_foot_milestone(env, **kwargs).tolist() == [1.0]
+    assert step_up_foot_milestone(env, **kwargs).tolist() == [0.0]
+
+    env.episode_length_buf[:] = 0
+    assert step_up_foot_milestone(env, **kwargs).tolist() == [1.0]
+
+
+def test_two_foot_milestone_requires_both_feet_past_and_above_edge():
+    feet = torch.tensor(
+        [
+            [[0.34, 0.0, 0.025], [0.20, 0.0, 0.0]],
+            [[0.34, 0.0, 0.025], [0.35, 0.0, 0.024]],
+        ]
+    )
+    env = _fake_env(feet, torch.tensor([2, 2]))
+    reward = step_up_foot_milestone(
+        env,
+        min_foot_forward=0.32,
+        min_foot_height=0.018,
+        required_feet=2,
+        state_key="_two_feet_seen",
+        feet_cfg=_feet_cfg(),
+    )
+    assert reward.tolist() == [0.0, 1.0]
+
+
+def test_strict_success_rejects_side_bypass_and_requires_both_feet_on_top():
+    data = SimpleNamespace(
+        root_link_pos_w=torch.tensor(
+            [[0.55, 0.00, 0.13], [0.55, 0.45, 0.13], [0.55, 0.00, 0.13]]
+        ),
+        root_link_quat_w=torch.tensor([[1.0, 0.0, 0.0, 0.0]] * 3),
+        site_pos_w=torch.tensor(
+            [
+                [[0.40, 0.05, 0.025], [0.41, -0.05, 0.025]],
+                [[0.60, 0.45, 0.000], [0.61, 0.52, 0.000]],
+                [[0.40, 0.05, 0.025], [0.30, -0.05, 0.000]],
+            ]
+        ),
+    )
+    robot = SimpleNamespace(data=data)
+    terrain = SimpleNamespace(env_origins=torch.zeros(3, 3))
+    env = SimpleNamespace(scene=_Scene(robot, terrain))
+    result = _step_up_success_mask(
+        env,
+        min_forward_distance=0.36,
+        min_trunk_height=0.105,
+        min_upright_cos=0.8,
+        max_lateral_offset=0.30,
+        min_foot_forward=0.34,
+        min_foot_height=0.018,
+        asset_cfg=SimpleNamespace(name="robot"),
+        feet_cfg=SimpleNamespace(name="robot", site_ids=[0, 1]),
+    )
+    assert result.tolist() == [True, False, False]
+    assert step_up_out_of_bounds(
+        env,
+        max_lateral_offset=0.34,
+        asset_cfg=SimpleNamespace(name="robot"),
+    ).tolist() == [False, True, False]

--- a/tests/test_step_up_terrain.py
+++ b/tests/test_step_up_terrain.py
@@ -1,0 +1,50 @@
+import math
+
+import mujoco
+import numpy as np
+
+from mjlab_microduck.tasks.step_up_terrain import (
+    STEP_HEIGHT_MAX,
+    STEP_HEIGHT_MIN,
+    UpStepTerrainCfg,
+    step_height_by_difficulty,
+)
+
+
+def _empty_terrain_spec():
+    spec = mujoco.MjSpec()
+    spec.worldbody.add_body(name="terrain")
+    return spec
+
+
+def test_step_height_curriculum_endpoints_and_clamping():
+    assert STEP_HEIGHT_MIN == 0.0
+    assert math.isclose(step_height_by_difficulty(0.0), STEP_HEIGHT_MIN)
+    assert math.isclose(step_height_by_difficulty(1.0), STEP_HEIGHT_MAX)
+    assert math.isclose(step_height_by_difficulty(-1.0), STEP_HEIGHT_MIN)
+    assert math.isclose(step_height_by_difficulty(2.0), STEP_HEIGHT_MAX)
+
+
+def test_up_step_is_continuous_upper_floor_with_square_edge():
+    cfg = UpStepTerrainCfg(lower_length=1.0, approach_distance_range=(0.3, 0.3))
+    cfg.size = (3.0, 1.2)
+    out = cfg.function(1.0, _empty_terrain_spec(), np.random.default_rng(0))
+    assert len(out.geometries) == 2
+    lower, upper = (g.geom for g in out.geometries)
+    lower_end = lower.pos[0] + lower.size[0]
+    upper_start = upper.pos[0] - upper.size[0]
+    assert math.isclose(lower_end, upper_start, abs_tol=1e-9)
+    assert math.isclose(upper.pos[2] + upper.size[2], 0.025, abs_tol=1e-9)
+    assert math.isclose(out.origin[0], 0.7, abs_tol=1e-9)
+    assert math.isclose(out.origin[1], 0.6, abs_tol=1e-9)
+    assert math.isclose(lower.pos[1], 0.6, abs_tol=1e-9)
+    assert math.isclose(upper.pos[1], 0.6, abs_tol=1e-9)
+
+
+def test_spawn_distance_is_randomized_within_camera_trigger_range():
+    cfg = UpStepTerrainCfg(approach_distance_range=(0.2, 0.4))
+    cfg.size = (3.0, 1.2)
+    for seed in range(20):
+        out = cfg.function(0.5, _empty_terrain_spec(), np.random.default_rng(seed))
+        distance = cfg.lower_length - out.origin[0]
+        assert 0.2 <= distance <= 0.4


### PR DESCRIPTION
## Summary

- add a dedicated Microduck step-up task for square-edged household thresholds
- provide a curriculum from a flush warm-up to a configurable 25 mm step, plus a fixed-height fine-tuning task
- preserve the shared 61D observation and 14D action contract for runtime policy hot-swapping
- add ascent milestones, success/bypass termination, terrain generation, task registration, and README commands
- add CPU-only regression tests for configuration, rewards, terminations, curriculum, and terrain geometry

## Motivation

A common home deployment obstacle is a single square-edged threshold rather than rough terrain. This task models an 80 cm-wide, 25 mm-high step-up use case while keeping the terrain and reward implementation reusable.

The intended deployment flow is for an external camera/controller to align the robot and switch from its walking policy to the dedicated ascent policy before the edge.

## Validation

- `uv run --with pytest pytest tests/`
- 169 passed, 1 skipped
- `git diff --check`

This PR adds the training environment and tests; it does not include a trained checkpoint.