### PR TITLE
Approach-and-inspect task (Mjlab-ApproachInspect-*-MicroDuck)

### DIFF
--- a/src/mjlab_microduck/robot/microduck/target.xml
+++ b/src/mjlab_microduck/robot/microduck/target.xml
@@ -1,0 +1,15 @@
+<mujoco model="microduck_target">
+    <compiler angle="radian" autolimits="true"/>
+
+    <worldbody>
+        <!-- Small static "thing to inspect" for the ApproachInspect task: a 60 mm
+             diameter, 80 mm tall puck standing on the floor. It has NO freejoint on
+             purpose — mjlab auto-wraps a fixed-base entity in a mocap body, which is
+             what lets the reset_target_around_robot event place it per env each
+             episode (radius 0.4–1.5 m from the robot) while it stays immovable. -->
+        <body name="target" pos="0 0 0">
+            <geom type="cylinder" name="target_geom" size="0.03 0.04" pos="0 0 0.04"
+                  rgba="0.2 0.6 1.0 1" mass="0.2"/>
+        </body>
+    </worldbody>
+</mujoco>

--- a/src/mjlab_microduck/robot/microduck_constants.py
+++ b/src/mjlab_microduck/robot/microduck_constants.py
@@ -273,3 +273,21 @@ if __name__ == "__main__":
 
     scene = Scene(SCENE_CFG, device="cuda:0")
     viewer.launch(scene.compile())
+
+
+# ── ApproachInspect target prop ──────────────────────────────────────────────
+# Fixed-base (no freejoint) puck the duck walks up to and inspects. mjlab wraps
+# fixed-base entities in a mocap body automatically, so the target is static
+# for physics but placeable per env: see approach_inspect_mdp.reset_target_around_robot.
+MICRODUCK_TARGET_XML: Path = _ROBOT_DIR / "target.xml"
+assert MICRODUCK_TARGET_XML.exists(), f"XML not found: {MICRODUCK_TARGET_XML}"
+
+
+def get_target_spec() -> mujoco.MjSpec:
+    return mujoco.MjSpec.from_file(str(MICRODUCK_TARGET_XML))
+
+
+MICRODUCK_TARGET_CFG = EntityCfg(
+    spec_fn=get_target_spec,
+    init_state=EntityCfg.InitialStateCfg(pos=(1.0, 0.0, 0.0)),
+)

--- a/src/mjlab_microduck/tasks/__init__.py
+++ b/src/mjlab_microduck/tasks/__init__.py
@@ -75,6 +75,10 @@ from .microduck_roulade_env_cfg import (
     make_microduck_roulade_env_cfg,
     MicroduckRouladeRlCfg,
 )
+from .microduck_approach_inspect_env_cfg import (
+    make_microduck_approach_inspect_env_cfg,
+    MicroduckApproachInspectRlCfg,
+)
 from .backlash import make_backlash_variant
 
 # Standard velocity task
@@ -233,6 +237,24 @@ register_mjlab_task(
     runner_cls=MicroduckOnPolicyRunner,
 )
 
+# ApproachInspect — walk to a target, stop on a standoff ring, aim the head,
+# hold the look, turn away. Velocity recipe + target entity; hot-swaps with walking.
+register_mjlab_task(
+    task_id="Mjlab-ApproachInspect-Flat-MicroDuck",
+    env_cfg=make_microduck_approach_inspect_env_cfg(),
+    play_env_cfg=make_microduck_approach_inspect_env_cfg(play=True),
+    rl_cfg=MicroduckApproachInspectRlCfg,
+    runner_cls=MicroduckOnPolicyRunner,
+)
+
+register_mjlab_task(
+    task_id="Mjlab-ApproachInspect-Rough-MicroDuck",
+    env_cfg=make_microduck_approach_inspect_env_cfg(rough=True),
+    play_env_cfg=make_microduck_approach_inspect_env_cfg(play=True, rough=True),
+    rl_cfg=MicroduckApproachInspectRlCfg,
+    runner_cls=MicroduckOnPolicyRunner,
+)
+
 # Backlash variants — ±1° serial gear play per servo + encoder-through-backlash
 # actuator feedback and joint obs (see tasks/backlash.py). Each family keeps its
 # base task's collision model: Velocity → robot_walk_backlash.xml,
