### PR TITLE
fix: make `train --hf-jobs` work on Windows

### DIFF
--- a/src/mjlab_microduck/hf_jobs.py
+++ b/src/mjlab_microduck/hf_jobs.py
@@ -124,17 +124,23 @@ exit $TRAIN_RC
 def _wandb_api_key() -> str | None:
     """Best-effort lookup of the user's wandb API key.
 
-    Order: WANDB_API_KEY env -> ~/.netrc (machine api.wandb.ai).
+    Order: WANDB_API_KEY env -> ~/.netrc, then ~/_netrc (machine api.wandb.ai).
+
+    `wandb login` writes `_netrc` on Windows (the platform's netrc convention,
+    which the stdlib `netrc` default path does not know about), so checking
+    only `.netrc` reported "no API key found" right after a successful login
+    (2026-09-02).
     """
     if k := os.environ.get("WANDB_API_KEY"):
         return k
-    try:
-        n = netrc(str(Path.home() / ".netrc"))
-        auth = n.authenticators("api.wandb.ai")
-        if auth and auth[2]:
-            return auth[2]
-    except (FileNotFoundError, OSError):
-        pass
+    for name in (".netrc", "_netrc"):
+        try:
+            n = netrc(str(Path.home() / name))
+            auth = n.authenticators("api.wandb.ai")
+            if auth and auth[2]:
+                return auth[2]
+        except (FileNotFoundError, OSError):
+            continue
     return None
 
 

--- a/src/mjlab_microduck/train_hook.py
+++ b/src/mjlab_microduck/train_hook.py
@@ -40,8 +40,15 @@ def _invoked_as_train() -> bool:
     `play --hf-jobs` must NOT submit a training job; let that command's own
     parser reject the flag instead.
     """
+    # Windows console scripts are `train.exe`, so the bare name never equals
+    # "train" and the flag silently fell through to tyro's
+    # `Unrecognized options: --hf-jobs` — the same failure this hook exists to
+    # fix, one platform over (2026-09-02).
     prog = Path(sys.argv[0]).name
-    return prog.removesuffix(".py").removesuffix("-script") == "train"
+    return (
+        prog.removesuffix(".exe").removesuffix(".py").removesuffix("-script")
+        == "train"
+    )
 
 
 def maybe_submit_to_hf_jobs() -> None:

--- a/tests/test_hf_jobs_flag.py
+++ b/tests/test_hf_jobs_flag.py
@@ -101,11 +101,26 @@ def fake_submit(monkeypatch):
     return calls
 
 
-def test_hook_submits_and_strips_the_flag(monkeypatch, fake_submit):
+# argv[0] is however the OS spells the installed console script. Windows
+# writes `train.exe`, so a bare `== "train"` check silently declined to
+# intercept and the flag fell through to tyro's `Unrecognized options:
+# --hf-jobs` — the exact failure this hook exists to prevent, one platform
+# over (2026-09-02). Forward slashes so the paths split on both platforms.
+_TRAIN_ARGV0 = [
+    "/x/.venv/bin/train",  # posix console script
+    "C:/x/.venv/Scripts/train.exe",  # windows console script
+    "train",  # bare name, invoked from PATH
+    "train.exe",
+    "train-script.py",  # setuptools-style wrapper
+]
+
+
+@pytest.mark.parametrize("argv0", _TRAIN_ARGV0)
+def test_hook_submits_and_strips_the_flag(monkeypatch, fake_submit, argv0):
     monkeypatch.setattr(
         sys,
         "argv",
-        ["/x/.venv/bin/train", _TASK, "--env.scene.num-envs", "4096", "--hf-jobs"],
+        [argv0, _TASK, "--env.scene.num-envs", "4096", "--hf-jobs"],
     )
     with pytest.raises(SystemExit) as exc:
         train_hook.maybe_submit_to_hf_jobs()
@@ -128,9 +143,14 @@ def test_no_flag_trains_locally(monkeypatch, fake_submit):
     assert fake_submit == []
 
 
-def test_other_commands_do_not_submit(monkeypatch, fake_submit):
-    """`play --hf-jobs` must reach play's parser, not submit a training job."""
-    monkeypatch.setattr(sys, "argv", ["/x/.venv/bin/play", _TASK, "--hf-jobs"])
+@pytest.mark.parametrize("argv0", ["/x/.venv/bin/play", "C:/x/.venv/Scripts/play.exe"])
+def test_other_commands_do_not_submit(monkeypatch, fake_submit, argv0):
+    """`play --hf-jobs` must reach play's parser, not submit a training job.
+
+    Guards the fix above from over-reaching: stripping the suffix must not
+    make every `*.exe` look like the trainer.
+    """
+    monkeypatch.setattr(sys, "argv", [argv0, _TASK, "--hf-jobs"])
     assert train_hook.maybe_submit_to_hf_jobs() is None
     assert fake_submit == []
 

