### PR TITLE
docs: note that the viewer needs mjpython on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Requires a CUDA GPU (training runs through MuJoCo Warp) and [uv](https://docs.as
 > wheels on first run and uv's default 30 s HTTP timeout can abort mid-download.
 > Export `UV_HTTP_TIMEOUT=600` for the first sync. 
 
+> **On macOS:** the viewer commands need `mjpython`, the launcher MuJoCo ships to
+> keep the Cocoa main thread free — `mujoco.viewer.launch_passive` refuses to run
+> without it. Prefix them: `uv run mjpython scripts/infer_policy.py ...`.
+
 ```bash
 git clone https://github.com/pollen-robotics/microduck_rl
 cd microduck_rl


### PR DESCRIPTION
The Quickstart's `infer_policy.py` command always fails on macOS: Cocoa ties window creation to the process's first thread, so the non-blocking `launch_passive` has nowhere legal to put its render thread and refuses to run without the dispatcher `mjpython` installs at startup. The README never mentions macOS, while microduck's CONTRIBUTING.md lists it as a supported development host.

Verified on macOS 26.5 (arm64), Python 3.12.14, mujoco 3.10.0.
