### PR TITLE
Add optional read-only MuJoCo visualization stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ uv run publish --onnx output.onnx --repo <user>/microduck-<name> --kind episodic
 uv run scripts/infer_policy.py --walking output.onnx
 ```
 
+### Optional MuJoCo visualization
+
+`duck-body` can optionally expose the exact MuJoCo world it simulates as cached
+JPEG or PNG frames for read-only developer tools. It does not change physics,
+training, policy inference, or the simulator wire state. Install the optional
+image encoder before enabling it:
+
+```bash
+uv sync --extra visualization
+uv run mjpython -m mjlab_microduck.sim.body_server \
+    --keyframe HOME --port 7801 --headless --render \
+    --render-width 1280 --render-height 720 --render-fps 24 --render-quality 95
+```
+
+The generic implementation lives under `sim/visualization`. It copies `MjData`
+while holding the world lock, then performs OpenGL rendering and image encoding
+after releasing it. Keeping the expensive work outside the lock preserves the
+50 Hz physics/control loop even when software rendering is slower than the
+requested frame rate. The optional `camera` and `render_config` operations only
+affect this read-only stream; they never mutate the authoritative simulation
+state.
+
 Resume from a checkpoint:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
     "torch==2.9.1",
 ]
 
+[project.optional-dependencies]
+visualization = ["pillow>=11,<13"]
+
 [project.entry-points."mjlab.tasks"]
 mjlab_microduck = "mjlab_microduck.tasks"
 

--- a/src/mjlab_microduck/sim/body_server.py
+++ b/src/mjlab_microduck/sim/body_server.py
@@ -55,6 +55,10 @@ import numpy as np
 from mjlab_microduck.sim.camera import FPS as CAMERA_FPS
 from mjlab_microduck.sim.camera import Camera, FrameHandler, FrameServer
 from mjlab_microduck.sim.tof import COLS, ROWS, Tof
+from mjlab_microduck.sim.visualization.service import (
+    VisualizationService,
+    add_visualization_arguments,
+)
 
 PROTOCOL = 1
 
@@ -395,14 +399,24 @@ class Handler(socketserver.StreamRequestHandler):
         self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         body: Body = self.server.body
         print(f"== duck {body.index}: daemon connected from {self.client_address}", flush=True)
-        for raw in self.rfile:
-            try:
-                answer = self.dispatch(body, json.loads(raw))
-            except Exception as error:  # a bad frame must not take the simulator down with it
-                answer = {"error": str(error)}
-            self.wfile.write((json.dumps(answer) + "\n").encode())
-            self.wfile.flush()
-        print(f"== duck {body.index}: daemon disconnected", flush=True)
+        visualization: VisualizationService = self.server.visualization
+        visualization_client = False
+        try:
+            for raw in self.rfile:
+                try:
+                    request = json.loads(raw)
+                    if request.get("op") == "render" and not visualization_client:
+                        visualization.client_connected()
+                        visualization_client = True
+                    answer = self.dispatch(body, request)
+                except Exception as error:  # noqa: BLE001 - isolate malformed client frames
+                    answer = {"error": str(error)}
+                self.wfile.write((json.dumps(answer) + "\n").encode())
+                self.wfile.flush()
+        finally:
+            if visualization_client:
+                visualization.client_disconnected()
+            print(f"== duck {body.index}: daemon disconnected", flush=True)
 
     def dispatch(self, body: Body, request: dict) -> dict:
         op = request.get("op")
@@ -428,6 +442,9 @@ class Handler(socketserver.StreamRequestHandler):
             return body.slow_sensors()
         if op == "tof":
             return body.depth()
+        visualization: VisualizationService = self.server.visualization
+        if visualization.handles(op):
+            return visualization.dispatch(request)
         raise ValueError(f"unknown op {op!r}")
 
 
@@ -436,7 +453,7 @@ class Server(socketserver.ThreadingTCPServer):
     daemon_threads = True
 
 
-def run(world: World, headless: bool) -> None:
+def run(world: World, headless: bool, stop_event: threading.Event | None = None) -> None:
     """Step in real time.
 
     **Real time, not as fast as possible.** The daemon's loop is wall-clock and its health gate
@@ -453,7 +470,7 @@ def run(world: World, headless: bool) -> None:
             viewer = mujoco.viewer.launch_passive(
                 world.model, world.data, show_left_ui=False, show_right_ui=False
             )
-        except Exception as error:
+        except Exception as error:  # noqa: BLE001 - viewer fallback must include GL failures
             print(f"== no viewer ({error}); running headless", flush=True)
 
     dt = world.model.opt.timestep
@@ -472,7 +489,7 @@ def run(world: World, headless: bool) -> None:
     next_step = time.perf_counter()
     behind = 0
     try:
-        while True:
+        while stop_event is None or not stop_event.is_set():
             world.step(batch)
             if viewer is not None and not viewer.is_running():
                 break
@@ -510,6 +527,7 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=7801, help="the first duck's port; +1 each")
     parser.add_argument("--headless", action="store_true", help="no viewer window")
+    add_visualization_arguments(parser)
     parser.add_argument(
         "--cameras",
         default="",
@@ -550,6 +568,7 @@ def main() -> None:
     elif args.cameras.strip():
         wanted = {ord(c.strip()) - ord("a") for c in args.cameras.split(",") if c.strip()}
     servers = []
+    body_servers = []
     for index in range(args.ducks):
         body = Body(world, index, limp=args.limp)
         body.place(pose, trunk_z, offset_y=index * SPACING)
@@ -561,23 +580,39 @@ def main() -> None:
         mujoco.mj_forward(world.model, world.data)
         server = Server((args.host, args.port + index), Handler)
         server.body = body
-        threading.Thread(target=server.serve_forever, daemon=True).start()
         servers.append(server)
+        body_servers.append(server)
 
         if index in wanted:
             body.camera = Camera(world.model, f"{body.prefix}head_camera")
             frames = FrameServer((args.host, args.frame_port + index), FrameHandler)
             frames.camera = body.camera
             frames.fps = args.camera_fps
-            threading.Thread(target=frames.serve_forever, daemon=True).start()
             servers.append(frames)
+
+    mujoco.mj_forward(world.model, world.data)
+    try:
+        visualization = VisualizationService.from_arguments(args, world)
+    except (RuntimeError, ValueError) as error:
+        raise SystemExit(str(error)) from error
+    visualization.start()
+    for server in body_servers:
+        server.visualization = visualization
+    for server in servers:
+        threading.Thread(target=server.serve_forever, daemon=True).start()
 
     print(f"== {args.scene.name}: {args.ducks} duck(s), starting at {args.keyframe}", flush=True)
     for index in range(args.ducks):
         eye = f" · camera on {args.host}:{args.frame_port + index}" if index in wanted else ""
         print(f"==   duck {index}: robotd --sim {args.host}:{args.port + index}{eye}", flush=True)
 
-    run(world, headless=args.headless)
+    try:
+        run(world, headless=args.headless, stop_event=visualization.exit_requested)
+    finally:
+        visualization.close()
+        for server in servers:
+            server.shutdown()
+            server.server_close()
 
 
 if __name__ == "__main__":

--- a/src/mjlab_microduck/sim/visualization/__init__.py
+++ b/src/mjlab_microduck/sim/visualization/__init__.py
@@ -1,0 +1,1 @@
+"""Optional visualization service for the authoritative MuJoCo world."""

--- a/src/mjlab_microduck/sim/visualization/service.py
+++ b/src/mjlab_microduck/sim/visualization/service.py
@@ -1,0 +1,125 @@
+"""CLI, lifecycle, and wire adapter for optional MuJoCo visualization."""
+
+from __future__ import annotations
+
+import argparse
+import threading
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mjlab_microduck.sim.visualization.stream import RenderStream, RenderWorld
+
+DEFAULT_WIDTH = 1280
+DEFAULT_HEIGHT = 720
+DEFAULT_FPS = 24
+DEFAULT_QUALITY = 95
+DEFAULT_FORMAT = "jpeg"
+
+VISUALIZATION_OPERATIONS = frozenset({"render", "camera", "render_config"})
+
+
+def add_visualization_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add optional visualization controls to a body-server argument parser."""
+
+    parser.add_argument(
+        "--render", action="store_true", help="serve cached image frames"
+    )
+    parser.add_argument("--render-width", type=int, default=DEFAULT_WIDTH)
+    parser.add_argument("--render-height", type=int, default=DEFAULT_HEIGHT)
+    parser.add_argument("--render-fps", type=int, default=DEFAULT_FPS)
+    parser.add_argument("--render-quality", type=int, default=DEFAULT_QUALITY)
+    parser.add_argument(
+        "--render-format", choices=("jpeg", "png"), default=DEFAULT_FORMAT
+    )
+    parser.add_argument(
+        "--exit-on-render-idle",
+        type=float,
+        metavar="SECONDS",
+        help="exit after the last render client stays disconnected for this long",
+    )
+
+
+class VisualizationService:
+    """Optional image stream attached to one or more simulated-body servers."""
+
+    def __init__(self, stream: RenderStream | None = None):
+        self.stream = stream
+
+    @classmethod
+    def from_arguments(
+        cls, args: argparse.Namespace, world: RenderWorld
+    ) -> VisualizationService:
+        if args.exit_on_render_idle is not None and not args.render:
+            raise ValueError("--exit-on-render-idle requires --render")
+        if not args.render:
+            return cls()
+        try:
+            from mjlab_microduck.sim.visualization.stream import RenderStream
+        except ImportError as error:
+            if error.name == "PIL":
+                raise RuntimeError(
+                    "rendering requires the visualization extra; "
+                    "run `uv sync --extra visualization`"
+                ) from error
+            raise
+        return cls(
+            RenderStream(
+                world,
+                width=args.render_width,
+                height=args.render_height,
+                fps=args.render_fps,
+                quality=args.render_quality,
+                image_format=args.render_format,
+                exit_idle_seconds=args.exit_on_render_idle,
+            )
+        )
+
+    @property
+    def exit_requested(self) -> threading.Event | None:
+        return self.stream.exit_requested if self.stream is not None else None
+
+    def start(self) -> None:
+        if self.stream is not None:
+            self.stream.start()
+
+    def close(self) -> None:
+        if self.stream is not None:
+            self.stream.close()
+
+    def handles(self, operation: Any) -> bool:
+        return operation in VISUALIZATION_OPERATIONS
+
+    def client_connected(self) -> None:
+        if self.stream is not None:
+            self.stream.client_connected()
+
+    def client_disconnected(self) -> None:
+        if self.stream is not None:
+            self.stream.client_disconnected()
+
+    def dispatch(self, request: dict) -> dict:
+        operation = request.get("op")
+        if not self.handles(operation):
+            raise ValueError(f"unknown visualization operation {operation!r}")
+        if self.stream is None:
+            raise RuntimeError(
+                "MuJoCo rendering is disabled; start duck-body with --render"
+            )
+        if operation == "render":
+            return self.stream.get(
+                after=int(request.get("after", 0)),
+                timeout_ms=int(request.get("timeout_ms", 1000)),
+            )
+        if operation == "camera":
+            return self.stream.camera(
+                action=str(request.get("action", "")),
+                dx=float(request.get("dx", 0.0)),
+                dy=float(request.get("dy", 0.0)),
+            )
+        return self.stream.configure(
+            width=int(request["width"]),
+            height=int(request["height"]),
+            fps=int(request.get("fps", DEFAULT_FPS)),
+            quality=int(request.get("quality", DEFAULT_QUALITY)),
+            image_format=str(request.get("format", DEFAULT_FORMAT)),
+        )

--- a/src/mjlab_microduck/sim/visualization/stream.py
+++ b/src/mjlab_microduck/sim/visualization/stream.py
@@ -1,0 +1,277 @@
+"""Cached image rendering from snapshots of a live MuJoCo world."""
+
+from __future__ import annotations
+
+import base64
+import io
+import math
+import os
+import threading
+import time
+from typing import Any, Protocol
+
+import mujoco
+from PIL import Image
+
+DEFAULT_WIDTH = 1280
+DEFAULT_HEIGHT = 720
+DEFAULT_FPS = 24
+DEFAULT_QUALITY = 95
+DEFAULT_FORMAT = "jpeg"
+
+
+class RenderWorld(Protocol):
+    """The small portion of the body server world required for rendering."""
+
+    model: Any
+    data: Any
+    lock: threading.Lock
+    bodies: list[Any]
+
+
+class RenderStream:
+    """Render cached images from snapshots of the authoritative MuJoCo world.
+
+    Snapshotting is the only work performed under ``world.lock``. OpenGL rendering and image
+    encoding happen against a private ``MjData`` after the lock is released, so a slow software
+    renderer cannot stall the 50 Hz physics and robot control path.
+    """
+
+    def __init__(
+        self,
+        world: RenderWorld,
+        *,
+        width: int = DEFAULT_WIDTH,
+        height: int = DEFAULT_HEIGHT,
+        fps: int = DEFAULT_FPS,
+        quality: int = DEFAULT_QUALITY,
+        image_format: str = DEFAULT_FORMAT,
+        exit_idle_seconds: float | None = None,
+    ):
+        self._validate_settings(width, height, fps, quality, image_format)
+        if exit_idle_seconds is not None and exit_idle_seconds <= 0:
+            raise ValueError("render idle exit must be positive")
+        self.world = world
+        self.width = width
+        self.height = height
+        self.fps = fps
+        self.quality = quality
+        self.image_format = image_format
+        self.backend = os.getenv("MUJOCO_GL", "default")
+        self.exit_idle_seconds = exit_idle_seconds
+        self.exit_requested = threading.Event()
+        self._condition = threading.Condition()
+        self._frame: dict | None = None
+        self._error: str | None = None
+        self._stopping = threading.Event()
+        self._clients = 0
+        self._had_client = False
+        self._idle_timer: threading.Timer | None = None
+        self._camera_azimuth = 135.0
+        self._camera_elevation = -18.0
+        self._camera_distance = max(0.85, 0.65 + len(self.world.bodies) * 0.2)
+        self._thread = threading.Thread(
+            target=self._run, name="mujoco-render", daemon=True
+        )
+
+    @staticmethod
+    def _validate_settings(
+        width: int, height: int, fps: int, quality: int, image_format: str
+    ) -> None:
+        if width < 1 or height < 1 or width * height > 3840 * 2160:
+            raise ValueError(
+                "render dimensions must be positive and at most 3840x2160 pixels"
+            )
+        if not 1 <= fps <= 60:
+            raise ValueError("render FPS must be between 1 and 60")
+        if not 1 <= quality <= 100:
+            raise ValueError("JPEG quality must be between 1 and 100")
+        if image_format not in {"jpeg", "png"}:
+            raise ValueError("render format must be jpeg or png")
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def close(self) -> None:
+        self._stopping.set()
+        with self._condition:
+            if self._idle_timer is not None:
+                self._idle_timer.cancel()
+                self._idle_timer = None
+            self._condition.notify_all()
+        if self._thread.is_alive():
+            self._thread.join(timeout=3.0)
+
+    def client_connected(self) -> None:
+        with self._condition:
+            self._clients += 1
+            self._had_client = True
+            if self._idle_timer is not None:
+                self._idle_timer.cancel()
+                self._idle_timer = None
+
+    def client_disconnected(self) -> None:
+        with self._condition:
+            self._clients = max(0, self._clients - 1)
+            if (
+                self._clients == 0
+                and self._had_client
+                and self.exit_idle_seconds is not None
+                and not self._stopping.is_set()
+            ):
+                if self._idle_timer is not None:
+                    self._idle_timer.cancel()
+                self._idle_timer = threading.Timer(
+                    self.exit_idle_seconds, self._exit_if_still_idle
+                )
+                self._idle_timer.daemon = True
+                self._idle_timer.start()
+
+    def _exit_if_still_idle(self) -> None:
+        with self._condition:
+            self._idle_timer = None
+            if self._clients == 0 and not self._stopping.is_set():
+                self.exit_requested.set()
+
+    def camera(self, action: str, dx: float = 0.0, dy: float = 0.0) -> dict:
+        if not math.isfinite(dx) or not math.isfinite(dy):
+            raise ValueError("camera movement must be finite")
+        with self._condition:
+            if action == "orbit":
+                self._camera_azimuth = (self._camera_azimuth - dx * 0.3) % 360
+                self._camera_elevation = min(
+                    85.0, max(-85.0, self._camera_elevation - dy * 0.25)
+                )
+            elif action == "zoom":
+                self._camera_distance = min(
+                    5.0, max(0.25, self._camera_distance * math.exp(dy * 0.0015))
+                )
+            elif action == "reset":
+                self._camera_azimuth = 135.0
+                self._camera_elevation = -18.0
+                self._camera_distance = max(0.85, 0.65 + len(self.world.bodies) * 0.2)
+            else:
+                raise ValueError(f"unknown camera action {action!r}")
+            return {
+                "azimuth": self._camera_azimuth,
+                "elevation": self._camera_elevation,
+                "distance": self._camera_distance,
+            }
+
+    def configure(
+        self,
+        *,
+        width: int,
+        height: int,
+        fps: int,
+        quality: int,
+        image_format: str,
+    ) -> dict:
+        self._validate_settings(width, height, fps, quality, image_format)
+        with self._condition:
+            self.width = width
+            self.height = height
+            self.fps = fps
+            self.quality = quality
+            self.image_format = image_format
+            self._condition.notify_all()
+            return {
+                "width": width,
+                "height": height,
+                "fps": fps,
+                "quality": quality,
+                "format": image_format,
+            }
+
+    def get(self, after: int = 0, timeout_ms: int = 1000) -> dict:
+        if after < 0:
+            raise ValueError("render sequence must not be negative")
+        if not 0 <= timeout_ms <= 30_000:
+            raise ValueError("render timeout_ms must be between 0 and 30000")
+        deadline = time.monotonic() + timeout_ms / 1000
+        with self._condition:
+            while self._frame is None or self._frame["seq"] <= after:
+                if self._error is not None:
+                    raise RuntimeError(f"MuJoCo renderer failed: {self._error}")
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or self._stopping.is_set():
+                    return {"seq": after, "timeout": True}
+                self._condition.wait(remaining)
+            return dict(self._frame)
+
+    def _run(self) -> None:
+        renderer = None
+        try:
+            render_data = mujoco.MjData(self.world.model)
+            camera = mujoco.MjvCamera()
+            camera.type = mujoco.mjtCamera.mjCAMERA_FREE
+            next_frame = time.monotonic()
+            seq = 0
+            active_size = None
+            while not self._stopping.is_set():
+                with self._condition:
+                    width = self.width
+                    height = self.height
+                    fps = self.fps
+                    quality = self.quality
+                    image_format = self.image_format
+                    camera.azimuth = self._camera_azimuth
+                    camera.elevation = self._camera_elevation
+                    camera.distance = self._camera_distance
+                if active_size != (width, height):
+                    if renderer is not None:
+                        renderer.close()
+                    visual_global = getattr(
+                        getattr(self.world.model, "vis", None), "global_", None
+                    )
+                    if visual_global is not None:
+                        visual_global.offwidth = max(visual_global.offwidth, width)
+                        visual_global.offheight = max(visual_global.offheight, height)
+                    renderer = mujoco.Renderer(
+                        self.world.model, height=height, width=width
+                    )
+                    active_size = (width, height)
+                period = 1.0 / fps
+                delay = next_frame - time.monotonic()
+                if delay > 0 and self._stopping.wait(delay):
+                    break
+
+                with self.world.lock:
+                    mujoco.mj_copyData(render_data, self.world.model, self.world.data)
+                sim_time = float(render_data.time)
+                if self.world.bodies:
+                    trunk = self.world.bodies[0].trunk
+                    camera.lookat[:] = render_data.qpos[trunk : trunk + 3]
+                    camera.lookat[2] = max(
+                        0.08, float(render_data.qpos[trunk + 2]) * 0.6
+                    )
+                renderer.update_scene(render_data, camera=camera)
+                rgb = renderer.render()
+                output = io.BytesIO()
+                if image_format == "png":
+                    Image.fromarray(rgb).save(output, format="PNG", compress_level=1)
+                    mime = "image/png"
+                else:
+                    Image.fromarray(rgb).save(output, format="JPEG", quality=quality)
+                    mime = "image/jpeg"
+                seq += 1
+                frame = {
+                    "seq": seq,
+                    "sim_time": sim_time,
+                    "width": width,
+                    "height": height,
+                    "mime": mime,
+                    "backend": self.backend,
+                    "image_b64": base64.b64encode(output.getvalue()).decode("ascii"),
+                }
+                with self._condition:
+                    self._frame = frame
+                    self._condition.notify_all()
+                next_frame = max(next_frame + period, time.monotonic())
+        except Exception as error:  # noqa: BLE001 - renderer failures are surfaced to clients
+            with self._condition:
+                self._error = str(error)
+                self._condition.notify_all()
+        finally:
+            if renderer is not None:
+                renderer.close()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,208 @@
+import threading
+from argparse import Namespace
+
+import numpy as np
+import pytest
+
+from mjlab_microduck.sim.visualization import stream as visualization_stream
+from mjlab_microduck.sim.visualization.service import VisualizationService
+from mjlab_microduck.sim.visualization.stream import RenderStream
+
+
+class FakeData:
+    def __init__(self, _model):
+        self.time = 2.5
+        self.qpos = np.zeros(8)
+
+
+class FakeWorld:
+    def __init__(self):
+        self.model = object()
+        self.data = FakeData(self.model)
+        self.lock = threading.Lock()
+        self.bodies = []
+
+
+class FakeCamera:
+    def __init__(self):
+        self.type = None
+        self.azimuth = 0
+        self.elevation = 0
+        self.distance = 0
+        self.lookat = np.zeros(3)
+
+
+def test_render_stream_releases_world_lock_before_slow_render(monkeypatch):
+    entered_render = threading.Event()
+    release_render = threading.Event()
+
+    class SlowRenderer:
+        def __init__(self, _model, *, height, width):
+            self.height = height
+            self.width = width
+
+        def update_scene(self, _data, *, camera):
+            del camera
+
+        def render(self):
+            entered_render.set()
+            assert release_render.wait(2)
+            return np.zeros((self.height, self.width, 3), dtype=np.uint8)
+
+        def close(self):
+            pass
+
+    def copy_data(destination, _model, source):
+        destination.time = source.time
+        destination.qpos[:] = source.qpos
+
+    monkeypatch.setattr(visualization_stream.mujoco, "MjData", FakeData)
+    monkeypatch.setattr(visualization_stream.mujoco, "Renderer", SlowRenderer)
+    monkeypatch.setattr(visualization_stream.mujoco, "MjvCamera", FakeCamera)
+    monkeypatch.setattr(visualization_stream.mujoco, "mj_copyData", copy_data)
+
+    world = FakeWorld()
+    stream = RenderStream(world, width=16, height=9, fps=1)
+    stream.start()
+    try:
+        assert entered_render.wait(1)
+        assert world.lock.acquire(timeout=0.1), "rendering held the physics lock"
+        world.lock.release()
+        release_render.set()
+        frame = stream.get(timeout_ms=1000)
+        assert frame["seq"] == 1
+        assert frame["sim_time"] == 2.5
+        assert frame["width"] == 16
+        assert frame["height"] == 9
+        assert frame["mime"] == "image/jpeg"
+        assert frame["image_b64"]
+        assert stream.get(after=frame["seq"], timeout_ms=1) == {
+            "seq": frame["seq"],
+            "timeout": True,
+        }
+    finally:
+        release_render.set()
+        stream.close()
+
+
+def test_render_stream_surfaces_initialization_failure(monkeypatch):
+    def fail_renderer(*_args, **_kwargs):
+        raise RuntimeError("no OpenGL device")
+
+    monkeypatch.setattr(visualization_stream.mujoco, "MjData", FakeData)
+    monkeypatch.setattr(visualization_stream.mujoco, "Renderer", fail_renderer)
+    stream = RenderStream(FakeWorld())
+    stream.start()
+    try:
+        with pytest.raises(RuntimeError, match="no OpenGL device"):
+            stream.get(timeout_ms=1000)
+    finally:
+        stream.close()
+
+
+def test_render_stream_exits_only_after_last_client_stays_disconnected():
+    stream = RenderStream(FakeWorld(), exit_idle_seconds=0.03)
+    stream.client_connected()
+    stream.client_disconnected()
+    stream.client_connected()
+    assert not stream.exit_requested.wait(0.05)
+    stream.client_disconnected()
+    assert stream.exit_requested.wait(0.2)
+    stream.close()
+
+
+def test_render_stream_camera_orbits_zooms_clamps_and_resets():
+    stream = RenderStream(FakeWorld())
+    moved = stream.camera("orbit", dx=20, dy=-1000)
+    assert moved["azimuth"] == 129
+    assert moved["elevation"] == 85
+    assert stream.camera("zoom", dy=10_000)["distance"] == 5
+    assert stream.camera("zoom", dy=-10_000)["distance"] == 0.25
+    assert stream.camera("reset") == {
+        "azimuth": 135,
+        "elevation": -18,
+        "distance": 0.85,
+    }
+    with pytest.raises(ValueError, match="unknown camera action"):
+        stream.camera("pan")
+
+
+def test_render_stream_switches_quality_profile():
+    stream = RenderStream(FakeWorld())
+    assert stream.configure(
+        width=1920,
+        height=1080,
+        fps=24,
+        quality=100,
+        image_format="png",
+    ) == {
+        "width": 1920,
+        "height": 1080,
+        "fps": 24,
+        "quality": 100,
+        "format": "png",
+    }
+    assert stream.image_format == "png"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"width": 0}, "dimensions"),
+        ({"fps": 0}, "FPS"),
+        ({"quality": 101}, "quality"),
+        ({"image_format": "webp"}, "format"),
+    ],
+)
+def test_render_stream_validates_settings(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        RenderStream(FakeWorld(), **kwargs)
+
+
+def test_disabled_visualization_preserves_protocol_but_rejects_requests():
+    service = VisualizationService()
+    assert service.handles("render")
+    assert service.handles("camera")
+    assert service.handles("render_config")
+    assert not service.handles("read")
+    assert service.exit_requested is None
+    with pytest.raises(RuntimeError, match="disabled"):
+        service.dispatch({"op": "render"})
+
+
+def test_visualization_requires_render_for_idle_exit():
+    args = Namespace(render=False, exit_on_render_idle=1.0)
+    with pytest.raises(ValueError, match="requires --render"):
+        VisualizationService.from_arguments(args, FakeWorld())
+
+
+def test_visualization_service_delegates_wire_operations():
+    class FakeStream:
+        exit_requested = threading.Event()
+
+        def get(self, *, after, timeout_ms):
+            return {"after": after, "timeout_ms": timeout_ms}
+
+        def camera(self, *, action, dx, dy):
+            return {"action": action, "dx": dx, "dy": dy}
+
+        def configure(self, **settings):
+            return settings
+
+    service = VisualizationService(FakeStream())
+    assert service.dispatch({"op": "render", "after": 4, "timeout_ms": 20}) == {
+        "after": 4,
+        "timeout_ms": 20,
+    }
+    assert service.dispatch({"op": "camera", "action": "orbit", "dx": 2}) == {
+        "action": "orbit",
+        "dx": 2.0,
+        "dy": 0.0,
+    }
+    assert service.dispatch({"op": "render_config", "width": 8, "height": 6}) == {
+        "width": 8,
+        "height": 6,
+        "fps": 24,
+        "quality": 95,
+        "image_format": "jpeg",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -832,6 +832,11 @@ dependencies = [
     { name = "warp-lang" },
 ]
 
+[package.optional-dependencies]
+visualization = [
+    { name = "pillow" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "better-actuator-models", git = "https://github.com/Rhoban/bam.git?branch=mjlab_frictionloss" },
@@ -839,12 +844,14 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.10.9" },
     { name = "mjlab", specifier = "==1.3.0" },
     { name = "onnxruntime", specifier = ">=1.24.4" },
+    { name = "pillow", marker = "extra == 'visualization'", specifier = ">=11,<13" },
     { name = "rustypot", specifier = ">=1.4.2" },
     { name = "scipy", specifier = ">=1.16" },
     { name = "torch", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'", specifier = "==2.9.1" },
     { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'", specifier = "==2.9.1", index = "https://download.pytorch.org/whl/cu129" },
     { name = "warp-lang", specifier = "==1.12.0" },
 ]
+provides-extras = ["visualization"]
 
 [[package]]
 name = "mjviser"


### PR DESCRIPTION
## Motivation

`duck-body` owns the authoritative MuJoCo world, but developer tools currently have no supported way to observe that exact state without opening the desktop viewer or duplicating simulation logic. This adds an optional read-only image stream so dashboards and debugging tools can inspect the same world that drives `robotd`.

## What changed

- Add an optional visualization service behind `duck-body --render`.
- Serve cached JPEG or PNG frames through the existing TCP/NDJSON server.
- Add `render`, `camera`, and `render_config` operations for frame polling, orbit/zoom/reset controls, and runtime resolution, FPS, quality, and format changes.
- Copy `MjData` while holding the world lock, then render and encode outside the lock so slow software rendering does not block the 50 Hz physics/control loop.
- Support optional shutdown after the last render client remains disconnected.
- Keep Pillow in a dedicated `visualization` extra.
- Document the feature and add focused lifecycle, locking, validation, camera, configuration, and wire-adapter tests.

## Compatibility and scope

The feature is disabled by default. Existing `duck-body` operations and startup behavior remain unchanged. It does not modify robot models, physics, training, reward design, policy inference, observation/action layouts, or authoritative simulator state. Camera and render configuration affect only the read-only visualization stream.

## What this enables

- Browser-based simulation dashboards and live robot monitoring.
- Headless or remote inspection of the authoritative MuJoCo scene.
- Recording, debugging, and automated visual regression tooling.
- Additional read-only developer clients without embedding or duplicating simulator logic.

## Validation

- `uv lock --check`
- `uv run --locked --extra visualization --with pytest pytest tests/` — 211 passed, 1 skipped
- `uv run --with ruff ruff check src/mjlab_microduck/sim/body_server.py src/mjlab_microduck/sim/visualization tests/test_visualization.py`
- End-to-end Studio → robotd → policy → MuJoCo contract probe