--- a/tests/test_hf_jobs_wandb_key.py
+++ b/tests/test_hf_jobs_wandb_key.py
@@ -1,0 +1,49 @@
+"""The wandb key lookup must find the file `wandb login` actually wrote.
+
+`wandb login` follows the platform's netrc convention: `~/.netrc` on POSIX,
+`~/_netrc` on Windows (it even prints the path it chose). Looking only at
+`.netrc` therefore reported
+
+    [wandb] x no API key found (checked $WANDB_API_KEY and ~/.netrc).
+
+immediately after a successful `wandb login` on Windows, and the submission
+refused to forward a key that was sitting right there (2026-09-02).
+"""
+
+import pytest
+
+from mjlab_microduck.hf_jobs import _wandb_api_key
+
+_KEY = "b" * 40
+_NETRC = f"machine api.wandb.ai\n  login user\n  password {_KEY}\n"
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Point `Path.home()` at a scratch dir on both platforms."""
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))  # posix
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # windows
+    return tmp_path
+
+
+@pytest.mark.parametrize("name", [".netrc", "_netrc"])
+def test_key_is_found_under_either_netrc_spelling(home, name):
+    (home / name).write_text(_NETRC)
+    assert _wandb_api_key() == _KEY
+
+
+def test_env_var_still_wins(home, monkeypatch):
+    (home / ".netrc").write_text(_NETRC)
+    monkeypatch.setenv("WANDB_API_KEY", "from-env")
+    assert _wandb_api_key() == "from-env"
+
+
+def test_missing_netrc_is_not_an_error(home):
+    """No key is a supported state — submission just warns and suggests --no-wandb."""
+    assert _wandb_api_key() is None
+
+
+def test_unrelated_machine_is_ignored(home):
+    home.joinpath(".netrc").write_text("machine example.com\n  login u\n  password p\n")
+    assert _wandb_api_key() is None


### PR DESCRIPTION
`train <task> --hf-jobs` is unusable on Windows. Two independent bugs, both
one-liners, both invisible in CI because they only trigger on `nt`. Found
while following `scripts/hf/README.md` from a clean clone.

### 1. The flag is never intercepted (`train_hook.py`)

`_invoked_as_train()` compares the console script's bare name to `"train"`,
stripping `.py` and `-script`. Windows installs the script as `train.exe`, so
the comparison fails, the hook returns early, and the flag reaches tyro:

```
Unrecognized options: --hf-jobs, --dry-run
```

Which is the same symptom #20 fixed on Linux. The cause is easy to miss
because tyro prints the program without the extension —
`C:\...\.venv\Scripts\train` — so argv[0] looks like it should have matched.
Confirmed with a `sitecustomize` probe on the real invocation:

```
ARGV0 = 'C:\GitHub\microduck_rl\.venv\Scripts\train.exe'
name  = 'train.exe'
```

Every existing case in `test_hf_jobs_flag.py` uses posix argv[0]
(`/x/.venv/bin/train`), so the suite stayed green. Now parametrized over the
spellings a console script actually takes, with `play.exe` added to the
negative case so the suffix strip can't over-reach.

### 2. The wandb key is never found (`hf_jobs.py`)

`wandb login` writes `~/_netrc` on Windows and says so:

```
Appending key for api.wandb.ai to your netrc file: C:\Users\...\_netrc
```

`_wandb_api_key()` reads only `~/.netrc`, so submission reports

```
[wandb] x no API key found (checked $WANDB_API_KEY and ~/.netrc).
        Run `wandb login` locally, or pass --no-wandb to skip.
```

immediately after a successful login. The suggested remedy is a dead end:
`wandb login` again just rewrites `_netrc`. Now tries both spellings, with a
new `test_hf_jobs_wandb_key.py` covering both, env-var precedence, and the
no-key path.

### Verification

`uv run --with pytest pytest tests/test_hf_jobs_flag.py tests/test_hf_jobs_wandb_key.py`
— 21 passed (see note below for the 1 unrelated pre-existing failure).

End-to-end on Windows, which previously could not get past argument parsing:

```
[hf] namespace: <user>
[wandb] forwarding API key from ~/.netrc
[src] building tarball -> src-20260902-223214.tar.gz
[src] HEAD=5946fd9, 9.9 MB
[dry-run] would submit job:
  flavor:    l4x1, timeout: 12h
  secrets:   {'HF_TOKEN': '***', 'WANDB_API_KEY': '***'}
```

### Not fixed here

`test_train_on_path_is_a_mjlab_trainer` also fails on Windows, for an
unrelated reason: it looks for `b"mjlab"` in the first 8192 bytes of the
resolved script, but a Windows console script is a PE launcher stub with the
payload appended at the end. In this venv `train.exe` is 46080 bytes and
`mjlab` first appears at offset **43543**, so the check can't pass on Windows
even when the script is correct. Left alone to keep this PR to the two
functional bugs — happy to add a commit or open a separate issue, whichever
you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oSADSTKCB8mSdb6yFpvLt
