### PR TITLE
Validate simulator motor targets before updating controls

### DIFF
--- a/src/mjlab_microduck/sim/body_server.py
+++ b/src/mjlab_microduck/sim/body_server.py
@@ -349,11 +349,23 @@ class Body:
     # ── what the daemon commands ──────────────────────────────────────────
 
     def set_targets(self, wire_targets: list[float]) -> None:
+        if not isinstance(wire_targets, list):
+            raise TypeError("targets must be a JSON array")
         if len(wire_targets) != len(JOINT_NAMES):
             raise ValueError(f"expected {len(JOINT_NAMES)} targets, got {len(wire_targets)}")
+        # Validate the entire wire frame, including the unmapped mouth slot,
+        # before writing anything. A late conversion error otherwise leaves
+        # earlier motors changed, and NaN/Infinity can reach the physics solver.
+        if any(isinstance(v, bool) or not isinstance(v, (int, float)) for v in wire_targets):
+            raise ValueError("targets must contain finite JSON numbers")
+        try:
+            targets = np.asarray(wire_targets, dtype=float)
+        except OverflowError as error:
+            raise ValueError("targets must contain finite JSON numbers") from error
+        if not np.isfinite(targets).all():
+            raise ValueError("targets must contain finite JSON numbers")
         with self.world.lock:
-            for slot, wire_index in enumerate(self.to_wire):
-                self.world.data.ctrl[self.actuators[slot]] = wire_targets[wire_index]
+            self.world.data.ctrl[self.actuator_slice] = targets[self.to_wire]
 
     def set_gain(self, kp: int) -> None:
         with self.world.lock:

--- a/tests/test_body_server_targets.py
+++ b/tests/test_body_server_targets.py
@@ -1,0 +1,127 @@
+"""Bad TCP write frames must leave the previous motor targets intact."""
+
+import json
+import socket
+import threading
+
+import numpy as np
+import pytest
+
+from mjlab_microduck.sim.body_server import (
+    DEFAULT_SCENE,
+    JOINT_NAMES,
+    MOUTH_INDEX,
+    Body,
+    Handler,
+    Server,
+    World,
+)
+
+
+@pytest.fixture(scope="module")
+def body():
+    return Body(World(DEFAULT_SCENE), 0)
+
+
+def dispatch(body, targets):
+    # Exercise the same JSON decode and dispatch path without binding a port.
+    request = json.loads(json.dumps({"op": "write", "targets": targets}))
+    return Handler.dispatch(None, body, request)
+
+
+def test_valid_targets_preserve_wire_mapping(body):
+    targets = [index / 100 for index in range(len(JOINT_NAMES))]
+    targets[MOUTH_INDEX] = 0.25
+    assert dispatch(body, targets) == {}
+    np.testing.assert_array_equal(
+        body.world.data.ctrl[body.actuator_slice],
+        np.array(targets)[body.to_wire],
+    )
+    assert MOUTH_INDEX not in body.to_wire
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        None,
+        "bad",
+        "0.1",
+        True,
+        [],
+        {},
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+        10**400,
+    ],
+)
+@pytest.mark.parametrize("index", [0, MOUTH_INDEX, len(JOINT_NAMES) - 1])
+def test_bad_target_rejects_the_whole_write(body, invalid, index):
+    dispatch(body, [0.125] * len(JOINT_NAMES))
+    before = body.world.data.ctrl.copy()
+    targets = [0.375] * len(JOINT_NAMES)
+    targets[index] = invalid
+    with pytest.raises(ValueError):
+        dispatch(body, targets)
+    np.testing.assert_array_equal(body.world.data.ctrl, before)
+
+
+@pytest.mark.parametrize(
+    "targets", [None, {}, "0" * len(JOINT_NAMES), [], [0] * 14, [0] * 16]
+)
+def test_bad_target_container_leaves_controls_unchanged(body, targets):
+    dispatch(body, [0.125] * len(JOINT_NAMES))
+    before = body.world.data.ctrl.copy()
+    with pytest.raises((TypeError, ValueError)):
+        dispatch(body, targets)
+    np.testing.assert_array_equal(body.world.data.ctrl, before)
+
+
+def test_numeric_overflow_from_json_is_rejected(body):
+    dispatch(body, [0.125] * len(JOINT_NAMES))
+    before = body.world.data.ctrl.copy()
+    request = json.loads(
+        '{"op":"write","targets":[' + ",".join(["0"] * 14 + ["1e400"]) + "]}"
+    )
+    with pytest.raises(ValueError):
+        Handler.dispatch(None, body, request)
+    np.testing.assert_array_equal(body.world.data.ctrl, before)
+
+
+def test_tcp_error_reply_preserves_targets_and_connection(body):
+    dispatch(body, [0.125] * len(JOINT_NAMES))
+    before = body.world.data.ctrl.copy()
+    with Server(("127.0.0.1", 0), Handler) as server:
+        server.body = body
+        worker = threading.Thread(target=server.serve_forever, daemon=True)
+        worker.start()
+        try:
+            with (
+                socket.create_connection(
+                    server.server_address, timeout=2
+                ) as connection,
+                connection.makefile("rwb") as stream,
+            ):
+                targets = [0.375] * (len(JOINT_NAMES) - 1) + [None]
+                stream.write(
+                    (json.dumps({"op": "write", "targets": targets}) + "\n").encode()
+                )
+                stream.flush()
+                assert "error" in json.loads(stream.readline())
+                np.testing.assert_array_equal(body.world.data.ctrl, before)
+                stream.write(
+                    (
+                        json.dumps(
+                            {"op": "write", "targets": [0.25] * len(JOINT_NAMES)}
+                        )
+                        + "\n"
+                    ).encode()
+                )
+                stream.flush()
+                assert json.loads(stream.readline()) == {}
+                np.testing.assert_array_equal(
+                    body.world.data.ctrl[body.actuator_slice], 0.25
+                )
+        finally:
+            server.shutdown()
+            worker.join(timeout=2)


### PR DESCRIPTION
`Body.set_targets()` writes one actuator at a time. If conversion fails in a later slot, the handler returns an error but earlier motor targets have already changed. NaN and infinity are also accepted; even a valid JSON number such as `1e400` decodes to infinity in Python.

This validates all 15 wire targets before updating `data.ctrl`, including the mouth slot that the current model does not actuate. Targets must be a JSON array of finite numbers. Strings, booleans, nulls, nested values, and overflowing numbers are rejected. Valid targets keep the existing name-based wire mapping.

The new tests use the actual MuJoCo body model. They check unchanged controls after invalid frames, valid mapping, and a local TCP connection that receives an error and then successfully writes a valid frame. Before the fix, 31 of the first 38 cases failed.

Validation on macOS, Python 3.12, CPU:

- `uv run --with pytest pytest tests/test_body_server_targets.py -q`: 39 passed.
- `uv run --with pytest pytest tests/ -q`: 238 passed, 1 skipped.
- `git diff --check`: passed.

No GPU, policy weights, robot hardware, or credentials are required for these tests. This does not change the protocol, joint limits, actuator physics, or training configuration.
