### PR TITLE
Add commanded left/right single-leg standing task

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ instead of locally (see [scripts/hf/README.md](scripts/hf/README.md)).
 | `Mjlab-GroundPick-{Flat,Rough}-MicroDuck` | flat/rough | Crouch and touch the ground with the mouth tip, return to stand |
 | `Mjlab-BallKick-Flat-MicroDuck` | flat | Kick a 70 mm / 15 g ball forward (actor is ball-blind) |
 | `Mjlab-Roulade-Flat-MicroDuck` | flat | Forward roll over the head, land back on the feet |
+| `Mjlab-SingleLegStand-Flat-MicroDuck` | flat | Commanded left/right single-leg standing in one symmetric policy |
 | `Mjlab-Velocity-Flat-MicroDuck-Rollers` | flat | Roller-skate velocity tracking (passive wheels under the feet) |
 | `Mjlab-Velocity-Swizzle-MicroDuck` | flat | Classic symmetric swizzle skating |
 | `Mjlab-RollerCrouch-Flat-MicroDuck` | flat | Crouch while gliding on rollers |

--- a/scripts/eval_single_leg.py
+++ b/scripts/eval_single_leg.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Headless left/right evaluation for a single-leg-stand checkpoint."""
+
+import argparse
+import contextlib
+import json
+import sys
+from dataclasses import asdict
+
+TASK = "Mjlab-SingleLegStand-Flat-MicroDuck"
+PERCENTILES = (0, 10, 25, 50, 75, 90, 100)
+
+
+def summarize(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    result = {"mean": sum(ordered) / len(ordered)}
+    for percentile in PERCENTILES:
+        position = (len(ordered) - 1) * percentile / 100
+        lower = int(position)
+        upper = min(lower + 1, len(ordered) - 1)
+        fraction = position - lower
+        result[f"p{percentile}"] = (
+            ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+        )
+    return result
+
+
+def evaluate(
+    checkpoint: str,
+    side: int,
+    num_envs: int,
+    episodes: int,
+    episode_seconds: float,
+    seed: int,
+    device: str,
+    strict: bool,
+) -> dict:
+    import torch
+    from rsl_rl.runners import OnPolicyRunner
+
+    from mjlab.envs import ManagerBasedRlEnv
+    from mjlab.rl import RslRlVecEnvWrapper
+    from mjlab.tasks.registry import load_env_cfg, load_rl_cfg, load_runner_cls
+    from mjlab.utils.lab_api.math import matrix_from_quat
+
+    env_cfg = load_env_cfg(TASK, play=True)
+    env_cfg.seed = seed
+    env_cfg.scene.num_envs = num_envs
+    env_cfg.episode_length_s = episode_seconds
+    env_cfg.commands["twist"].fixed_side = side
+    env_cfg.commands["twist"].resampling_time_range = (
+        episode_seconds,
+        episode_seconds,
+    )
+    agent_cfg = load_rl_cfg(TASK)
+
+    env = RslRlVecEnvWrapper(
+        ManagerBasedRlEnv(cfg=env_cfg, device=device),
+        clip_actions=agent_cfg.clip_actions,
+    )
+    runner_cls = load_runner_cls(TASK) or OnPolicyRunner
+    runner = runner_cls(env, asdict(agent_cfg), device=device)
+    runner.load(
+        checkpoint,
+        load_cfg={"actor": True},
+        strict=True,
+        map_location=device,
+    )
+    policy = runner.get_inference_policy(device=device)
+    obs = env.get_observations()
+
+    achieved = torch.zeros(num_envs, dtype=torch.bool, device=device)
+    first_success_step = torch.full((num_envs,), -1, dtype=torch.long, device=device)
+    episode_step = torch.zeros(num_envs, dtype=torch.long, device=device)
+    completed = successes = survived = 0
+    success_times: list[float] = []
+    gate_totals = {
+        name: torch.zeros((), device=device)
+        for name in (
+            "support_contact",
+            "swing_clearance",
+            "swing_no_contact",
+            "com_inside",
+            "tilt",
+            "quiet",
+            "nonfoot_clear",
+            "all_instant",
+        )
+    }
+    eligible_total = torch.zeros((), device=device)
+    clearance_total = torch.zeros((), device=device)
+    no_contact_run_s = torch.zeros(num_envs, device=device)
+    valid_run_s = torch.zeros(num_envs, device=device)
+    episode_max_no_contact_s = torch.zeros(num_envs, device=device)
+    episode_max_valid_s = torch.zeros(num_envs, device=device)
+    contact_transitions = torch.zeros(num_envs, device=device)
+    eligible_steps = torch.zeros(num_envs, device=device)
+    previous_contact = torch.zeros(num_envs, dtype=torch.bool, device=device)
+    previous_contact_valid = torch.zeros(num_envs, dtype=torch.bool, device=device)
+    max_no_contact_times: list[float] = []
+    max_valid_times: list[float] = []
+    transition_rates: list[float] = []
+
+    with torch.inference_mode():
+        while completed < episodes:
+            obs, _, dones, extras = env.step(policy(obs))
+            episode_step += 1
+            raw = env.unwrapped
+            time_outs = extras.get("time_outs", raw.reset_time_outs)
+            alpha = raw.command_manager.get_term("twist").alpha
+            eligible = alpha >= 0.99
+            support = 0 if side == -1 else 1
+            swing = 1 - support
+            contacts = (
+                raw.scene.sensors["feet_ground_contact"].data.found.reshape(
+                    num_envs, -1
+                )[:, :2]
+                > 0.0
+            )
+            asset = raw.scene["robot"]
+            feet_ids = asset.find_sites(("left_foot", "right_foot"))[0]
+            feet = asset.data.site_pos_w[:, feet_ids]
+            clearance = feet[:, swing, 2] - feet[:, support, 2]
+            delta_w = asset.data.root_com_pos_w - feet[:, support]
+            delta_b = torch.bmm(
+                matrix_from_quat(asset.data.root_link_quat_w).transpose(1, 2),
+                delta_w.unsqueeze(-1),
+            ).squeeze(-1)
+            com_inside = (
+                torch.square(delta_b[:, 0] / 0.025)
+                + torch.square(delta_b[:, 1] / 0.018)
+            ) <= 1.0
+            quat = asset.data.root_link_quat_w
+            cos_tilt = 1.0 - 2.0 * (quat[:, 1] ** 2 + quat[:, 2] ** 2)
+            quiet = (
+                torch.linalg.vector_norm(asset.data.root_link_lin_vel_w, dim=-1) < 0.08
+            ) & (torch.linalg.vector_norm(asset.data.root_link_ang_vel_w, dim=-1) < 0.8)
+            nonfoot_clear = (
+                raw.scene.sensors["nonfoot_ground_contact"]
+                .data.found.reshape(num_envs, -1)
+                .sum(dim=-1)
+                == 0.0
+            )
+            clearance_threshold = 0.003 if strict else 0.008
+            gates = {
+                "support_contact": contacts[:, support],
+                "swing_clearance": clearance >= clearance_threshold,
+                "swing_no_contact": ~contacts[:, swing],
+                "com_inside": com_inside,
+                "tilt": cos_tilt
+                >= torch.cos(torch.tensor(0.6108652382, device=device)),
+                "quiet": quiet,
+                "nonfoot_clear": nonfoot_clear,
+            }
+            required = [
+                gate
+                for name, gate in gates.items()
+                if not strict or name != "com_inside"
+            ]
+            gates["all_instant"] = torch.stack(required).all(dim=0)
+            swing_contact = contacts[:, swing]
+            no_contact_run_s = torch.where(
+                eligible & ~swing_contact,
+                no_contact_run_s + env.unwrapped.step_dt,
+                torch.zeros_like(no_contact_run_s),
+            )
+            valid_run_s = torch.where(
+                eligible & gates["all_instant"],
+                valid_run_s + env.unwrapped.step_dt,
+                torch.zeros_like(valid_run_s),
+            )
+            episode_max_no_contact_s = torch.maximum(
+                episode_max_no_contact_s, no_contact_run_s
+            )
+            episode_max_valid_s = torch.maximum(episode_max_valid_s, valid_run_s)
+            contact_transitions += (
+                eligible
+                & previous_contact_valid
+                & (swing_contact != previous_contact)
+            )
+            eligible_steps += eligible
+            previous_contact = swing_contact
+            previous_contact_valid = eligible
+            eligible_total += eligible.sum()
+            clearance_total += torch.where(eligible, clearance, 0.0).sum()
+            for name, gate in gates.items():
+                gate_totals[name] += (gate & eligible).sum()
+
+            current = valid_run_s >= 1.0
+            first = current & ~achieved
+            first_success_step[first] = episode_step[first]
+            achieved |= current
+
+            done_ids = torch.nonzero(dones, as_tuple=False).flatten()
+            for idx in done_ids.tolist():
+                if completed >= episodes:
+                    break
+                completed += 1
+                survived += int(bool(time_outs[idx]))
+                if bool(achieved[idx]):
+                    successes += 1
+                    success_times.append(
+                        float(first_success_step[idx]) * env.unwrapped.step_dt
+                    )
+                max_no_contact_times.append(float(episode_max_no_contact_s[idx]))
+                max_valid_times.append(float(episode_max_valid_s[idx]))
+                eligible_s = float(eligible_steps[idx]) * env.unwrapped.step_dt
+                transition_rates.append(
+                    float(contact_transitions[idx]) / max(eligible_s, 1e-6)
+                )
+            achieved[done_ids] = False
+            first_success_step[done_ids] = -1
+            episode_step[done_ids] = 0
+            no_contact_run_s[done_ids] = 0.0
+            valid_run_s[done_ids] = 0.0
+            episode_max_no_contact_s[done_ids] = 0.0
+            episode_max_valid_s[done_ids] = 0.0
+            contact_transitions[done_ids] = 0.0
+            eligible_steps[done_ids] = 0.0
+            previous_contact_valid[done_ids] = False
+
+    env.close()
+    eligible_count = float(eligible_total)
+
+    def eligible_rate(value: torch.Tensor) -> float | None:
+        return float(value) / eligible_count if eligible_count > 0.0 else None
+
+    swing_no_contact_rate = eligible_rate(gate_totals["swing_no_contact"])
+    nonfoot_clear_rate = eligible_rate(gate_totals["nonfoot_clear"])
+    return {
+        "side": "left" if side == -1 else "right",
+        "episodes": completed,
+        "episode_seconds": episode_seconds,
+        "seed": seed,
+        "strict": strict,
+        "successes": successes,
+        "success_rate": successes / completed,
+        "survivals": survived,
+        "survival_rate": survived / completed,
+        "mean_time_to_success_s": (
+            sum(success_times) / len(success_times) if success_times else None
+        ),
+        "mean_swing_clearance_m": (
+            float(clearance_total) / eligible_count if eligible_count > 0.0 else None
+        ),
+        "swing_foot_contact_fraction": (
+            1.0 - swing_no_contact_rate
+            if swing_no_contact_rate is not None
+            else None
+        ),
+        "nonfoot_contact_fraction": (
+            1.0 - nonfoot_clear_rate if nonfoot_clear_rate is not None else None
+        ),
+        "gate_rates": {
+            name: eligible_rate(value) for name, value in gate_totals.items()
+        },
+        "continuity": {
+            "longest_swing_no_contact_s": summarize(max_no_contact_times),
+            "longest_all_gates_s": summarize(max_valid_times),
+            "mean_contact_transitions_per_s": sum(transition_rates)
+            / len(transition_rates),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("checkpoint")
+    parser.add_argument("--num-envs", type=int, default=128)
+    parser.add_argument("--episodes", type=int, default=100)
+    parser.add_argument("--episode-seconds", type=float, default=6.0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+    if args.num_envs <= 0:
+        parser.error("--num-envs must be positive")
+    if args.episodes <= 0:
+        parser.error("--episodes must be positive")
+    if args.episode_seconds <= 0.0:
+        parser.error("--episode-seconds must be positive")
+
+    with contextlib.redirect_stdout(sys.stderr):
+        results = [
+            evaluate(
+                args.checkpoint,
+                side,
+                args.num_envs,
+                args.episodes,
+                args.episode_seconds,
+                args.seed,
+                args.device,
+                args.strict,
+            )
+            for side in (-1, 1)
+        ]
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/log_single_leg_eval_tensorboard.py
+++ b/scripts/log_single_leg_eval_tensorboard.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Append single-leg evaluation percentiles to TensorBoard."""
+
+import argparse
+import json
+from pathlib import Path
+
+from torch.utils.tensorboard import SummaryWriter
+
+
+SERIES = ("p0", "p10", "p25", "p50", "p75", "p90", "p100", "mean")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log_dir", type=Path)
+    parser.add_argument(
+        "evaluations",
+        nargs="+",
+        metavar="STEP=JSON",
+        help="Evaluation step and JSON path, for example 2250=eval.json.",
+    )
+    args = parser.parse_args()
+
+    writer = SummaryWriter(args.log_dir)
+    for item in args.evaluations:
+        step_text, path_text = item.split("=", 1)
+        step = int(step_text)
+        results = json.loads(Path(path_text).read_text())
+        for result in results:
+            side = result["side"]
+            continuity = result["continuity"]
+            for metric, source in (
+                ("longest_no_contact_s", "longest_swing_no_contact_s"),
+                ("longest_all_gates_s", "longest_all_gates_s"),
+            ):
+                for series in SERIES:
+                    writer.add_scalar(
+                        f"Evaluation/{side}/{metric}/{series}",
+                        continuity[source][series],
+                        step,
+                    )
+            writer.add_scalar(
+                f"Evaluation/{side}/success_rate",
+                result["success_rate"],
+                step,
+            )
+            writer.add_scalar(
+                f"Evaluation/{side}/contact_transitions_per_s",
+                continuity["mean_contact_transitions_per_s"],
+                step,
+            )
+
+    layout = {}
+    for side in ("left", "right"):
+        label = f"{side.title()} support"
+        for metric, title in (
+            ("longest_no_contact_s", "Longest no-contact duration (s)"),
+            ("longest_all_gates_s", "Longest valid hold duration (s)"),
+        ):
+            layout[f"{label}: {title}"] = [
+                "Multiline",
+                [f"Evaluation/{side}/{metric}/{series}" for series in SERIES],
+            ]
+    writer.add_custom_scalars({"Single-leg evaluation": layout})
+    writer.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/record_single_leg.py
+++ b/scripts/record_single_leg.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Record fixed left/right single-leg rollouts from a checkpoint."""
+
+import argparse
+from dataclasses import asdict
+from pathlib import Path
+
+import torch
+from rsl_rl.runners import OnPolicyRunner
+
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.rl import RslRlVecEnvWrapper
+from mjlab.tasks.registry import load_env_cfg, load_rl_cfg, load_runner_cls
+from mjlab.utils.wrappers import VideoRecorder
+
+
+TASK = "Mjlab-SingleLegStand-Flat-MicroDuck"
+
+
+def record(
+    checkpoint: Path,
+    output_dir: Path,
+    side_name: str,
+    video_length: int,
+    device: str,
+    width: int,
+    height: int,
+) -> Path:
+    side = -1 if side_name == "left" else 1
+    env_cfg = load_env_cfg(TASK, play=True)
+    env_cfg.scene.num_envs = 1
+    env_cfg.commands["twist"].fixed_side = side
+    env_cfg.viewer.distance = 0.45
+    env_cfg.viewer.elevation = -10.0
+    env_cfg.viewer.width = width
+    env_cfg.viewer.height = height
+    agent_cfg = load_rl_cfg(TASK)
+
+    raw_env = ManagerBasedRlEnv(cfg=env_cfg, device=device, render_mode="rgb_array")
+    recorded_env = VideoRecorder(
+        raw_env,
+        video_folder=output_dir,
+        step_trigger=lambda step: step == 0,
+        video_length=video_length,
+        name_prefix=f"single-leg-{side_name}-support",
+    )
+    env = RslRlVecEnvWrapper(recorded_env, clip_actions=agent_cfg.clip_actions)
+    runner_cls = load_runner_cls(TASK) or OnPolicyRunner
+    runner = runner_cls(env, asdict(agent_cfg), device=device)
+    runner.load(
+        str(checkpoint),
+        load_cfg={"actor": True},
+        strict=True,
+        map_location=device,
+    )
+    policy = runner.get_inference_policy(device=device)
+    obs = env.get_observations()
+
+    with torch.inference_mode():
+        for _ in range(video_length):
+            obs, _, _, _ = env.step(policy(obs))
+    env.close()
+    return output_dir / f"single-leg-{side_name}-support-step-0.mp4"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("checkpoint", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument(
+        "--side",
+        choices=("left", "right", "both"),
+        default="both",
+        help="Commanded support side to record.",
+    )
+    parser.add_argument("--seconds", type=float, default=6.0)
+    parser.add_argument("--device", default="cuda:0" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--width", type=int, default=960)
+    parser.add_argument("--height", type=int, default=720)
+    args = parser.parse_args()
+
+    if not args.checkpoint.is_file():
+        parser.error(f"checkpoint not found: {args.checkpoint}")
+    if args.seconds <= 0.0:
+        parser.error("--seconds must be positive")
+
+    sides = ("left", "right") if args.side == "both" else (args.side,)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    env_cfg = load_env_cfg(TASK, play=True)
+    step_dt = env_cfg.decimation * env_cfg.sim.mujoco.timestep
+    video_length = max(1, round(args.seconds / step_dt))
+
+    for side_name in sides:
+        path = record(
+            args.checkpoint,
+            args.output_dir,
+            side_name,
+            video_length,
+            args.device,
+            args.width,
+            args.height,
+        )
+        print(path.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mjlab_microduck/tasks/__init__.py
+++ b/src/mjlab_microduck/tasks/__init__.py
@@ -75,6 +75,11 @@ from .microduck_roulade_env_cfg import (
     make_microduck_roulade_env_cfg,
     MicroduckRouladeRlCfg,
 )
+from .microduck_single_leg_stand_env_cfg import (
+    make_microduck_single_leg_stand_env_cfg,
+    make_microduck_single_leg_stand_strict_env_cfg,
+    MicroduckSingleLegStandRlCfg,
+)
 from .backlash import make_backlash_variant
 
 # Standard velocity task
@@ -233,6 +238,23 @@ register_mjlab_task(
     runner_cls=MicroduckOnPolicyRunner,
 )
 
+# Commanded left/right single-leg standing in one symmetric policy.
+register_mjlab_task(
+    task_id="Mjlab-SingleLegStand-Flat-MicroDuck",
+    env_cfg=make_microduck_single_leg_stand_env_cfg(),
+    play_env_cfg=make_microduck_single_leg_stand_env_cfg(play=True),
+    rl_cfg=MicroduckSingleLegStandRlCfg,
+    runner_cls=MicroduckOnPolicyRunner,
+)
+
+register_mjlab_task(
+    task_id="Mjlab-SingleLegStand-Strict-Flat-MicroDuck",
+    env_cfg=make_microduck_single_leg_stand_strict_env_cfg(),
+    play_env_cfg=make_microduck_single_leg_stand_strict_env_cfg(play=True),
+    rl_cfg=MicroduckSingleLegStandRlCfg,
+    runner_cls=MicroduckOnPolicyRunner,
+)
+
 # Backlash variants — ±1° serial gear play per servo + encoder-through-backlash
 # actuator feedback and joint obs (see tasks/backlash.py). Each family keeps its
 # base task's collision model: Velocity → robot_walk_backlash.xml,
@@ -267,6 +289,7 @@ _BACKLASH_TASKS = (
     ("Mjlab-Velocity-Swizzle-Backlash-MicroDuck", make_microduck_velocity_swizzle_env_cfg, {}, MicroduckSwizzleRlCfg, _BL_ROLLERS),
     ("Mjlab-RollerCrouch-Flat-Backlash-MicroDuck", make_microduck_roller_crouch_env_cfg, {}, MicroduckRollerCrouchRlCfg, _BL_ROLLERS),
     ("Mjlab-RollerSlope-Flat-Backlash-MicroDuck", make_microduck_roller_slope_env_cfg, {}, MicroduckRollerSlopeRlCfg, _BL_ROLLERS),
+    ("Mjlab-SingleLegStand-Flat-Backlash-MicroDuck", make_microduck_single_leg_stand_env_cfg, {}, MicroduckSingleLegStandRlCfg, _BL_GROUNDCONTACT),
 )
 for _task_id, _make_cfg, _kw, _rl_cfg, _robot_cfg in _BACKLASH_TASKS:
     register_mjlab_task(

--- a/src/mjlab_microduck/tasks/mdp.py
+++ b/src/mjlab_microduck/tasks/mdp.py
@@ -5824,6 +5824,400 @@ def single_foot_grounded_reward(
     return torch.clamp(found, 0.0, 1.0)
 
 
+class SingleLegStandCommand(UniformVelocityCommand):
+    """Command one support side in twist-y: -1 left, +1 right.
+
+    The actor sees the final side immediately. Reward targets move from double
+    support to single support over ``ramp_s`` so reaching the goal early is not
+    worth a violent leg snap.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        self._left_prob = float(cfg.left_prob)
+        self._ramp_s = float(cfg.ramp_s)
+        self._alpha = torch.zeros(self.num_envs, device=self.device)
+        self._support_side_gui = None
+
+    @property
+    def command(self) -> torch.Tensor:
+        return self.vel_command_b
+
+    @property
+    def alpha(self) -> torch.Tensor:
+        """Target blend: 0 = double support, 1 = commanded single support."""
+        return self._alpha
+
+    def _resample_command(self, env_ids: torch.Tensor) -> None:
+        count = len(env_ids)
+        if count == 0:
+            return
+        if self.cfg.fixed_side in (-1, 1):
+            side = torch.full(
+                (count,),
+                float(self.cfg.fixed_side),
+                device=self.device,
+            )
+        else:
+            side = torch.where(
+                torch.rand(count, device=self.device) < self._left_prob,
+                -1.0,
+                1.0,
+            )
+        self.vel_command_b[env_ids] = 0.0
+        self.vel_command_b[env_ids, 1] = side
+        self._alpha[env_ids] = 0.0
+
+    def compute(self, dt: float) -> None:
+        super().compute(dt)
+        if self._support_side_gui is not None:
+            side = -1.0 if self._support_side_gui.value == "Left support" else 1.0
+            changed = self.vel_command_b[:, 1] != side
+            self.vel_command_b[:] = 0.0
+            self.vel_command_b[:, 1] = side
+            self._alpha[changed] = 0.0
+        self._alpha = torch.clamp(self._alpha + dt / max(self._ramp_s, 1e-6), max=1.0)
+
+    def _update_command(self) -> None:
+        pass
+
+    def _update_metrics(self) -> None:
+        pass
+
+    def create_gui(self, name, server, *args, **kwargs) -> None:
+        """Create a support-side selector instead of velocity sliders."""
+        del args, kwargs
+        initial = "Right support" if self.cfg.fixed_side == 1 else "Left support"
+        with server.gui.add_folder(name.capitalize()):
+            self._support_side_gui = server.gui.add_dropdown(
+                "Support side",
+                ("Left support", "Right support"),
+                initial_value=initial,
+            )
+
+
+@_dataclass(kw_only=True)
+class SingleLegStandCommandCfg(UniformVelocityCommandCfg):
+    left_prob: float = 0.5
+    ramp_s: float = 1.5
+    fixed_side: int = 0
+
+    def build(self, env: ManagerBasedRlEnv) -> "SingleLegStandCommand":
+        return SingleLegStandCommand(self, env)
+
+
+def _single_leg_command_state(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    command = env.command_manager.get_command(command_name)
+    side = torch.where(command[:, 1] < 0.0, -1.0, 1.0)
+    support = (side > 0.0).long()  # left=0, right=1
+    swing = 1 - support
+    term = env.command_manager.get_term(command_name)
+    alpha = getattr(term, "alpha", torch.ones(env.num_envs, device=env.device))
+    return side, support, swing, alpha
+
+
+def _single_leg_contacts(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    found = env.scene.sensors[sensor_name].data.found
+    assert found is not None
+    return (found.reshape(env.num_envs, -1)[:, :2] > 0.0).float()
+
+
+def _single_leg_sites(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg,
+    support: torch.Tensor,
+    swing: torch.Tensor,
+) -> tuple[Entity, torch.Tensor, torch.Tensor]:
+    asset: Entity = env.scene[asset_cfg.name]
+    sites = asset.data.site_pos_w[:, asset_cfg.site_ids]
+    batch = torch.arange(env.num_envs, device=env.device)
+    return asset, sites[batch, support], sites[batch, swing]
+
+
+def single_leg_com_tracking(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    asset_cfg: SceneEntityCfg,
+    std_x: float = 0.04,
+    std_y: float = 0.025,
+) -> torch.Tensor:
+    """Track a slewed CoM target from the feet midpoint to the support foot."""
+    _, support, swing, alpha = _single_leg_command_state(env, command_name)
+    asset, support_pos, swing_pos = _single_leg_sites(env, asset_cfg, support, swing)
+    midpoint = 0.5 * (support_pos + swing_pos)
+    target = midpoint + alpha.unsqueeze(-1) * (support_pos - midpoint)
+    delta_w = asset.data.root_com_pos_w - target
+    root_mat = matrix_from_quat(asset.data.root_link_quat_w)
+    delta_b = torch.bmm(root_mat.transpose(1, 2), delta_w.unsqueeze(-1)).squeeze(-1)
+    return torch.exp(-torch.square(delta_b[:, 0] / std_x) - torch.square(delta_b[:, 1] / std_y))
+
+
+def single_leg_swing_height_tracking(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    asset_cfg: SceneEntityCfg,
+    target_height: float = 0.012,
+    std: float = 0.008,
+) -> torch.Tensor:
+    """Track swing-foot height relative to the support foot."""
+    _, support, swing, alpha = _single_leg_command_state(env, command_name)
+    _, support_pos, swing_pos = _single_leg_sites(env, asset_cfg, support, swing)
+    height = swing_pos[:, 2] - support_pos[:, 2]
+    target = alpha * target_height
+    return torch.exp(-torch.square((height - target) / std))
+
+
+def single_leg_support_contact(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    sensor_name: str,
+) -> torch.Tensor:
+    """Binary reward for keeping the commanded support foot grounded."""
+    _, support, _, _ = _single_leg_command_state(env, command_name)
+    contacts = _single_leg_contacts(env, sensor_name)
+    batch = torch.arange(env.num_envs, device=env.device)
+    return contacts[batch, support]
+
+
+def single_leg_swing_contact_cost(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    sensor_name: str,
+) -> torch.Tensor:
+    """Swing-foot contact cost, slewed in with the single-support target."""
+    _, _, swing, alpha = _single_leg_command_state(env, command_name)
+    contacts = _single_leg_contacts(env, sensor_name)
+    batch = torch.arange(env.num_envs, device=env.device)
+    return alpha * contacts[batch, swing]
+
+
+def single_leg_touchdown_cost(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    sensor_name: str,
+) -> torch.Tensor:
+    """Return one reward-unit per touchdown, independent of control frequency."""
+    _, _, swing, alpha = _single_leg_command_state(env, command_name)
+    contacts = _single_leg_contacts(env, sensor_name).bool()
+    batch = torch.arange(env.num_envs, device=env.device)
+    contact = contacts[batch, swing]
+    if not hasattr(env, "_single_leg_previous_swing_contact"):
+        env._single_leg_previous_swing_contact = contact.clone()
+    fresh = env.episode_length_buf <= 1
+    env._single_leg_previous_swing_contact[fresh] = contact[fresh]
+    touchdown = (
+        (alpha >= 0.99)
+        & contact
+        & ~env._single_leg_previous_swing_contact
+    )
+    env._single_leg_previous_swing_contact = contact.clone()
+    return touchdown.float() / env.step_dt
+
+
+def single_leg_support_slip_cost(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Squared horizontal velocity of the grounded support foot."""
+    _, support, _, _ = _single_leg_command_state(env, command_name)
+    contacts = _single_leg_contacts(env, sensor_name)
+    asset: Entity = env.scene[asset_cfg.name]
+    velocities = asset.data.site_lin_vel_w[:, asset_cfg.site_ids, :2]
+    batch = torch.arange(env.num_envs, device=env.device)
+    return torch.sum(torch.square(velocities[batch, support]), dim=-1) * contacts[batch, support]
+
+
+def single_leg_excess_tilt_cost(
+    env: ManagerBasedRlEnv,
+    max_tilt_deg: float = 32.0,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> torch.Tensor:
+    """Penalize only tilt beyond the lean the geometry needs for one-leg support."""
+    asset: Entity = env.scene[asset_cfg.name]
+    quat = asset.data.root_link_quat_w
+    cos_tilt = torch.clamp(1.0 - 2.0 * (quat[:, 1] ** 2 + quat[:, 2] ** 2), -1.0, 1.0)
+    tilt = torch.acos(cos_tilt)
+    return torch.square(torch.clamp(tilt - math.radians(max_tilt_deg), min=0.0))
+
+
+def any_contact_cost(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Binary cost when any contact represented by the sensor is active."""
+    found = env.scene.sensors[sensor_name].data.found
+    assert found is not None
+    return (found.reshape(env.num_envs, -1).sum(dim=-1) > 0.0).float()
+
+
+def single_leg_success_state(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+    nonfoot_sensor_name: str | None = None,
+    min_clearance: float = 0.008,
+    max_tilt_deg: float = 35.0,
+    max_lin_vel: float = 0.08,
+    max_ang_vel: float = 0.8,
+    support_radius_x: float = 0.025,
+    support_radius_y: float = 0.018,
+    require_com_inside: bool = True,
+) -> torch.Tensor:
+    """Binary metric for a valid, quiet commanded single-leg stance."""
+    _, support, swing, alpha = _single_leg_command_state(env, command_name)
+    contacts = _single_leg_contacts(env, sensor_name)
+    asset, support_pos, swing_pos = _single_leg_sites(env, asset_cfg, support, swing)
+    batch = torch.arange(env.num_envs, device=env.device)
+
+    delta_w = asset.data.root_com_pos_w - support_pos
+    root_mat = matrix_from_quat(asset.data.root_link_quat_w)
+    delta_b = torch.bmm(root_mat.transpose(1, 2), delta_w.unsqueeze(-1)).squeeze(-1)
+    inside = (
+        torch.square(delta_b[:, 0] / support_radius_x)
+        + torch.square(delta_b[:, 1] / support_radius_y)
+    ) <= 1.0
+    if not require_com_inside:
+        inside = torch.ones_like(inside)
+
+    quat = asset.data.root_link_quat_w
+    cos_tilt = torch.clamp(1.0 - 2.0 * (quat[:, 1] ** 2 + quat[:, 2] ** 2), -1.0, 1.0)
+    quiet = (
+        torch.linalg.vector_norm(asset.data.root_link_lin_vel_w, dim=-1) < max_lin_vel
+    ) & (
+        torch.linalg.vector_norm(asset.data.root_link_ang_vel_w, dim=-1) < max_ang_vel
+    )
+    no_other_contact = torch.ones(env.num_envs, dtype=torch.bool, device=env.device)
+    if nonfoot_sensor_name is not None:
+        no_other_contact = any_contact_cost(env, nonfoot_sensor_name) == 0.0
+    return (
+        (alpha >= 0.99)
+        & (contacts[batch, support] > 0.0)
+        & (contacts[batch, swing] == 0.0)
+        & ((swing_pos[:, 2] - support_pos[:, 2]) >= min_clearance)
+        & inside
+        & (cos_tilt >= math.cos(math.radians(max_tilt_deg)))
+        & quiet
+        & no_other_contact
+    ).float()
+
+
+def single_leg_hold_progress_reward(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+    nonfoot_sensor_name: str | None = None,
+    target_s: float = 1.0,
+    min_clearance: float = 0.008,
+    max_tilt_deg: float = 35.0,
+    max_lin_vel: float = 0.08,
+    max_ang_vel: float = 0.8,
+    require_com_inside: bool = True,
+) -> torch.Tensor:
+    """Reward only uninterrupted progress toward a valid single-leg hold."""
+    valid = single_leg_success_state(
+        env,
+        command_name=command_name,
+        sensor_name=sensor_name,
+        asset_cfg=asset_cfg,
+        nonfoot_sensor_name=nonfoot_sensor_name,
+        min_clearance=min_clearance,
+        max_tilt_deg=max_tilt_deg,
+        max_lin_vel=max_lin_vel,
+        max_ang_vel=max_ang_vel,
+        require_com_inside=require_com_inside,
+    ).bool()
+    if not hasattr(env, "_single_leg_reward_hold_s"):
+        env._single_leg_reward_hold_s = torch.zeros(env.num_envs, device=env.device)
+    env._single_leg_reward_hold_s[env.episode_length_buf <= 1] = 0.0
+    env._single_leg_reward_hold_s = torch.where(
+        valid,
+        torch.clamp(env._single_leg_reward_hold_s + env.step_dt, max=target_s),
+        torch.zeros_like(env._single_leg_reward_hold_s),
+    )
+    return env._single_leg_reward_hold_s / max(target_s, 1e-6)
+
+
+def single_leg_hold_success(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+    nonfoot_sensor_name: str | None = None,
+    hold_s: float = 1.0,
+    min_clearance: float = 0.008,
+    max_tilt_deg: float = 35.0,
+    max_lin_vel: float = 0.08,
+    max_ang_vel: float = 0.8,
+    require_com_inside: bool = True,
+) -> torch.Tensor:
+    """Success only after the valid stance has held continuously for ``hold_s``."""
+    step = int(env.common_step_counter)
+    if getattr(env, "_single_leg_hold_step", None) != step:
+        valid = single_leg_success_state(
+            env,
+            command_name=command_name,
+            sensor_name=sensor_name,
+            asset_cfg=asset_cfg,
+            nonfoot_sensor_name=nonfoot_sensor_name,
+            min_clearance=min_clearance,
+            max_tilt_deg=max_tilt_deg,
+            max_lin_vel=max_lin_vel,
+            max_ang_vel=max_ang_vel,
+            require_com_inside=require_com_inside,
+        ).bool()
+        if not hasattr(env, "_single_leg_hold_s"):
+            env._single_leg_hold_s = torch.zeros(env.num_envs, device=env.device)
+        env._single_leg_hold_s[env.episode_length_buf <= 1] = 0.0
+        env._single_leg_hold_s = torch.where(
+            valid,
+            env._single_leg_hold_s + env.step_dt,
+            torch.zeros_like(env._single_leg_hold_s),
+        )
+        env._single_leg_hold_success = env._single_leg_hold_s >= hold_s
+        env._single_leg_hold_step = step
+    return env._single_leg_hold_success.float()
+
+
+def single_leg_success_rate_for_side(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+    support_side: int,
+    nonfoot_sensor_name: str | None = None,
+    hold_s: float = 1.0,
+    min_clearance: float = 0.008,
+    max_tilt_deg: float = 35.0,
+    max_lin_vel: float = 0.08,
+    max_ang_vel: float = 0.8,
+    require_com_inside: bool = True,
+) -> torch.Tensor:
+    """Per-step success rate for one commanded side, broadcast for metric logging."""
+    if support_side not in (-1, 1):
+        raise ValueError("support_side must be -1 (left) or +1 (right)")
+    side, _, _, _ = _single_leg_command_state(env, command_name)
+    selected = side == float(support_side)
+    success = single_leg_hold_success(
+        env,
+        command_name=command_name,
+        sensor_name=sensor_name,
+        asset_cfg=asset_cfg,
+        nonfoot_sensor_name=nonfoot_sensor_name,
+        hold_s=hold_s,
+        min_clearance=min_clearance,
+        max_tilt_deg=max_tilt_deg,
+        max_lin_vel=max_lin_vel,
+        max_ang_vel=max_ang_vel,
+        require_com_inside=require_com_inside,
+    )
+    rate = torch.sum(success * selected) / torch.clamp(torch.sum(selected), min=1)
+    return rate.expand(env.num_envs)
+
+
 def ball_pos_in_base(
     env: ManagerBasedRlEnv,
     asset_name: str = "ball",

--- a/src/mjlab_microduck/tasks/microduck_single_leg_stand_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_single_leg_stand_env_cfg.py
@@ -1,0 +1,406 @@
+"""Commanded left/right single-leg standing in one symmetric policy."""
+
+import math
+import os
+
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.managers import (
+    CurriculumTermCfg,
+    MetricsTermCfg,
+    ObservationTermCfg,
+    RewardTermCfg,
+    TerminationTermCfg,
+)
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.rl import RslRlModelCfg, RslRlOnPolicyRunnerCfg
+from mjlab.sensor import ContactMatch, ContactSensorCfg
+from mjlab.tasks.velocity import mdp
+from mjlab.tasks.velocity.mdp import UniformVelocityCommandCfg
+
+from mjlab_microduck.robot.microduck_constants import MICRODUCK_STANDUP_ROBOT_CFG
+from mjlab_microduck.tasks import mdp as microduck_mdp
+from mjlab_microduck.tasks.microduck_velocity_env_cfg import (
+    NUM_STEPS_PER_ENV,
+    make_microduck_velocity_env_cfg,
+)
+from mjlab_microduck.tasks.symmetry import SYMMETRY_CFG, PpoWithSymmetryCfg
+
+
+EPISODE_LENGTH_S = 6.0
+STRICT_EPISODE_LENGTH_S = 10.0
+RAMP_S = 1.5
+TARGET_FOOT_HEIGHT = 0.012
+COMMAND_NAME = "twist"
+FEET_SENSOR = "feet_ground_contact"
+NONFOOT_SENSOR = "nonfoot_ground_contact"
+FEET_CFG = SceneEntityCfg("robot", site_names=("left_foot", "right_foot"))
+
+
+def _fixed_play_side() -> int:
+    value = os.environ.get("SINGLE_LEG_PLAY_SIDE", "random").lower()
+    if value in ("random", "0"):
+        return 0
+    if value in ("left", "-1"):
+        return -1
+    if value in ("right", "1"):
+        return 1
+    raise ValueError("SINGLE_LEG_PLAY_SIDE must be left, right, or random")
+
+
+def _play_episode_length_s() -> float:
+    value = float(os.environ.get("SINGLE_LEG_PLAY_EPISODE_S", EPISODE_LENGTH_S))
+    if value <= 0.0:
+        raise ValueError("SINGLE_LEG_PLAY_EPISODE_S must be positive")
+    return value
+
+
+def make_microduck_single_leg_stand_env_cfg(
+    play: bool = False,
+) -> ManagerBasedRlEnvCfg:
+    episode_length_s = _play_episode_length_s() if play else EPISODE_LENGTH_S
+    cfg = make_microduck_velocity_env_cfg(play=play)
+    cfg.scene.entities = {"robot": MICRODUCK_STANDUP_ROBOT_CFG}
+    cfg.scene.sensors = (
+        *cfg.scene.sensors,
+        ContactSensorCfg(
+            name=NONFOOT_SENSOR,
+            primary=ContactMatch(
+                mode="body",
+                pattern=(
+                    "trunk_base",
+                    "hip_l",
+                    "leg",
+                    "jaw_soft",
+                    "hip_l_2",
+                    "leg_2",
+                ),
+                entity="robot",
+            ),
+            secondary=ContactMatch(mode="body", pattern="terrain"),
+            fields=("found",),
+            reduce="none",
+            num_slots=1,
+        ),
+    )
+    cfg.episode_length_s = episode_length_s
+
+    cfg.commands[COMMAND_NAME] = microduck_mdp.SingleLegStandCommandCfg(
+        entity_name="robot",
+        resampling_time_range=(episode_length_s, episode_length_s),
+        rel_standing_envs=0.0,
+        rel_heading_envs=0.0,
+        rel_forward_envs=0.0,
+        heading_command=False,
+        debug_vis=False,
+        ranges=UniformVelocityCommandCfg.Ranges(
+            lin_vel_x=(0.0, 0.0),
+            lin_vel_y=(-1.0, 1.0),
+            ang_vel_z=(0.0, 0.0),
+            heading=None,
+        ),
+        left_prob=0.5,
+        ramp_s=RAMP_S,
+        fixed_side=_fixed_play_side() if play else 0,
+    )
+    cfg.commands.pop("head_pose", None)
+    cfg.commands.pop("body_pose", None)
+    for group in ("actor", "critic"):
+        cfg.observations[group].terms["head_command"] = ObservationTermCfg(
+            func=microduck_mdp.zero_command_padding,
+            params={"dim": 4},
+        )
+        cfg.observations[group].terms["body_command"] = ObservationTermCfg(
+            func=microduck_mdp.zero_command_padding,
+            params={"dim": 6},
+        )
+
+    for name in (
+        "track_linear_velocity",
+        "track_angular_velocity",
+        "upright",
+        "pose",
+        "air_time",
+        "foot_clearance",
+        "foot_swing_height",
+        "foot_slip",
+        "head_pose_tracking",
+        "body_pose_tracking",
+        "head_pose_bias",
+    ):
+        cfg.rewards.pop(name, None)
+
+    cfg.rewards["single_leg_com"] = RewardTermCfg(
+        func=microduck_mdp.single_leg_com_tracking,
+        weight=5.0,
+        params={"command_name": COMMAND_NAME, "asset_cfg": FEET_CFG},
+    )
+    cfg.rewards["support_contact"] = RewardTermCfg(
+        func=microduck_mdp.single_leg_support_contact,
+        weight=1.0,
+        params={"command_name": COMMAND_NAME, "sensor_name": FEET_SENSOR},
+    )
+    cfg.rewards["swing_height"] = RewardTermCfg(
+        func=microduck_mdp.single_leg_swing_height_tracking,
+        weight=0.0,
+        params={
+            "command_name": COMMAND_NAME,
+            "asset_cfg": FEET_CFG,
+            "target_height": TARGET_FOOT_HEIGHT,
+            "std": 0.008,
+        },
+    )
+    cfg.rewards["swing_contact"] = RewardTermCfg(
+        func=microduck_mdp.single_leg_swing_contact_cost,
+        weight=0.0,
+        params={"command_name": COMMAND_NAME, "sensor_name": FEET_SENSOR},
+    )
+    cfg.rewards["support_slip"] = RewardTermCfg(
+        func=microduck_mdp.single_leg_support_slip_cost,
+        weight=-0.5,
+        params={
+            "command_name": COMMAND_NAME,
+            "sensor_name": FEET_SENSOR,
+            "asset_cfg": FEET_CFG,
+        },
+    )
+    cfg.rewards["excess_tilt"] = RewardTermCfg(
+        func=microduck_mdp.single_leg_excess_tilt_cost,
+        weight=-2.0,
+        params={"max_tilt_deg": 32.0},
+    )
+    cfg.rewards["height_stand"] = RewardTermCfg(
+        func=microduck_mdp.height_target_gaussian,
+        weight=1.0,
+        params={
+            "target_height": 0.115,
+            "std": 0.03,
+            "asset_cfg": SceneEntityCfg("robot", body_names=("trunk_base",)),
+        },
+    )
+    cfg.rewards["nonfoot_contact"] = RewardTermCfg(
+        func=microduck_mdp.any_contact_cost,
+        weight=-5.0,
+        params={"sensor_name": NONFOOT_SENSOR},
+    )
+    cfg.rewards["action_rate_l2"].weight = -0.05
+    cfg.rewards["body_ang_vel"].weight = -0.02
+    cfg.rewards["angular_momentum"].weight = -0.01
+    cfg.rewards["joint_torque_rate_l2"] = RewardTermCfg(
+        func=microduck_mdp.joint_torque_rate_l2,
+        weight=0.0,
+    )
+
+    cfg.metrics["single_leg_success"] = MetricsTermCfg(
+        func=microduck_mdp.single_leg_hold_success,
+        params={
+            "command_name": COMMAND_NAME,
+            "sensor_name": FEET_SENSOR,
+            "asset_cfg": FEET_CFG,
+            "nonfoot_sensor_name": NONFOOT_SENSOR,
+            "hold_s": 1.0,
+        },
+    )
+    for side_name, support_side in (("left", -1), ("right", 1)):
+        cfg.metrics[f"single_leg_success_{side_name}"] = MetricsTermCfg(
+            func=microduck_mdp.single_leg_success_rate_for_side,
+            params={
+                "command_name": COMMAND_NAME,
+                "sensor_name": FEET_SENSOR,
+                "asset_cfg": FEET_CFG,
+                "support_side": support_side,
+                "nonfoot_sensor_name": NONFOOT_SENSOR,
+                "hold_s": 1.0,
+            },
+        )
+
+    cfg.terminations["fell_over"].params["limit_angle"] = math.radians(45.0)
+    cfg.terminations["root_too_low"] = TerminationTermCfg(
+        func=microduck_mdp.root_height_below,
+        time_out=False,
+        params={"min_height": 0.075},
+    )
+
+    cfg.events["push_robot"].params["velocity_range"] = {
+        "x": (0.0, 0.0),
+        "y": (0.0, 0.0),
+    }
+
+    for name in (
+        "standing_envs",
+        "head_pose_range",
+        "body_pose_range",
+        "head_pose_bias_weight",
+    ):
+        cfg.curriculum.pop(name, None)
+
+    cfg.curriculum["swing_height_weight"] = CurriculumTermCfg(
+        func=microduck_mdp.reward_weight,
+        params={
+            "reward_name": "swing_height",
+            "weight_stages": [
+                {"step": 0, "weight": 0.0},
+                {"step": 500 * NUM_STEPS_PER_ENV, "weight": 0.5},
+                {"step": 1000 * NUM_STEPS_PER_ENV, "weight": 2.0},
+            ],
+        },
+    )
+    cfg.curriculum["swing_contact_weight"] = CurriculumTermCfg(
+        func=microduck_mdp.reward_weight,
+        params={
+            "reward_name": "swing_contact",
+            "weight_stages": [
+                {"step": 0, "weight": 0.0},
+                {"step": 500 * NUM_STEPS_PER_ENV, "weight": -1.0},
+                {"step": 1000 * NUM_STEPS_PER_ENV, "weight": -4.0},
+            ],
+        },
+    )
+    cfg.curriculum["action_rate_weight"] = CurriculumTermCfg(
+        func=microduck_mdp.reward_weight,
+        params={
+            "reward_name": "action_rate_l2",
+            "weight_stages": [
+                {"step": 0, "weight": -0.05},
+                {"step": 1000 * NUM_STEPS_PER_ENV, "weight": -0.1},
+                {"step": 2000 * NUM_STEPS_PER_ENV, "weight": -0.3},
+            ],
+        },
+    )
+    cfg.curriculum["torque_rate_weight"] = CurriculumTermCfg(
+        func=microduck_mdp.reward_weight,
+        params={
+            "reward_name": "joint_torque_rate_l2",
+            "weight_stages": [
+                {"step": 0, "weight": 0.0},
+                {"step": 1500 * NUM_STEPS_PER_ENV, "weight": -1e-3},
+            ],
+        },
+    )
+    cfg.curriculum["push_magnitude"] = CurriculumTermCfg(
+        func=microduck_mdp.push_curriculum,
+        params={
+            "event_name": "push_robot",
+            "push_stages": [
+                {
+                    "step": 0,
+                    "velocity_range": {"x": (0.0, 0.0), "y": (0.0, 0.0)},
+                },
+                {
+                    "step": 2500 * NUM_STEPS_PER_ENV,
+                    "velocity_range": {"x": (-0.05, 0.05), "y": (-0.05, 0.05)},
+                },
+            ],
+        },
+    )
+    return cfg
+
+
+def make_microduck_single_leg_stand_strict_env_cfg(
+    play: bool = False,
+) -> ManagerBasedRlEnvCfg:
+    """Continuation phase whose only positive task reward is a valid hold."""
+    cfg = make_microduck_single_leg_stand_env_cfg(play=play)
+    if not play:
+        cfg.episode_length_s = STRICT_EPISODE_LENGTH_S
+        cfg.commands[COMMAND_NAME].resampling_time_range = (
+            STRICT_EPISODE_LENGTH_S,
+            STRICT_EPISODE_LENGTH_S,
+        )
+
+    for name in (
+        "single_leg_com",
+        "support_contact",
+        "swing_height",
+        "height_stand",
+        "body_ang_vel",
+        "angular_momentum",
+        "excess_tilt",
+    ):
+        cfg.rewards.pop(name)
+    cfg.terminations.pop("fell_over", None)
+    for name in (
+        "swing_height_weight",
+        "swing_contact_weight",
+        "action_rate_weight",
+        "torque_rate_weight",
+        "push_magnitude",
+    ):
+        cfg.curriculum.pop(name)
+
+    cfg.rewards["strict_single_leg_hold"] = RewardTermCfg(
+        func=microduck_mdp.single_leg_hold_progress_reward,
+        weight=10.0,
+        params={
+            "command_name": COMMAND_NAME,
+            "sensor_name": FEET_SENSOR,
+            "asset_cfg": FEET_CFG,
+            "nonfoot_sensor_name": NONFOOT_SENSOR,
+            "target_s": 1.0,
+            "min_clearance": -1.0,
+            "max_tilt_deg": 180.0,
+            "max_lin_vel": float("inf"),
+            "max_ang_vel": float("inf"),
+            "require_com_inside": False,
+        },
+    )
+    cfg.rewards["swing_contact"].weight = -10.0
+    cfg.rewards["touchdown"] = RewardTermCfg(
+        func=microduck_mdp.single_leg_touchdown_cost,
+        weight=-5.0,
+        params={"command_name": COMMAND_NAME, "sensor_name": FEET_SENSOR},
+    )
+    # RewardManager scales by dt=0.02, so this is a fixed -10 per failed episode.
+    cfg.rewards["failed_episode"] = RewardTermCfg(
+        func=mdp.is_terminated,
+        weight=-500.0,
+    )
+    cfg.rewards["action_rate_l2"].weight = -0.3
+    cfg.rewards["joint_torque_rate_l2"].weight = -1e-3
+    for metric in cfg.metrics.values():
+        if "single_leg_success" in metric.func.__name__ or metric.func is microduck_mdp.single_leg_hold_success:
+            metric.params["min_clearance"] = -1.0
+            metric.params["max_tilt_deg"] = 180.0
+            metric.params["max_lin_vel"] = float("inf")
+            metric.params["max_ang_vel"] = float("inf")
+            metric.params["require_com_inside"] = False
+    return cfg
+
+
+MicroduckSingleLegStandRlCfg = RslRlOnPolicyRunnerCfg(
+    actor=RslRlModelCfg(
+        hidden_dims=(512, 256, 128),
+        activation="elu",
+        obs_normalization=True,
+        distribution_cfg={
+            "class_name": "GaussianDistribution",
+            "init_std": 1.0,
+            "std_type": "scalar",
+        },
+    ),
+    critic=RslRlModelCfg(
+        hidden_dims=(512, 256, 128),
+        activation="elu",
+        obs_normalization=True,
+    ),
+    algorithm=PpoWithSymmetryCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.01,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+        symmetry_cfg=SYMMETRY_CFG,
+    ),
+    wandb_project="mjlab_microduck",
+    experiment_name="single_leg_stand",
+    run_name="single_leg_stand",
+    save_interval=250,
+    num_steps_per_env=NUM_STEPS_PER_ENV,
+    max_iterations=6_000,
+)

--- a/tests/test_single_leg_stand_cfg.py
+++ b/tests/test_single_leg_stand_cfg.py
@@ -1,0 +1,129 @@
+import pytest
+from mjlab.tasks.registry import list_tasks
+
+from mjlab_microduck.tasks import mdp as microduck_mdp
+from mjlab_microduck.tasks.microduck_single_leg_stand_env_cfg import (
+    COMMAND_NAME,
+    EPISODE_LENGTH_S,
+    STRICT_EPISODE_LENGTH_S,
+    NONFOOT_SENSOR,
+    MicroduckSingleLegStandRlCfg,
+    make_microduck_single_leg_stand_env_cfg,
+    make_microduck_single_leg_stand_strict_env_cfg,
+)
+
+
+def test_env_builds_and_keeps_the_61d_command_layout():
+    cfg = make_microduck_single_leg_stand_env_cfg()
+    assert cfg.episode_length_s == EPISODE_LENGTH_S == 6.0
+    assert isinstance(
+        cfg.commands[COMMAND_NAME], microduck_mdp.SingleLegStandCommandCfg
+    )
+    assert (
+        cfg.observations["actor"].terms["command"].params["command_name"]
+        == COMMAND_NAME
+    )
+    assert cfg.observations["actor"].terms["head_command"].params["dim"] == 4
+    assert cfg.observations["actor"].terms["body_command"].params["dim"] == 6
+
+
+def test_one_policy_trains_both_support_sides_with_mirror_loss():
+    cmd = make_microduck_single_leg_stand_env_cfg().commands[COMMAND_NAME]
+    assert cmd.left_prob == 0.5
+    assert cmd.ranges.lin_vel_y == (-1.0, 1.0)
+    assert MicroduckSingleLegStandRlCfg.algorithm.symmetry_cfg is not None
+    assert (
+        MicroduckSingleLegStandRlCfg.algorithm.symmetry_cfg["use_mirror_loss"] is True
+    )
+
+
+def test_play_side_can_be_forced(monkeypatch):
+    monkeypatch.setenv("SINGLE_LEG_PLAY_SIDE", "left")
+    assert (
+        make_microduck_single_leg_stand_env_cfg(play=True)
+        .commands[COMMAND_NAME]
+        .fixed_side
+        == -1
+    )
+    monkeypatch.setenv("SINGLE_LEG_PLAY_SIDE", "right")
+    assert (
+        make_microduck_single_leg_stand_env_cfg(play=True)
+        .commands[COMMAND_NAME]
+        .fixed_side
+        == 1
+    )
+    monkeypatch.setenv("SINGLE_LEG_PLAY_SIDE", "invalid")
+    with pytest.raises(ValueError):
+        make_microduck_single_leg_stand_env_cfg(play=True)
+
+
+def test_play_episode_length_can_be_extended(monkeypatch):
+    monkeypatch.setenv("SINGLE_LEG_PLAY_EPISODE_S", "300")
+    cfg = make_microduck_single_leg_stand_env_cfg(play=True)
+    assert cfg.episode_length_s == 300.0
+    assert cfg.commands[COMMAND_NAME].resampling_time_range == (300.0, 300.0)
+
+
+def test_reward_signs_and_discovery_curriculum():
+    cfg = make_microduck_single_leg_stand_env_cfg()
+    assert cfg.rewards["single_leg_com"].weight > 0.0
+    assert cfg.rewards["support_contact"].weight > 0.0
+    assert cfg.rewards["swing_height"].weight == 0.0
+    assert cfg.rewards["swing_contact"].weight == 0.0
+    assert cfg.rewards["support_slip"].weight < 0.0
+    assert cfg.rewards["excess_tilt"].weight < 0.0
+    assert cfg.rewards["nonfoot_contact"].weight < 0.0
+
+    lift = cfg.curriculum["swing_height_weight"].params["weight_stages"]
+    contact = cfg.curriculum["swing_contact_weight"].params["weight_stages"]
+    assert lift[0]["weight"] == 0.0 and lift[-1]["weight"] > 0.0
+    assert contact[0]["weight"] == 0.0 and contact[-1]["weight"] < 0.0
+
+
+def test_success_metrics_are_split_by_support_side():
+    cfg = make_microduck_single_leg_stand_env_cfg()
+    metrics = cfg.metrics
+    assert NONFOOT_SENSOR in {sensor.name for sensor in cfg.scene.sensors}
+    assert metrics["single_leg_success"].func is microduck_mdp.single_leg_hold_success
+    assert metrics["single_leg_success"].params["hold_s"] == 1.0
+    assert metrics["single_leg_success_left"].params["support_side"] == -1
+    assert metrics["single_leg_success_right"].params["support_side"] == 1
+
+
+def test_strict_phase_has_one_positive_task_reward_and_no_shaping_rewards():
+    cfg = make_microduck_single_leg_stand_strict_env_cfg()
+    for name in (
+        "single_leg_com",
+        "support_contact",
+        "swing_height",
+        "height_stand",
+        "body_ang_vel",
+        "angular_momentum",
+        "excess_tilt",
+    ):
+        assert name not in cfg.rewards
+    assert cfg.episode_length_s == STRICT_EPISODE_LENGTH_S == 10.0
+    assert "fell_over" not in cfg.terminations
+    assert (
+        cfg.rewards["strict_single_leg_hold"].func
+        is microduck_mdp.single_leg_hold_progress_reward
+    )
+    assert cfg.rewards["strict_single_leg_hold"].weight > 0.0
+    assert cfg.rewards["swing_contact"].weight < 0.0
+    assert cfg.rewards["touchdown"].weight == -5.0
+    assert cfg.rewards["failed_episode"].weight == -500.0
+    assert cfg.rewards["strict_single_leg_hold"].params["min_clearance"] == -1.0
+    assert cfg.rewards["strict_single_leg_hold"].params["max_tilt_deg"] == 180.0
+    assert cfg.rewards["strict_single_leg_hold"].params["require_com_inside"] is False
+    assert cfg.metrics["single_leg_success"].params["min_clearance"] == -1.0
+    assert cfg.metrics["single_leg_success"].params["max_tilt_deg"] == 180.0
+    assert cfg.metrics["single_leg_success"].params["require_com_inside"] is False
+    assert "swing_contact_weight" not in cfg.curriculum
+    assert "push_magnitude" not in cfg.curriculum
+
+
+def test_task_and_backlash_twin_are_registered():
+    tasks = set(list_tasks())
+    assert "Mjlab-SingleLegStand-Flat-MicroDuck" in tasks
+    assert "Mjlab-SingleLegStand-Strict-Flat-MicroDuck" in tasks
+    assert "Mjlab-SingleLegStand-Flat-Backlash-MicroDuck" in tasks


### PR DESCRIPTION
## Summary

- add one symmetric policy task for commanded left/right single-leg standing;
- select the support side through the existing 3D twist command slot;
- preserve the shared 61D actor observation and 14D action contracts;
- add a strict continuation task, Backlash twin, CPU config tests, headless
  evaluation, TensorBoard summaries, and fixed-side video recording.

No hopping or cloud-operation code is included.

## Motivation

The runtime needs one hot-swappable policy that can hold either support side
without adding another observation or requiring separate left/right networks.
This task keeps the existing policy-family contract and trains both sides with
one mirrored actor.

## Command Contract

The requested support side is carried in `twist_y`:

- left support: `[0, -1, 0]`;
- right support: `[0, +1, 0]`.

The actor observation remains:

```text
48 proprioception + twist(3) + head_pose(4) + body_pose(6) = 61
```

The actor sees the final side immediately. Reward targets slew from double
support to the requested support foot over 1.5 seconds, so snapping to the
target early is not rewarded.

## Environment And Reward Design

The discovery task starts from the existing velocity sim2real recipe and
replaces locomotion objectives with:

- slewed CoM tracking toward the support foot;
- support-foot contact and swing-foot height;
- swing-foot contact, support slip, excess tilt, non-foot contact, and
  smoothness costs;
- curricula that introduce lift/contact strictness and pushes only after the
  basic balance skill exists.

The strict continuation task removes dense shaping. Its only positive task
reward is uninterrupted commanded single-leg hold progress, with strong
swing-contact, touchdown, and failed-episode costs.

Mirror loss is enabled so one actor learns both support sides.

## Tasks Registered

- `Mjlab-SingleLegStand-Flat-MicroDuck`
- `Mjlab-SingleLegStand-Strict-Flat-MicroDuck`
- `Mjlab-SingleLegStand-Flat-Backlash-MicroDuck`

The Backlash twin uses the current ground-contact Backlash model and existing
encoder-through-backlash observations. Actor and action dimensions are
unchanged.

## Evaluation

Evaluation used the frozen stand-only strict checkpoint `model_3250.pt`
(`sha256:03d3245ad63623088af0c4818c54044d3f30157ca8f6554d2c7015e2db54c679`).
It predates the repeated-hop work. All results below use the current
ground-contact model, deterministic actor inference, seed 42, and strict
swing-foot no-contact scoring.

### 256 Episodes Per Side

| Side | Success | Survival | Swing contact | Contact transitions/s | Non-foot contact |
|---|---:|---:|---:|---:|---:|
| Left | 243/256 (94.92%) | 248/256 (96.88%) | 0.851% | 0.181 | 0% |
| Right | 238/256 (92.97%) | 241/256 (94.14%) | 0.636% | 0.089 | 0% |

Longest swing-foot no-contact duration:

| Side | Mean | P0 | P10 | P25 | P50 | P75 | P90 | P100 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Left | 4.18 | 0.00 | 3.57 | 4.50 | 4.50 | 4.52 | 4.52 | 4.52 |
| Right | 4.13 | 0.00 | 3.63 | 4.50 | 4.50 | 4.52 | 4.52 | 4.52 |

Longest valid single-leg duration:

| Side | Mean | P0 | P10 | P25 | P50 | P75 | P90 | P100 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Left | 4.16 | 0.00 | 3.27 | 4.50 | 4.50 | 4.52 | 4.52 | 4.52 |
| Right | 4.13 | 0.00 | 3.59 | 4.50 | 4.50 | 4.52 | 4.52 | 4.52 |

[Full 256-episode JSON](https://github.com/BingoWon/microduck_rl/releases/download/single-leg-stand-pr-evidence-2026-09-03/eval-256x6s.json)

### 60-Second Battery

64 parallel episodes per support side:

| Side | Success | Survival | Swing contact | Contact transitions/s | Non-foot contact | P0/P50/P100 valid hold |
|---|---:|---:|---:|---:|---:|---:|
| Left | 64/64 | 64/64 | 0% | 0 | 0% | 57.94 / 58.50 / 58.50 s |
| Right | 64/64 | 64/64 | 0% | 0 | 0% | 58.50 / 58.50 / 58.50 s |

[Full 60-second JSON](https://github.com/BingoWon/microduck_rl/releases/download/single-leg-stand-pr-evidence-2026-09-03/eval-64x60s.json)

### 300-Second Rollouts

| Side | Success | Survival | Longest no-contact | Longest valid hold | Contact transitions/s | Non-foot contact |
|---|---:|---:|---:|---:|---:|---:|
| Left | 1/1 | 1/1 | 298.49 s | 298.49 s | 0 | 0% |
| Right | 1/1 | 1/1 | 298.49 s | 298.49 s | 0 | 0% |

The 1.5-second difference from the configured horizon is the support-target
ramp.

[Full 300-second JSON](https://github.com/BingoWon/microduck_rl/releases/download/single-leg-stand-pr-evidence-2026-09-03/eval-1x300s.json)

## Videos

- [Left support, 10 seconds](https://github.com/BingoWon/microduck_rl/releases/download/single-leg-stand-pr-evidence-2026-09-03/single-leg-left-support-step-0.mp4)
- [Right support, 10 seconds](https://github.com/BingoWon/microduck_rl/releases/download/single-leg-stand-pr-evidence-2026-09-03/single-leg-right-support-step-0.mp4)

Both files are H.264, 960x720, 50 fps, 500 frames. They were generated and
metadata-checked without visually inspecting their contents.

## Tests Run

```bash
uv run --with pytest pytest tests/test_single_leg_stand_cfg.py -q
uv run --with pytest pytest tests/ -q
WANDB_MODE=disabled uv run train Mjlab-SingleLegStand-Flat-MicroDuck \
  --env.scene.num-envs 64 \
  --agent.max-iterations 5 \
  --gpu-ids None
```

Results:

- focused tests: 8 passed;
- full suite: 207 passed, 1 skipped;
- smoke: 5/5 iterations completed on CPU;
- actor observation: 61D;
- action output: 14D;
- `Episode_Termination/nan_state`: 0;
- all logged penalty rewards were non-positive.

[Smoke log](https://github.com/BingoWon/microduck_rl/releases/download/single-leg-stand-pr-evidence-2026-09-03/smoke-64x5.log) |
[Test log](https://github.com/BingoWon/microduck_rl/releases/download/single-leg-stand-pr-evidence-2026-09-03/tests.log) |
[Evidence summary and checksums](https://github.com/BingoWon/microduck_rl/releases/tag/single-leg-stand-pr-evidence-2026-09-03)

The stand-only checkpoint was also exported through the repository ONNX path:
input `[1,61]`, output `[1,14]`, expected metadata present, and the graph
contains the observation-normalizer initializer plus normalization `Sub`/`Div`
nodes. The checkpoint and ONNX are intentionally not attached; maintainers can
decide whether they want a policy artifact or a separate runtime-repository PR.

## Known Limitations

- fixed left-support and fixed right-support standing are trained and evaluated;
- reliable mid-episode left-to-right support switching is not part of this PR;
- videos were generated but not manually inspected.
