### PR TITLE
reuse NUM_STEPS_PER_ENV in the RslRlOnPolicyRunnerCfg

### DIFF
--- a/src/mjlab_microduck/tasks/microduck_velocity_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_velocity_env_cfg.py
@@ -944,6 +944,6 @@ MicroduckRlCfg = RslRlOnPolicyRunnerCfg(
     experiment_name="velocity",  # Directory name
     run_name="velocity",  # Appended to datetime in wandb: <datetime>_velocity
     save_interval=250,
-    num_steps_per_env=24,
+    num_steps_per_env=NUM_STEPS_PER_ENV,
     max_iterations=50_000,
 )

--- a/src/mjlab_microduck/tasks/microduck_velstand_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_velstand_env_cfg.py
@@ -411,6 +411,6 @@ MicroduckVelStandRlCfg = RslRlOnPolicyRunnerCfg(
     experiment_name="velstand",
     run_name="velstand",
     save_interval=250,
-    num_steps_per_env=24,
+    num_steps_per_env=NUM_STEPS_PER_ENV,
     max_iterations=20_000,
 )


### PR DESCRIPTION
In 2 of the tasks, the NUM_STEPS_PER_ENV is not reused in the RslRlOnPolicyRunnerCfg