@@ -254,6 +276,7 @@ _BL_ROLLERS = MICRODUCK_ROLLERS_BACKLASH_ROBOT_CFG
 _BACKLASH_TASKS = (
     ("Mjlab-Velocity-Flat-Backlash-MicroDuck", make_microduck_velocity_env_cfg, {}, MicroduckRlCfg, _BL_WALK),
     ("Mjlab-Velocity-Rough-Backlash-MicroDuck", make_microduck_velocity_env_cfg, {"rough": True}, MicroduckRlCfg, _BL_WALK),
+    ("Mjlab-ApproachInspect-Flat-Backlash-MicroDuck", make_microduck_approach_inspect_env_cfg, {}, MicroduckApproachInspectRlCfg, _BL_WALK),
     ("Mjlab-VelStand-Flat-Backlash-MicroDuck", make_microduck_velstand_env_cfg, {}, MicroduckVelStandRlCfg, _BL_GROUNDCONTACT),
     ("Mjlab-VelStand-Rough-Backlash-MicroDuck", make_microduck_velstand_env_cfg, {"rough": True}, MicroduckVelStandRlCfg, _BL_GROUNDCONTACT),
     ("Mjlab-StandUp-Flat-Backlash-MicroDuck", make_microduck_standup_env_cfg, {}, MicroduckStandUpRlCfg, _BL_GROUNDCONTACT),

--- a/src/mjlab_microduck/tasks/approach_inspect_mdp.py
+++ b/src/mjlab_microduck/tasks/approach_inspect_mdp.py
@@ -1,0 +1,399 @@
+"""Reward terms for the approach-and-inspect task.
+
+Drop this file into ``src/mjlab_microduck/tasks/`` and import it from the env
+cfg as ``microduck_ai_mdp``. Nothing here touches the existing ``mdp.py``.
+
+Conventions (from AGENTS.md — do not break these):
+
+* Potential-based shaping pays ``Δ(potential)`` per step. Holding pays zero, so
+  no state can farm it. Freshly reset envs (``episode_length_buf <= 1``) reseed
+  their previous potential so there is no spurious delta across episodes.
+* Anything named ``*_penalty`` returns ``<= 0`` and takes a POSITIVE weight.
+* Every ``*_progress`` latch is slewed at a constant rate: being ahead of the
+  ramp pays zero, so arriving fast is never a jackpot.
+* Gates are hard state checks, never soft nudges. Positive rewards are never
+  gated on a bad state (fallen, low).
+
+The target object is a scene entity (default name ``"target"``) with
+``data.root_link_pos_w``. The head forward direction is the vector from the
+``jaw_soft`` body CoM to the ``mouth_tip`` site — the same pair
+``apply_mouth_payload_force`` uses — so this needs no new sites.
+"""
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import torch
+
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mjlab.entity import Entity
+    from mjlab.envs.manager_based_rl_env import ManagerBasedRlEnv
+
+_HEAD_CFG = SceneEntityCfg("robot", body_names=["jaw_soft"], site_names=["mouth_tip"])
+_ROBOT_CFG = SceneEntityCfg("robot")
+
+
+# ── geometry helpers ────────────────────────────────────────────────────────
+
+def _planar_offset_to_target(env, asset_cfg, target_name):
+    """(N,2) vector from robot base to target, world XY."""
+    robot: Entity = env.scene[asset_cfg.name]
+    target: Entity = env.scene[target_name]
+    return target.data.root_link_pos_w[:, :2] - robot.data.root_link_pos_w[:, :2]
+
+
+def _ring_error(env, asset_cfg, target_name, standoff):
+    """|d - standoff|, (N,). Zero on the ring, grows either side."""
+    d = torch.linalg.norm(_planar_offset_to_target(env, asset_cfg, target_name), dim=-1)
+    return torch.abs(d - standoff)
+
+
+def _resolved(env, cfg):
+    """mjlab managers resolve a SceneEntityCfg only when it is passed in a term's
+    ``params``; a module-level default keeps ``site_ids``/``body_ids`` as
+    ``slice(None)``. Resolve lazily so the defaults work too."""
+    if isinstance(cfg.site_ids, slice) or isinstance(cfg.body_ids, slice):
+        cfg.resolve(env.scene)
+    return cfg
+
+
+def _head_bearing_error(env, head_cfg, target_name):
+    """Planar angle (rad, >= 0) between where the head points and the target."""
+    head_cfg = _resolved(env, head_cfg)
+    robot: Entity = env.scene[head_cfg.name]
+    target: Entity = env.scene[target_name]
+    sid = int(head_cfg.site_ids[0])
+    bid = int(head_cfg.body_ids[0])
+    p_tip = robot.data.site_pos_w[:, sid, :2]
+    p_head = robot.data.body_com_pos_w[:, bid, :2]
+    fwd = p_tip - p_head
+    to_t = target.data.root_link_pos_w[:, :2] - p_head
+    fwd_ang = torch.atan2(fwd[:, 1], fwd[:, 0])
+    tgt_ang = torch.atan2(to_t[:, 1], to_t[:, 0])
+    err = tgt_ang - fwd_ang
+    err = torch.atan2(torch.sin(err), torch.cos(err))  # wrap to [-pi, pi]
+    return torch.abs(err)
+
+
+def _planar_speed(env, asset_cfg):
+    robot: Entity = env.scene[asset_cfg.name]
+    return torch.linalg.norm(robot.data.root_link_lin_vel_w[:, :2], dim=-1)
+
+
+def _fresh(env):
+    return env.episode_length_buf <= 1
+
+
+def _delta_potential(env, attr: str, potential: torch.Tensor) -> torch.Tensor:
+    """Generic Δpotential with fresh-episode reseed. Stores prev on env.<attr>."""
+    if not hasattr(env, attr):
+        setattr(env, attr, potential.clone())
+    prev = getattr(env, attr)
+    fresh = _fresh(env)
+    prev[fresh] = potential[fresh]
+    delta = potential - prev
+    setattr(env, attr, potential.clone())
+    return delta
+
+
+# ── task rewards ────────────────────────────────────────────────────────────
+
+def delta_ring_distance(
+    env: ManagerBasedRlEnv,
+    standoff: float = 0.22,
+    asset_cfg: SceneEntityCfg = _ROBOT_CFG,
+    target_name: str = "target",
+) -> torch.Tensor:
+    """Potential-based approach: Δ(-|d - standoff|) per step.
+
+    Closing on the ring pays, holding pays zero, overshooting past it charges.
+    A raw exp(-d) proximity term would pay per step for parking on the ring —
+    that is the jackpot AGENTS.md warns about. This one cannot be farmed.
+    """
+    potential = -_ring_error(env, asset_cfg, target_name, standoff)
+    return _delta_potential(env, "_ai_ring_potential_prev", potential)
+
+
+def head_bearing_gaussian(
+    env: ManagerBasedRlEnv,
+    sigma: float = 0.25,
+    gate_tol: float = 0.08,
+    standoff: float = 0.22,
+    head_cfg: SceneEntityCfg = _HEAD_CFG,
+    target_name: str = "target",
+) -> torch.Tensor:
+    """exp(-θ² / 2σ²) on head bearing error, hard-gated on being in the ring.
+
+    The gate is a state check (|d - standoff| < gate_tol), not a shaped weight,
+    so the policy cannot collect aim reward from across the room. It is a
+    positive reward gated on a GOOD state (in the ring), which is allowed; the
+    forbidden pattern is gating on a bad one.
+    """
+    theta = _head_bearing_error(env, head_cfg, target_name)
+    in_ring = _ring_error(env, head_cfg, target_name, standoff) < gate_tol
+    g = torch.exp(-(theta ** 2) / (2.0 * sigma ** 2))
+    return torch.where(in_ring, g, torch.zeros_like(g))
+
+
+def head_bearing_ema_l1_penalty(
+    env: ManagerBasedRlEnv,
+    tau_s: float = 1.0,
+    head_cfg: SceneEntityCfg = _HEAD_CFG,
+    target_name: str = "target",
+) -> torch.Tensor:
+    """-L1 of a τ-second EMA of the signed bearing error. Self-negating: POSITIVE weight.
+
+    Charges the DC bias of the aim and lets the walking oscillation cancel.
+    The head is a large fraction of body mass and MUST swing while walking;
+    an instantaneous tight-std aim term taxed walking so hard a previous
+    policy stood still. Price only the escapable part.
+    """
+    head_cfg = _resolved(env, head_cfg)
+    robot: Entity = env.scene[head_cfg.name]
+    target: Entity = env.scene[target_name]
+    sid = int(head_cfg.site_ids[0])
+    bid = int(head_cfg.body_ids[0])
+    p_tip = robot.data.site_pos_w[:, sid, :2]
+    p_head = robot.data.body_com_pos_w[:, bid, :2]
+    fwd = p_tip - p_head
+    to_t = target.data.root_link_pos_w[:, :2] - p_head
+    err = torch.atan2(to_t[:, 1], to_t[:, 0]) - torch.atan2(fwd[:, 1], fwd[:, 0])
+    err = torch.atan2(torch.sin(err), torch.cos(err))  # signed, wrapped
+
+    dt = float(env.step_dt)
+    alpha = dt / max(tau_s, dt)
+    if not hasattr(env, "_ai_bearing_ema"):
+        env._ai_bearing_ema = err.clone()
+    fresh = _fresh(env)
+    env._ai_bearing_ema[fresh] = err[fresh]
+    env._ai_bearing_ema = (1.0 - alpha) * env._ai_bearing_ema + alpha * err
+    return -torch.abs(env._ai_bearing_ema)
+
+
+def delta_dwell_progress(
+    env: ManagerBasedRlEnv,
+    rate: float = 0.5,
+    gate_tol: float = 0.08,
+    aim_tol: float = 0.25,
+    speed_tol: float = 0.05,
+    standoff: float = 0.22,
+    head_cfg: SceneEntityCfg = _HEAD_CFG,
+    target_name: str = "target",
+) -> torch.Tensor:
+    """Slewed dwell latch. Pays Δprogress; progress ramps at ``rate`` per second
+    while ALL of (in ring, aimed, stopped) hold, and decays at the same rate
+    otherwise. Saturates at 1 and stays there — the phase flag reads it.
+
+    ``speed_tol`` is inside the gate on purpose: without it the policy can orbit
+    the target at the standoff radius, farming aim while never stopping. That
+    is the failure I expect on the first run, and the fix is the gate, not a
+    bigger speed penalty.
+    """
+    in_ring = _ring_error(env, head_cfg, target_name, standoff) < gate_tol
+    aimed = _head_bearing_error(env, head_cfg, target_name) < aim_tol
+    stopped = _planar_speed(env, head_cfg) < speed_tol
+    ok = in_ring & aimed & stopped
+
+    dt = float(env.step_dt)
+    if not hasattr(env, "_ai_dwell"):
+        env._ai_dwell = torch.zeros(env.num_envs, device=env.device)
+    fresh = _fresh(env)
+    env._ai_dwell[fresh] = 0.0
+    prev = env._ai_dwell.clone()
+    step = rate * dt
+    env._ai_dwell = torch.where(ok, prev + step, prev - step).clamp(0.0, 1.0)
+    return env._ai_dwell - prev
+
+
+def planar_speed_gated_penalty(
+    env: ManagerBasedRlEnv,
+    gate_tol: float = 0.08,
+    standoff: float = 0.22,
+    asset_cfg: SceneEntityCfg = _ROBOT_CFG,
+    target_name: str = "target",
+) -> torch.Tensor:
+    """-|v_xy| while inside the ring, zero outside. Self-negating: POSITIVE weight.
+
+    Zero outside the ring so it never taxes the approach itself.
+    """
+    in_ring = _ring_error(env, asset_cfg, target_name, standoff) < gate_tol
+    v = _planar_speed(env, asset_cfg)
+    return torch.where(in_ring, -v, torch.zeros_like(v))
+
+
+def delta_heading_progress(
+    env: ManagerBasedRlEnv,
+    target_offset: float = math.pi,
+    require_dwell: float = 0.999,
+    asset_cfg: SceneEntityCfg = _ROBOT_CFG,
+    target_name: str = "target",
+) -> torch.Tensor:
+    """Potential-based turn-away: Δ(-|heading error to (bearing + offset)|).
+
+    Only active once the dwell latch has saturated (``require_dwell``). Before
+    that the potential is frozen, so there is no reward for turning away early
+    and no waypoint to camp at.
+    """
+    robot: Entity = env.scene[asset_cfg.name]
+    q = robot.data.root_link_quat_w
+    yaw = torch.atan2(2.0 * (q[:, 0] * q[:, 3] + q[:, 1] * q[:, 2]),
+                      1.0 - 2.0 * (q[:, 2] ** 2 + q[:, 3] ** 2))
+    off = _planar_offset_to_target(env, asset_cfg, target_name)
+    bearing = torch.atan2(off[:, 1], off[:, 0])
+    want = bearing + target_offset
+    err = want - yaw
+    err = torch.atan2(torch.sin(err), torch.cos(err))
+    potential = -torch.abs(err)
+
+    dwell = getattr(env, "_ai_dwell", None)
+    if dwell is None:
+        return torch.zeros(env.num_envs, device=env.device)
+    active = dwell >= require_dwell
+
+    if not hasattr(env, "_ai_heading_potential_prev"):
+        env._ai_heading_potential_prev = potential.clone()
+    prev = env._ai_heading_potential_prev
+    fresh = _fresh(env)
+    prev[fresh] = potential[fresh]
+    # Frozen while inactive: reseed prev every step so the first active step
+    # starts from the current pose rather than paying a backlog.
+    prev[~active] = potential[~active]
+    delta = potential - prev
+    env._ai_heading_potential_prev = potential.clone()
+    return torch.where(active, delta, torch.zeros_like(delta))
+
+
+def phase_flag(env: ManagerBasedRlEnv) -> torch.Tensor:
+    """0 during approach, 1 once the dwell latch has saturated. For the command slot."""
+    dwell = getattr(env, "_ai_dwell", None)
+    if dwell is None:
+        return torch.zeros(env.num_envs, device=env.device)
+    return (dwell >= 0.999).float()
+
+
+# ── critic-only observations ────────────────────────────────────────────────
+
+def dwell_progress_obs(env: ManagerBasedRlEnv) -> torch.Tensor:
+    """(N,1) dwell latch value in [0, 1]. CRITIC ONLY — the actor sees the
+    binary phase flag through the command slot, which is what the runtime can
+    reproduce."""
+    dwell = getattr(env, "_ai_dwell", None)
+    if dwell is None:
+        return torch.zeros(env.num_envs, 1, device=env.device)
+    return dwell.unsqueeze(-1)
+
+
+# ── target spawn event ──────────────────────────────────────────────────────
+
+def reset_target_around_robot(
+    env: ManagerBasedRlEnv,
+    env_ids: torch.Tensor,
+    radius_range: tuple[float, float] = (0.4, 1.5),
+    asset_name: str = "target",
+    z_offset: float = 0.0,
+) -> None:
+    """Place the (mocap) target at a uniform bearing and radius from the robot.
+
+    Reads the robot root from qpos directly (root_link_pos_w lags until the next
+    forward()) — same trick as ``reset_ball_in_front_of_foot``. Must be
+    registered AFTER ``reset_base`` (events run in dict insertion order) so the
+    robot pose is final.
+    """
+    if env_ids is None or len(env_ids) == 0:
+        return
+    env_ids = env_ids.to(env.device)
+    robot: Entity = env.scene["robot"]
+    target: Entity = env.scene[asset_name]
+
+    root = env.sim.data.qpos[env_ids][:, robot.indexing.free_joint_q_adr]
+    n = len(env_ids)
+    radius = torch.empty(n, device=env.device).uniform_(*radius_range)
+    bearing = torch.empty(n, device=env.device).uniform_(-math.pi, math.pi)
+
+    pose = torch.zeros(n, 7, device=env.device)
+    pose[:, 0] = root[:, 0] + radius * torch.cos(bearing)
+    pose[:, 1] = root[:, 1] + radius * torch.sin(bearing)
+    pose[:, 2] = env.scene.terrain.env_origins[env_ids, 2] + z_offset
+    pose[:, 3] = 1.0  # identity quat
+    target.write_mocap_pose_to_sim(pose, env_ids)
+
+
+# ── command term: target offset in the base frame + phase flag ──────────────
+
+from mjlab.tasks.velocity.mdp import UniformVelocityCommand  # noqa: E402
+from mjlab_microduck.tasks.mdp import VelocityCommandCommandOnlyCfg  # noqa: E402
+
+
+class TargetCommand(UniformVelocityCommand):
+    """Fills the 3-D twist slot with ``[dx_norm, dy_norm, phase_flag]``.
+
+    ``dx_norm, dy_norm`` = target offset in the robot's yaw frame divided by
+    ``scale_m`` (1.5 m → ±1) and clipped to ±1. ``phase_flag`` = 0 during the
+    approach, 1 once the dwell latch has saturated (see ``phase_flag``).
+
+    Subclasses the velocity command so the ``twist`` obs term, the viz hooks and
+    the runtime's 13-D command layout are untouched: at deployment the runtime
+    writes the same three numbers from its own target estimate.
+
+    Nothing is sampled here — the command is a pure function of state, so
+    ``_resample_command`` is a no-op and ``reset`` just refreshes the values.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        self._ai_env = env
+        self._target_name = str(getattr(cfg, "target_name", "target"))
+        self._scale_m = float(getattr(cfg, "scale_m", 1.5))
+
+    @property
+    def command(self) -> torch.Tensor:
+        return self.vel_command_b
+
+    def _refresh(self) -> None:
+        robot: Entity = self.robot
+        target: Entity = self._ai_env.scene[self._target_name]
+        rel = target.data.root_link_pos_w[:, :2] - robot.data.root_link_pos_w[:, :2]
+        q = robot.data.root_link_quat_w
+        yaw = torch.atan2(2.0 * (q[:, 0] * q[:, 3] + q[:, 1] * q[:, 2]),
+                          1.0 - 2.0 * (q[:, 2] ** 2 + q[:, 3] ** 2))
+        c, s = torch.cos(yaw), torch.sin(yaw)
+        dx = c * rel[:, 0] + s * rel[:, 1]
+        dy = -s * rel[:, 0] + c * rel[:, 1]
+        self.vel_command_b[:, 0] = (dx / self._scale_m).clamp(-1.0, 1.0)
+        self.vel_command_b[:, 1] = (dy / self._scale_m).clamp(-1.0, 1.0)
+        self.vel_command_b[:, 2] = phase_flag(self._ai_env)
+
+    def compute(self, dt: float) -> None:
+        self._refresh()
+
+    def reset(self, env_ids: torch.Tensor | None) -> dict:
+        self._refresh()
+        return {}
+
+    def _resample_command(self, env_ids: torch.Tensor) -> None:
+        pass  # pure function of state
+
+    def _update_command(self) -> None:
+        pass  # done in compute()
+
+    def _update_metrics(self) -> None:
+        pass  # no velocity-tracking metrics
+
+
+from dataclasses import dataclass as _dataclass  # noqa: E402
+
+
+@_dataclass(kw_only=True)
+class TargetCommandCfg(VelocityCommandCommandOnlyCfg):
+    """Cfg for :class:`TargetCommand`. Inherits the velocity cfg so it can be
+    built from ``vars()`` of the velocity env's twist command (ranges etc. are
+    carried but unused)."""
+    class_type: type = TargetCommand
+    target_name: str = "target"
+    scale_m: float = 1.5
+
+    def build(self, env: ManagerBasedRlEnv) -> "TargetCommand":
+        return TargetCommand(self, env)

--- a/src/mjlab_microduck/tasks/microduck_approach_inspect_env_cfg.py
+++ b/src/mjlab_microduck/tasks/microduck_approach_inspect_env_cfg.py
@@ -1,0 +1,270 @@
+"""Microduck approach-and-inspect task.
+
+Walks to a target object, stops at a standoff ring, aims the head at it, holds
+the look, then turns away. Obs (61-D) / action (14) spaces are identical to the
+walking policy so the two hot-swap at runtime.
+
+Built ON TOP of ``make_microduck_velocity_env_cfg`` (the AGENTS.md workflow):
+the returned cfg IS the velocity recipe — every DR / sim2real block (CoM,
+head-CoM, mass/inertia, BAM friction, armature, pushes, IMU misalignment,
+encoder bias, obs noise/delays, NaN guards, foot friction) is the velocity
+env's own object, untouched. This file only swaps the COMMAND, the TASK
+rewards, the regulariser weights and the curricula that drove them.
+``tests/test_approach_inspect_cfg.py`` locks the DR parity term by term.
+
+Command encoding (3-D twist slot, see approach_inspect_mdp.TargetCommand):
+    command = [dx_norm, dy_norm, phase_flag]
+dx/dy = target offset in the base yaw frame, ±1 at 1.5 m; phase_flag = 0
+during the approach, 1 once the dwell latch has saturated. The head_pose and
+body_pose slots keep the velocity env's tiny stage-0 sampling ranges at weight
+0 so their input neurons stay alive (never zero-pad a slot).
+
+Gait shaping (air_time, foot_clearance, foot_swing_height, foot_slip, walking
+pose std) is gated on the command norm, which here is planar distance / 1.5 m:
+GAIT_CMD_THRESHOLD = 0.20 ⇔ d > 0.30 m, i.e. OUTSIDE the standoff ring
+(0.22 ± 0.08). Inside the ring the gait terms are silent, the standing pose
+std applies, and the dwell/stop terms take over — so stepping in place at the
+ring is not paid for by air_time.
+
+Reward design: kit/approach_inspect_reward_design.md. Terms live in
+approach_inspect_mdp.py (never in tasks/mdp.py).
+"""
+
+import math
+from copy import deepcopy
+
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.managers import (
+    CurriculumTermCfg,
+    EventTermCfg,
+    ObservationTermCfg,
+    RewardTermCfg,
+)
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.rl import RslRlModelCfg, RslRlOnPolicyRunnerCfg
+
+from mjlab_microduck.robot.microduck_constants import (
+    MICRODUCK_TARGET_CFG,
+    MICRODUCK_WALK_ROBOT_CFG,
+)
+from mjlab_microduck.tasks import approach_inspect_mdp as ai_mdp
+from mjlab_microduck.tasks import mdp as microduck_mdp
+from mjlab_microduck.tasks.microduck_velocity_env_cfg import (
+    NUM_STEPS_PER_ENV,
+    make_microduck_velocity_env_cfg,
+)
+from mjlab_microduck.tasks.symmetry import PpoWithSymmetryCfg
+
+# Symmetry: OFF (the task is asymmetric — the target sits on one side).
+ENABLE_SYMMETRY = False
+
+# ── Task constants ────────────────────────────────────────────────────────────
+STANDOFF_M      = 0.22            # ring radius the duck stops at
+RING_TOL_M      = 0.08            # |d - STANDOFF_M| < tol ⇒ "in the ring"
+AIM_SIGMA_RAD   = 0.25            # head-bearing Gaussian std (escapable error only)
+DWELL_RATE      = 1.0 / 2.0       # dwell latch saturates after 2 s of held gaze
+DWELL_SPEED_TOL = 0.05            # m/s — moving faster than this accrues no dwell
+SPAWN_RADIUS_M  = (0.4, 1.5)      # target spawn radius from the robot, any bearing
+CMD_SCALE_M     = 1.5             # dx/dy command = offset / CMD_SCALE_M, clipped ±1
+EPISODE_LENGTH_S = 12.0           # ~5 s approach + 2 s dwell + turn + settle
+# Command-norm gate for the velocity env's gait terms: norm = d / CMD_SCALE_M,
+# so 0.20 ⇔ d > 0.30 m ⇔ outside the ring (0.22 + 0.08).
+GAIT_CMD_THRESHOLD = (STANDOFF_M + RING_TOL_M) / CMD_SCALE_M
+
+# Regularisers: ~60 % of the velocity env's values (smaller task stack ⇒ the
+# same weight lands harder), ramped in from ~0 so no attempt-tax is active
+# while the approach skill is being discovered.
+REG_SCALE = 0.6
+
+
+def _head_cfg() -> SceneEntityCfg:
+    """Head forward = jaw_soft CoM → mouth_tip site (the pair
+    apply_mouth_payload_force uses). A fresh instance per term: the manager
+    resolves SceneEntityCfg params in place, and only those passed in params."""
+    return SceneEntityCfg("robot", body_names=["jaw_soft"], site_names=["mouth_tip"])
+
+
+def make_microduck_approach_inspect_env_cfg(
+    play: bool = False,
+    rough: bool = False,
+) -> ManagerBasedRlEnvCfg:
+    """Create the Microduck approach-and-inspect environment configuration."""
+
+    # ── Walk layer: the velocity recipe, verbatim (DR / sim2real untouched) ──
+    cfg = make_microduck_velocity_env_cfg(play=play, rough=rough)
+
+    # ── Scene: add the static target. Robot MUST stay the first entity ───────
+    cfg.scene.entities = {
+        "robot": MICRODUCK_WALK_ROBOT_CFG,
+        "target": MICRODUCK_TARGET_CFG,
+    }
+    if not rough:
+        # Headroom for foot–target contacts on top of the walk model's budget.
+        cfg.sim.nconmax = 50
+    cfg.episode_length_s = EPISODE_LENGTH_S
+
+    # ── Command: [dx_norm, dy_norm, phase_flag] from state ───────────────────
+    twist = deepcopy(cfg.commands["twist"])
+    twist.rel_standing_envs = 0.0
+    twist.rel_heading_envs = 0.0
+    twist.rel_turn_in_place_envs = 0.0
+    twist.heading_command = False
+    twist.ranges.heading = None
+    twist.resampling_time_range = (EPISODE_LENGTH_S * 2, EPISODE_LENGTH_S * 4)
+    twist.debug_vis = False
+    cfg.commands["twist"] = ai_mdp.TargetCommandCfg(
+        **vars(twist), target_name="target", scale_m=CMD_SCALE_M,
+    )
+
+    # ── Events: spawn the target AFTER reset_base (dict insertion order) ─────
+    cfg.events["reset_target"] = EventTermCfg(
+        func=ai_mdp.reset_target_around_robot,
+        mode="reset",
+        params={"radius_range": SPAWN_RADIUS_M, "asset_name": "target"},
+    )
+
+    # ── Observations: actor unchanged (61-D); critic gets target + dwell ────
+    cfg.observations["critic"].terms["target_position"] = ObservationTermCfg(
+        func=microduck_mdp.ball_pos_in_base, params={"asset_name": "target"},
+    )
+    cfg.observations["critic"].terms["dwell_progress"] = ObservationTermCfg(
+        func=ai_mdp.dwell_progress_obs,
+    )
+
+    # ── Rewards: drop velocity tracking, keep gait shaping outside the ring ──
+    for name in ("track_linear_velocity", "track_angular_velocity"):
+        cfg.rewards.pop(name, None)
+    for name in ("air_time", "foot_clearance", "foot_swing_height", "foot_slip"):
+        cfg.rewards[name].params["command_threshold"] = GAIT_CMD_THRESHOLD
+    cfg.rewards["pose"].params["walking_threshold"] = GAIT_CMD_THRESHOLD
+
+    # Head is the task's tool: keep the head_pose slot alive (tiny ranges,
+    # weight 0), drop the droop-bias term and its curriculum.
+    cfg.rewards["head_pose_tracking"].weight = 0.0
+    cfg.rewards.pop("head_pose_bias", None)
+    cfg.curriculum.pop("head_pose_bias_weight", None)
+    cfg.curriculum.pop("head_pose_range", None)   # stay at stage-0 tiny ranges
+    cfg.curriculum.pop("standing_envs", None)     # velocity-command only
+
+    # ── Rewards: task (approach_inspect_reward_design.md) ────────────────────
+    # Potential-based approach: Δ(-|d - standoff|). Closing pays, holding pays
+    # zero, overshoot charges. No per-step proximity jackpot.
+    cfg.rewards["ring_progress"] = RewardTermCfg(
+        func=ai_mdp.delta_ring_distance,
+        weight=6.0,
+        params={"standoff": STANDOFF_M, "target_name": "target"},
+    )
+    # Gaussian on head bearing, hard-gated on being in the ring (a GOOD state).
+    cfg.rewards["head_aim"] = RewardTermCfg(
+        func=ai_mdp.head_bearing_gaussian,
+        weight=3.0,
+        params={"sigma": AIM_SIGMA_RAD, "gate_tol": RING_TOL_M,
+                "standoff": STANDOFF_M, "head_cfg": _head_cfg(),
+                "target_name": "target"},
+    )
+    # L1 on a 1 s EMA of the signed bearing error: charges the DC aim bias,
+    # lets the walking head oscillation cancel. Self-negating ⇒ POSITIVE weight.
+    cfg.rewards["head_aim_bias"] = RewardTermCfg(
+        func=ai_mdp.head_bearing_ema_l1_penalty,
+        weight=1.5,
+        params={"tau_s": 1.0, "head_cfg": _head_cfg(), "target_name": "target"},
+    )
+    # Slewed dwell latch (in ring & aimed & stopped): pays Δprogress, no jackpot.
+    # MUST precede turn_away and the command's phase flag reads it.
+    cfg.rewards["dwell"] = RewardTermCfg(
+        func=ai_mdp.delta_dwell_progress,
+        weight=4.0,
+        params={"rate": DWELL_RATE, "gate_tol": RING_TOL_M, "aim_tol": AIM_SIGMA_RAD,
+                "speed_tol": DWELL_SPEED_TOL, "standoff": STANDOFF_M,
+                "head_cfg": _head_cfg(), "target_name": "target"},
+    )
+    # -|v_xy| inside the ring only. Self-negating ⇒ POSITIVE weight.
+    cfg.rewards["stop_in_ring"] = RewardTermCfg(
+        func=ai_mdp.planar_speed_gated_penalty,
+        weight=2.0,
+        params={"gate_tol": RING_TOL_M, "standoff": STANDOFF_M, "target_name": "target"},
+    )
+    # Potential-based turn-away, frozen until the dwell latch saturates.
+    cfg.rewards["turn_away"] = RewardTermCfg(
+        func=ai_mdp.delta_heading_progress,
+        weight=2.0,
+        params={"target_offset": math.pi, "require_dwell": 0.999, "target_name": "target"},
+    )
+
+    # ── Regularisers: 60 % of velocity, ramped from ~0 ───────────────────────
+    cfg.rewards["action_rate_l2"].weight = -0.1 * REG_SCALE
+    cfg.rewards["body_ang_vel"].weight = -0.05 * REG_SCALE
+    cfg.rewards["angular_momentum"].weight = -0.02 * REG_SCALE
+    # Neck-only smoothness: the head is the tool here, so it gets its own
+    # damping (the velocity env deliberately has none). Ramped with action_rate.
+    cfg.rewards["neck_action_rate_l2"] = RewardTermCfg(
+        func=microduck_mdp.neck_action_rate_l2, weight=0.0,
+    )
+    cfg.curriculum["action_rate_weight"] = CurriculumTermCfg(
+        func=microduck_mdp.reward_weight,
+        params={
+            "reward_name": "action_rate_l2",
+            "weight_stages": [
+                {"step": 0,                         "weight": -0.1 * REG_SCALE},
+                {"step": 500 * NUM_STEPS_PER_ENV,   "weight": -0.2 * REG_SCALE},
+                {"step": 750 * NUM_STEPS_PER_ENV,   "weight": -0.4 * REG_SCALE},
+                {"step": 1000 * NUM_STEPS_PER_ENV,  "weight": -0.6 * REG_SCALE},
+                {"step": 1250 * NUM_STEPS_PER_ENV,  "weight": -0.8 * REG_SCALE},
+                {"step": 1500 * NUM_STEPS_PER_ENV,  "weight": -1.0 * REG_SCALE},
+            ],
+        },
+    )
+    cfg.curriculum["neck_action_rate_weight"] = CurriculumTermCfg(
+        func=microduck_mdp.reward_weight,
+        params={
+            "reward_name": "neck_action_rate_l2",
+            "weight_stages": [
+                {"step": 0,                         "weight": 0.0},
+                {"step": 500 * NUM_STEPS_PER_ENV,   "weight": -0.15},
+                {"step": 1000 * NUM_STEPS_PER_ENV,  "weight": -0.3},
+                {"step": 1500 * NUM_STEPS_PER_ENV,  "weight": -0.6},
+            ],
+        },
+    )
+
+    return cfg
+
+
+MicroduckApproachInspectRlCfg = RslRlOnPolicyRunnerCfg(
+    actor=RslRlModelCfg(
+        hidden_dims=(512, 256, 128),
+        activation="elu",
+        obs_normalization=True,  # normalizer MUST be baked into ONNX by export.py
+        distribution_cfg={
+            "class_name": "GaussianDistribution",
+            "init_std": 1.0,
+            "std_type": "scalar",
+        },
+    ),
+    critic=RslRlModelCfg(
+        hidden_dims=(512, 256, 128),
+        activation="elu",
+        obs_normalization=True,
+    ),
+    algorithm=PpoWithSymmetryCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.01,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+        symmetry_cfg=None,
+    ),
+    wandb_project="mjlab_microduck",
+    experiment_name="approach_inspect",
+    run_name="approach_inspect",
+    save_interval=250,
+    num_steps_per_env=NUM_STEPS_PER_ENV,
+    max_iterations=6_000,
+)

--- a/tests/test_approach_inspect_cfg.py
+++ b/tests/test_approach_inspect_cfg.py
@@ -1,0 +1,161 @@
+"""Cfg invariants for Mjlab-ApproachInspect-*-MicroDuck (CPU, no env build).
+
+Locks in, per AGENTS.md "Building a new env" step 4:
+  * the target scene entity exists and the robot stays entity #1
+  * the twist command is the state-driven TargetCommand
+  * every DR / sim2real block is the velocity env's, term for term
+  * reward sign convention: self-negating penalties POSITIVE, mjlab costs NEGATIVE
+  * the 61-D command slots are all still present (head/body kept alive at weight 0)
+  * gait terms are gated OUTSIDE the ring; reset_target runs after reset_base
+"""
+import dataclasses
+
+import pytest
+
+from mjlab_microduck.robot.microduck_constants import MICRODUCK_TARGET_CFG
+from mjlab_microduck.tasks import approach_inspect_mdp as ai_mdp
+from mjlab_microduck.tasks.microduck_approach_inspect_env_cfg import (
+    GAIT_CMD_THRESHOLD,
+    RING_TOL_M,
+    STANDOFF_M,
+    make_microduck_approach_inspect_env_cfg,
+)
+from mjlab_microduck.tasks.microduck_velocity_env_cfg import (
+    make_microduck_velocity_env_cfg,
+)
+
+# Everything sim2real in the velocity env that must be byte-identical here.
+DR_EVENTS = (
+    "expand_bam_friction_fields", "reset_action_history", "foot_friction",
+    "push_robot", "randomize_com", "randomize_head_com", "randomize_mass_inertia",
+    "randomize_joint_friction", "randomize_armature", "encoder_bias",
+)
+DR_CURRICULA = ("com_range", "head_com_range")
+NOISY_ACTOR_TERMS = ("base_ang_vel", "projected_gravity", "joint_pos", "joint_vel")
+
+
+def _plain(obj):
+    """Dataclass → comparable nested structure (functions compared by identity)."""
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return {f.name: _plain(getattr(obj, f.name)) for f in dataclasses.fields(obj)}
+    if isinstance(obj, dict):
+        return {k: _plain(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_plain(v) for v in obj)
+    return obj
+
+
+@pytest.fixture(scope="module")
+def cfg():
+    return make_microduck_approach_inspect_env_cfg()
+
+
+@pytest.fixture(scope="module")
+def vel():
+    return make_microduck_velocity_env_cfg()
+
+
+def test_target_entity_and_robot_first(cfg):
+    names = list(cfg.scene.entities)
+    assert names[0] == "robot"
+    assert cfg.scene.entities["target"] is MICRODUCK_TARGET_CFG
+
+
+def test_command_is_state_driven_target(cfg):
+    cmd = cfg.commands["twist"]
+    assert isinstance(cmd, ai_mdp.TargetCommandCfg)
+    assert cmd.class_type is ai_mdp.TargetCommand
+    assert cmd.target_name == "target"
+    assert cmd.rel_standing_envs == 0.0 and cmd.rel_turn_in_place_envs == 0.0
+    # The other two command slots stay (61-D layout), tiny ranges, alive.
+    assert "head_pose" in cfg.commands and "body_pose" in cfg.commands
+    for grp in ("actor", "critic"):
+        terms = cfg.observations[grp].terms
+        assert "twist" in terms or "velocity_command" in terms or any(
+            getattr(t, "params", {}).get("command_name") == "twist" for t in terms.values()
+        )
+        assert "head_command" in terms and "body_command" in terms
+    assert cfg.rewards["head_pose_tracking"].weight == 0.0
+    assert "head_pose_bias" not in cfg.rewards
+    assert "head_pose_range" not in cfg.curriculum
+
+
+def test_dr_blocks_identical_to_velocity(cfg, vel):
+    for name in DR_EVENTS:
+        assert name in cfg.events, name
+        assert _plain(cfg.events[name]) == _plain(vel.events[name]), name
+    for name in DR_CURRICULA:
+        assert _plain(cfg.curriculum[name]) == _plain(vel.curriculum[name]), name
+    # Obs noise / delays / IMU misalignment / encoder bias live on the actor terms.
+    for name in NOISY_ACTOR_TERMS:
+        a, b = cfg.observations["actor"].terms[name], vel.observations["actor"].terms[name]
+        assert _plain(a) == _plain(b), name
+    assert cfg.terminations["nan_state"].func is vel.terminations["nan_state"].func
+    assert cfg.actions["joint_pos"].scale == vel.actions["joint_pos"].scale
+
+
+def test_reward_signs(cfg):
+    r = cfg.rewards
+    # velocity-tracking gone
+    assert "track_linear_velocity" not in r and "track_angular_velocity" not in r
+    # self-negating microduck penalties (return <= 0) take POSITIVE weights
+    assert r["head_aim_bias"].func is ai_mdp.head_bearing_ema_l1_penalty
+    assert r["head_aim_bias"].weight > 0
+    assert r["stop_in_ring"].func is ai_mdp.planar_speed_gated_penalty
+    assert r["stop_in_ring"].weight > 0
+    # potentials / gated positives
+    assert r["ring_progress"].weight > 0 and r["head_aim"].weight > 0
+    assert r["dwell"].weight > 0 and r["turn_away"].weight > 0
+    # mjlab-base costs (>= 0) take NEGATIVE weights
+    for name in ("action_rate_l2", "body_ang_vel", "angular_momentum", "self_collisions", "foot_slip"):
+        assert r[name].weight < 0, name
+    assert r["neck_action_rate_l2"].weight <= 0
+    # dwell must be computed before turn_away (turn_away reads env._ai_dwell)
+    names = list(r)
+    assert names.index("dwell") < names.index("turn_away")
+
+
+def test_task_params_consistent(cfg):
+    r = cfg.rewards
+    for name in ("ring_progress", "head_aim", "dwell", "stop_in_ring"):
+        assert r[name].params["standoff"] == STANDOFF_M, name
+    for name in ("head_aim", "dwell", "stop_in_ring"):
+        assert r[name].params["gate_tol"] == RING_TOL_M, name
+    assert r["dwell"].params["speed_tol"] > 0          # orbiting accrues no dwell
+    # head_cfg must be passed in params (the manager resolves only those) and
+    # name the mouth_tip site + jaw_soft body that exist on the walk model.
+    for name in ("head_aim", "head_aim_bias", "dwell"):
+        hc = r[name].params["head_cfg"]
+        assert hc.name == "robot" and list(hc.site_names) == ["mouth_tip"]
+        assert list(hc.body_names) == ["jaw_soft"]
+    assert r["turn_away"].params["require_dwell"] >= 0.99
+
+
+def test_gait_terms_gated_outside_ring(cfg):
+    # command norm = d / 1.5 ⇒ threshold must sit just past the ring's outer edge
+    assert abs(GAIT_CMD_THRESHOLD - (STANDOFF_M + RING_TOL_M) / 1.5) < 1e-9
+    for name in ("air_time", "foot_clearance", "foot_swing_height", "foot_slip"):
+        assert cfg.rewards[name].params["command_threshold"] == GAIT_CMD_THRESHOLD, name
+    assert cfg.rewards["pose"].params["walking_threshold"] == GAIT_CMD_THRESHOLD
+
+
+def test_reset_target_after_reset_base(cfg):
+    ev = cfg.events["reset_target"]
+    assert ev.func is ai_mdp.reset_target_around_robot and ev.mode == "reset"
+    assert ev.params["radius_range"] == (0.4, 1.5)
+    order = list(cfg.events)
+    assert order.index("reset_base") < order.index("reset_target")
+
+
+def test_regularisers_ramp_from_low(cfg):
+    stages = cfg.curriculum["action_rate_weight"].params["weight_stages"]
+    assert stages[0]["weight"] == cfg.rewards["action_rate_l2"].weight
+    assert all(s["weight"] <= 0 for s in stages)
+    assert stages[-1]["weight"] > -1.0     # < velocity's -1.0 (smaller task stack)
+    nstages = cfg.curriculum["neck_action_rate_weight"].params["weight_stages"]
+    assert nstages[0]["weight"] == 0.0 and nstages[-1]["weight"] < 0
+
+
+def test_rough_and_play_variants_build():
+    assert "ring_progress" in make_microduck_approach_inspect_env_cfg(rough=True).rewards
+    assert "ring_progress" in make_microduck_approach_inspect_env_cfg(play=True).rewards

--- a/tests/test_approach_inspect_mdp.py
+++ b/tests/test_approach_inspect_mdp.py
@@ -1,0 +1,176 @@
+"""Invariant tests for approach_inspect_mdp.
+
+Run inside microduck_rl:  uv run pytest tests/test_approach_inspect_mdp.py
+CPU only, no mjlab env — a minimal fake scene is enough to check the reward
+properties AGENTS.md cares about:
+
+  * potentials pay zero for holding
+  * penalties are <= 0 everywhere
+  * the dwell latch cannot be jackpotted by arriving fast
+  * orbiting the ring does not accumulate dwell
+  * fresh episodes carry no delta from the previous one
+"""
+import math
+import types
+
+import pytest
+import torch
+
+import mjlab_microduck.tasks.approach_inspect_mdp as M
+
+
+# ── fake scene ──────────────────────────────────────────────────────────────
+
+class _Data:
+    pass
+
+
+class _Entity:
+    def __init__(self, n):
+        self.data = _Data()
+        self.data.root_link_pos_w = torch.zeros(n, 3)
+        self.data.root_link_quat_w = torch.tensor([[1.0, 0, 0, 0]]).repeat(n, 1)
+        self.data.root_link_lin_vel_w = torch.zeros(n, 3)
+        self.data.site_pos_w = torch.zeros(n, 1, 3)
+        self.data.body_com_pos_w = torch.zeros(n, 1, 3)
+
+
+class _Cfg:
+    name = "robot"
+    site_ids = [0]
+    body_ids = [0]
+
+
+def make_env(n=4, dt=0.02):
+    env = types.SimpleNamespace()
+    env.num_envs = n
+    env.device = "cpu"
+    env.step_dt = dt
+    env.episode_length_buf = torch.full((n,), 10)
+    robot, target = _Entity(n), _Entity(n)
+    env.scene = {"robot": robot, "target": target}
+    return env, robot, target
+
+
+def place(robot, target, dist, yaw=0.0, head_bearing=0.0, speed=0.0):
+    """Robot at origin facing +x (yaw), target at dist along +x, head aimed at
+    head_bearing relative to +x, moving at speed along +y."""
+    n = robot.data.root_link_pos_w.shape[0]
+    target.data.root_link_pos_w[:] = torch.tensor([dist, 0.0, 0.0])
+    robot.data.root_link_quat_w[:] = torch.tensor(
+        [math.cos(yaw / 2), 0.0, 0.0, math.sin(yaw / 2)])
+    robot.data.body_com_pos_w[:, 0] = torch.tensor([0.0, 0.0, 0.2])
+    robot.data.site_pos_w[:, 0] = torch.tensor(
+        [0.05 * math.cos(head_bearing), 0.05 * math.sin(head_bearing), 0.2])
+    robot.data.root_link_lin_vel_w[:] = torch.tensor([0.0, speed, 0.0])
+
+
+CFG = _Cfg()
+
+
+# ── tests ───────────────────────────────────────────────────────────────────
+
+def test_ring_progress_pays_for_closing_and_zero_for_holding():
+    env, r, t = make_env()
+    place(r, t, 1.0)
+    M.delta_ring_distance(env, standoff=0.22, asset_cfg=CFG)   # seed
+    place(r, t, 0.8)
+    closing = M.delta_ring_distance(env, standoff=0.22, asset_cfg=CFG)
+    assert torch.allclose(closing, torch.full((4,), 0.2), atol=1e-6)
+    hold = M.delta_ring_distance(env, standoff=0.22, asset_cfg=CFG)
+    assert torch.all(hold == 0)
+
+
+def test_ring_progress_charges_overshoot():
+    env, r, t = make_env()
+    place(r, t, 0.22)
+    M.delta_ring_distance(env, asset_cfg=CFG)
+    place(r, t, 0.10)   # walked past the ring into the object
+    assert torch.all(M.delta_ring_distance(env, asset_cfg=CFG) < 0)
+
+
+def test_fresh_episode_has_no_delta():
+    env, r, t = make_env()
+    place(r, t, 1.0)
+    M.delta_ring_distance(env, asset_cfg=CFG)
+    place(r, t, 0.22)
+    env.episode_length_buf[:] = 0    # reset happened
+    assert torch.all(M.delta_ring_distance(env, asset_cfg=CFG) == 0)
+
+
+def test_aim_is_zero_outside_ring_and_peaks_inside():
+    env, r, t = make_env()
+    place(r, t, 1.0, head_bearing=0.0)
+    assert torch.all(M.head_bearing_gaussian(env, head_cfg=CFG) == 0)
+    place(r, t, 0.22, head_bearing=0.0)
+    assert torch.allclose(M.head_bearing_gaussian(env, head_cfg=CFG), torch.ones(4))
+    place(r, t, 0.22, head_bearing=1.0)
+    assert torch.all(M.head_bearing_gaussian(env, head_cfg=CFG) < 0.01)
+
+
+def test_penalties_are_never_positive():
+    env, r, t = make_env()
+    for d, hb, sp in [(0.22, 0.0, 0.3), (0.22, 1.2, 0.0), (1.0, 0.0, 1.0), (0.05, -2.0, 0.1)]:
+        place(r, t, d, head_bearing=hb, speed=sp)
+        assert torch.all(M.planar_speed_gated_penalty(env, asset_cfg=CFG) <= 0)
+        assert torch.all(M.head_bearing_ema_l1_penalty(env, head_cfg=CFG) <= 0)
+
+
+def test_speed_penalty_is_zero_outside_ring():
+    env, r, t = make_env()
+    place(r, t, 1.0, speed=1.0)
+    assert torch.all(M.planar_speed_gated_penalty(env, asset_cfg=CFG) == 0)
+    place(r, t, 0.22, speed=1.0)
+    assert torch.all(M.planar_speed_gated_penalty(env, asset_cfg=CFG) < 0)
+
+
+def test_dwell_is_slewed_and_saturates():
+    env, r, t = make_env(dt=0.1)
+    place(r, t, 0.22, head_bearing=0.0, speed=0.0)
+    total = 0.0
+    for _ in range(30):
+        total += float(M.delta_dwell_progress(env, rate=0.5, head_cfg=CFG)[0])
+    assert abs(total - 1.0) < 1e-6           # exactly one unit, no more
+    assert float(M.delta_dwell_progress(env, rate=0.5, head_cfg=CFG)[0]) == 0.0
+
+
+def test_dwell_cannot_be_jackpotted_by_arriving_fast():
+    """Arriving instantly vs. arriving slowly must pay the same total."""
+    fast_env, r, t = make_env(dt=0.1)
+    place(r, t, 0.22, speed=0.0)
+    fast = sum(float(M.delta_dwell_progress(fast_env, rate=0.5, head_cfg=CFG)[0]) for _ in range(40))
+
+    slow_env, r2, t2 = make_env(dt=0.1)
+    for d in [1.0, 0.8, 0.6, 0.4]:
+        place(r2, t2, d, speed=0.0)
+        M.delta_dwell_progress(slow_env, rate=0.5, head_cfg=CFG)
+    place(r2, t2, 0.22, speed=0.0)
+    slow = sum(float(M.delta_dwell_progress(slow_env, rate=0.5, head_cfg=CFG)[0]) for _ in range(40))
+    assert abs(fast - slow) < 1e-6
+
+
+def test_orbiting_does_not_accumulate_dwell():
+    env, r, t = make_env(dt=0.1)
+    place(r, t, 0.22, head_bearing=0.0, speed=0.4)   # on ring, aimed, moving
+    total = sum(float(M.delta_dwell_progress(env, head_cfg=CFG)[0]) for _ in range(20))
+    assert total == 0.0
+
+
+def test_turn_away_frozen_until_dwell_saturates():
+    env, r, t = make_env(dt=0.1)
+    place(r, t, 0.22, yaw=0.0)
+    env._ai_dwell = torch.zeros(4)
+    M.delta_heading_progress(env, asset_cfg=CFG)
+    place(r, t, 0.22, yaw=1.0)
+    assert torch.all(M.delta_heading_progress(env, asset_cfg=CFG) == 0)
+    env._ai_dwell = torch.ones(4)
+    M.delta_heading_progress(env, asset_cfg=CFG)      # first active step: reseed
+    place(r, t, 0.22, yaw=2.0)                        # turning toward pi pays
+    assert torch.all(M.delta_heading_progress(env, asset_cfg=CFG) > 0)
+
+
+def test_phase_flag_follows_dwell():
+    env, _, _ = make_env()
+    assert torch.all(M.phase_flag(env) == 0)
+    env._ai_dwell = torch.ones(4)
+    assert torch.all(M.phase_flag(env) == 1)


### PR DESCRIPTION
## What

A new task family: the duck walks to a small static target, stops on a 22 cm standoff ring, aims its head at it, holds the look for 2 s, then turns away. Built on `make_microduck_velocity_env_cfg` so every DR / sim2real block is the velocity recipe verbatim (locked by tests), obs stays 61-D and actions 14 so the policy hot-swaps with the walking policy.

- `tasks/approach_inspect_mdp.py` — reward terms in their own module (no `mdp.py` edits): potential-based ring progress (Δ of −|d − standoff|), head-aim Gaussian gated on the ring, L1 on a 1 s EMA of bearing error, a slewed dwell latch (rate-limited, cannot be jackpotted by arriving fast, does not accumulate while moving), a ring-gated planar-speed penalty, and potential-based turn-away. Self-negating penalties take positive weights per AGENTS.md.
- `TargetCommand` writes `[dx_norm, dy_norm, phase_flag]` into the twist slot (target offset in the base yaw frame, ±1 at 1.5 m); head/body slots keep tiny sampling ranges at weight 0.
- `robot/microduck/target.xml` + `MICRODUCK_TARGET_CFG`: a fixed-base puck that mjlab auto-wraps in mocap; `reset_target_around_robot` spawns it at radius 0.4–1.5 m, any bearing.
- Gait terms (`air_time`, foot clearance/swing/slip, walking pose std) are gated on the command norm so they are active only outside the ring (d > 0.30 m); inside, the standing pose std applies.
- Registered: `Mjlab-ApproachInspect-Flat-MicroDuck`, `-Rough-`, and `-Flat-Backlash-` (walk backlash model, like Velocity).

## Verified

- `tests/test_approach_inspect_mdp.py` (11) and `tests/test_approach_inspect_cfg.py` (9) pass on CPU; the cfg tests assert every DR/obs-noise/delay term is identical to the velocity cfg and every penalty weight has the right sign.
- Env instantiates on CPU (warp cpu, 4 envs) with 61-D actor obs and 14 actions.
- 5-iteration / 64-env smoke train on CPU: all `Episode_Reward/*penalty*` ≤ 0, no NaN terminations, ONNX auto-export is `obs[1,61] → actions[1,14]`; the exported policy runs in `scripts/infer_policy.py`.
- **Not yet trained** — opened as a draft so the reward design can be read before GPU time is spent. Design notes are in the module docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)